### PR TITLE
Fetch full content from article URL

### DIFF
--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -978,7 +978,7 @@ class Post_Collection {
 
 	public function feed_table_row( $feed, $term_id ) {
 		?>
-		<td><input type="checkbox" name="feeds[<?php echo esc_attr( $term_id ); ?>][fetch-full-content]" value="1" aria-label="<?php esc_attr_e( 'Fetch Full Content', 'friends' ); ?>" <?php checked( $feed->get_metadata( 'fetch-full-content' ) ); ?> /></td>
+		<td style="padding-left: 1em"><input type="checkbox" name="feeds[<?php echo esc_attr( $term_id ); ?>][fetch-full-content]" value="1" aria-label="<?php esc_attr_e( 'Fetch Full Content', 'friends' ); ?>" <?php checked( $feed->get_metadata( 'fetch-full-content' ) ); ?> /></td>
 		<?php
 	}
 

--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -203,12 +203,18 @@ class Post_Collection {
 			<?php
 		}
 
+		$already_fetched = get_post_meta( get_the_ID(), 'full-content-fetched', true );
+		$i_classes = 'form-icon';
+		if ( $already_fetched ) {
+			$i_classes = 'dashicons dashicons-saved';
+		}
+
 		?>
 		<li class="menu-item"><a href="#" data-id="<?php echo esc_attr( get_the_ID() ); ?>" data-author="<?php echo esc_attr( get_the_author_ID() ); ?>" class="friends-post-collection-fetch-full-content has-icon-right">
 			<?php
 				esc_html_e( 'Fetch full content', 'friends' );
 			?>
-			<i class="form-icon"></i></a>
+			<i class="<?php echo esc_attr( $i_classes ); ?>"></i></a>
 		</li>
 		<?php
 	}
@@ -999,11 +1005,11 @@ class Post_Collection {
 		if ( $user_feed->get_metadata( 'fetch-full-content' ) ) {
 			$already_fetched = get_post_meta( $post_id, 'full-content-fetched', true );
 			if ( ! $already_fetched ) {
-				if ( isset( $this->fetched_for_feed[ $user_feed->term_id ] ) ) {
+				if ( isset( $this->fetched_for_feed[ $user_feed->get_id() ] ) ) {
 					// Only fetch a single item per feed per call.
 					return $item;
 				}
-				$this->fetched_for_feed[ $user_feed->term_id ] = $post_id;
+				$this->fetched_for_feed[ $user_feed->get_id() ] = $post_id;
 
 				$fetched_item = $this->download( $item->permalink );
 				if ( is_wp_error( $fetched_item ) ) {
@@ -1024,10 +1030,10 @@ class Post_Collection {
 
 	public function can_update_modified_feed_posts( $can_update, $item, $user_feed, $friend_user, $post_id ) {
 		if ( $user_feed->get_metadata( 'fetch-full-content' ) ) {
-			$already_fetched = get_post_meta( $post_id, 'full-content-fetched', true );
-			if ( $post_id === $this->fetched_for_feed[ $user_feed->term_id ] ) {
+			if ( $post_id === $this->fetched_for_feed[ $user_feed->get_id() ] ) {
 				return true;
 			}
+			$already_fetched = get_post_meta( $post_id, 'full-content-fetched', true );
 			return ! $already_fetched;
 		}
 		return $can_update;

--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -1022,12 +1022,12 @@ class Post_Collection {
 		return $item;
 	}
 
-	public function can_update_modified_feed_posts( $can_track, $item, $user_feed, $friend_user, $post_id ) {
+	public function can_update_modified_feed_posts( $can_update, $item, $user_feed, $friend_user, $post_id ) {
 		if ( $user_feed->get_metadata( 'fetch-full-content' ) ) {
 			$already_fetched = get_post_meta( $post_id, 'full-content-fetched', true );
 			return ! $already_fetched;
 		}
-		return $can_track;
+		return $can_update;
 	}
 
 	function wp_ajax_mark_private() {

--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -56,7 +56,7 @@ class Post_Collection {
 		add_action( 'wp_loaded', array( $this, 'save_url_endpoint' ), 100 );
 		add_filter( 'get_edit_user_link', array( $this, 'edit_post_collection_link' ), 10, 2 );
 		add_action( 'friend_post_edit_link', array( $this, 'allow_post_editing' ), 10, 2 );
-		add_action( 'friends_entry_dropdown_menu', array( $this, 'add_post_collection_dropdown_items' ) );
+		add_action( 'friends_entry_dropdown_menu', array( $this, 'entry_dropdown_menu' ) );
 		add_action( 'friends_friend_feed_viewable', array( $this, 'friends_friend_feed_viewable' ), 10, 2 );
 		add_action( 'friend_user_role_name', array( $this, 'friend_user_role_name' ), 10, 2 );
 		add_filter( 'friends_associated_roles', array( $this, 'associate_friend_user_role' ) );
@@ -67,6 +67,7 @@ class Post_Collection {
 		add_action( 'wp_ajax_friends-post-collection-mark-publish', array( $this, 'wp_ajax_mark_publish' ) );
 		add_action( 'wp_ajax_friends-post-collection-mark-private', array( $this, 'wp_ajax_mark_private' ) );
 		add_action( 'wp_ajax_friends-post-collection-change-author', array( $this, 'wp_ajax_change_author' ) );
+		add_action( 'wp_ajax_friends-post-collection-fetch-full-content', array( $this, 'wp_ajax_fetch_full_content' ) );
 	}
 
 	/**
@@ -141,7 +142,7 @@ class Post_Collection {
 		return $link;
 	}
 
-	public function add_post_collection_dropdown_items() {
+	public function entry_dropdown_menu() {
 		$divider = '<li class="divider" data-content="' . esc_attr__( 'Post Collection', 'friends' ) . '"></li>';
 		$list_tags = array(
 			'li' => array(
@@ -189,6 +190,14 @@ class Post_Collection {
 			<?php
 		}
 
+		?>
+		<li class="menu-item"><a href="#" data-id="<?php echo esc_attr( get_the_ID() ); ?>" data-author="<?php echo esc_attr( get_the_author_ID() ); ?>" class="friends-post-collection-fetch-full-content has-icon-right">
+			<?php
+				esc_html_e( 'Fetch full content', 'friends' );
+			?>
+			<i class="form-icon"></i></a>
+		</li>
+		<?php
 	}
 
 	public function edit_post_collection_link( $link, $user_id ) {
@@ -979,7 +988,7 @@ class Post_Collection {
 			wp_send_json_error( 'error' );
 		}
 
-		$user = new \WP_User( $_POST['author'] );
+		$user = new User( $_POST['author'] );
 		if ( is_wp_error( $user ) ) {
 			wp_send_json_error( 'error' );
 		}
@@ -992,7 +1001,7 @@ class Post_Collection {
 		$post->post_author = $user->ID;
 		wp_update_post( $post );
 
-		$first = new \WP_User( $_POST['first'] );
+		$first = new User( $_POST['first'] );
 		$move_to = sprintf(
 			// translators: %s is the name of a post collection.
 			_x( 'Move to %s', 'post-collection', 'friends' ),
@@ -1003,6 +1012,54 @@ class Post_Collection {
 			array(
 				'new_text'   => intval( $old_author ) !== $first->ID ? __( 'Undo' ) : $move_to, // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
 				'old_author' => $old_author,
+			)
+		);
+	}
+
+	function wp_ajax_fetch_full_content() {
+		if ( ! current_user_can( Friends::REQUIRED_ROLE ) ) {
+			wp_send_json_error( __( 'Sorry, you are not allowed to do that' ) ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+			exit;
+		}
+
+		$user = new User( $_POST['author'] );
+		if ( ! $user || is_wp_error( $user ) ) {
+			wp_send_json_error( __( 'User not found.' ) );
+			exit;
+		}
+		if ( ! User::is_friends_plugin_user( $user ) ) {
+			wp_send_json_error( "User doesn't belong to the Friends plugin." );
+			exit;
+		}
+
+		$post = get_post( $_POST['id'] );
+		$url = get_permalink( $post );
+		$item = $this->download( $url );
+		if ( is_wp_error( $item ) ) {
+			wp_send_json_error( $item );
+			exit;
+		}
+
+		if ( ! $item->content && ! $item->title ) {
+			wp_send_json_error( new \WP_Error( 'invalid-content', __( 'No content was extracted.', 'friends' ) ) );
+			exit;
+		}
+
+		$title   = strip_tags( trim( $item->title ) );
+		$content = trim( wp_kses_post( $item->content ) );
+
+		$post_data = array(
+			'ID'           => $post->ID,
+			'post_title'   => $title,
+			'post_content' => $content,
+		);
+
+		wp_update_post( $post_data );
+
+		wp_send_json_success(
+			array(
+				'post_title'   => $title,
+				'post_content' => $content,
 			)
 		);
 	}

--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -964,7 +964,7 @@ class Post_Collection {
 
 	public function feed_table_row( $feed, $term_id ) {
 		?>
-		<td><input type="checkbox" name="feeds[<?php echo esc_attr( $term_id ); ?>][fetch-full-content]" value="1" size="20" aria-label="<?php esc_attr_e( 'Fetch Full Content', 'friends' ); ?>" <?php checked( $feed->get_metadata( 'fetch-full-content' ) ); ?> /></td>
+		<td><input type="checkbox" name="feeds[<?php echo esc_attr( $term_id ); ?>][fetch-full-content]" value="1" aria-label="<?php esc_attr_e( 'Fetch Full Content', 'friends' ); ?>" <?php checked( $feed->get_metadata( 'fetch-full-content' ) ); ?> /></td>
 		<?php
 	}
 
@@ -986,6 +986,7 @@ class Post_Collection {
 			$user_feed->delete_metadata( 'fetch-full-content' );
 		}
 	}
+
 	public function modify_feed_item( $item, $user_feed, $friend_user, $post_id ) {
 		if ( $user_feed->get_metadata( 'fetch-full-content' ) ) {
 			$already_fetched = get_post_meta( $post_id, 'full-content-fetched', true );

--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -694,7 +694,7 @@ class Post_Collection {
 			}
 
 			$title   = strip_tags( trim( $item->title ) );
-			$content = trim( wp_kses_post( $item->content ) );
+			$content = force_balance_tags( trim( wp_kses_post( $item->content ) ) );
 
 			$post_data = array(
 				'post_title'   => $title,
@@ -1016,7 +1016,7 @@ class Post_Collection {
 				}
 
 				$item->title   = strip_tags( trim( $fetched_item->title ) );
-				$item->post_content = trim( wp_kses_post( $fetched_item->content ) );
+				$item->post_content = force_balance_tags( trim( wp_kses_post( $fetched_item->content ) ) );
 			}
 		}
 		return $item;
@@ -1126,7 +1126,7 @@ class Post_Collection {
 		update_post_meta( $post->ID, 'full-content-fetched', true );
 
 		$title   = strip_tags( trim( $item->title ) );
-		$content = trim( wp_kses_post( $item->content ) );
+		$content = force_balance_tags( trim( wp_kses_post( $item->content ) ) );
 
 		$post_data = array(
 			'ID'           => $post->ID,

--- a/friends-post-collection.js
+++ b/friends-post-collection.js
@@ -32,10 +32,35 @@ jQuery( function( $ ) {
 			data: {
 				id: $this.data( 'id' ),
 				author: $this.data( 'author' ),
-				first: $this.data( 'first' ),
+				first: $this.data( 'first' )
 			},
 			success: function( response ) {
 				$this.text( response.new_text ).data( 'author', response.old_author );
+			}
+		} );
+		return false;
+	} );
+	$document.on( 'click', 'a.friends-post-collection-fetch-full-content', function() {
+		var $this = $(this);
+		var search_indicator = $this.find( 'i' );
+		if ( search_indicator.hasClass( 'loading' ) ) {
+			return;
+		}
+		wp.ajax.send( 'friends-post-collection-fetch-full-content', {
+			data: {
+				id: $this.data( 'id' ),
+				author: $this.data( 'author' )
+			},
+			beforeSend: function() {
+				search_indicator.addClass( 'form-icon loading' );
+			},
+			success: function( response ) {
+				search_indicator.removeClass( 'form-icon loading' ).addClass( 'dashicons dashicons-saved' );
+				$this.closest( 'article' ).find( 'h4.card-title a' ).text( response.post_title );
+				$this.closest( 'article' ).find( 'div.card-body' ).html( response.post_content );
+			},
+			error: function( e ) {
+				search_indicator.removeClass( 'form-icon loading' ).addClass( 'dashicons dashicons-warning' ).prop( 'title', e );
 			}
 		} );
 		return false;


### PR DESCRIPTION
This implements https://github.com/akirk/friends/issues/106 by re-using the already existing extractor.

In order not to overload other servers, per feed retrieval only one full content article will be fetched. So if you activate this option on an existing feed, the older posts will only gradually be fully fetched.

## Screenshots
![fetch-full](https://user-images.githubusercontent.com/203408/167285187-00910ba5-01d9-4833-8944-977934f9fcc9.gif)

You can also automatically have the full context fetched upon retrieval (for feeds that only provide summaries). It can be activated per feed via this checkbox:
<img width="1288" alt="Screenshot 2022-05-08 at 08 41 02" src="https://user-images.githubusercontent.com/203408/167285206-a0fda68b-6b7a-4bab-8403-36a5fca8b5ba.png">

Later (not only immediately after retrieval) you can verify within the dropdown that the content was (automatically) fetched:

![Screenshot 2022-05-09 at 09 19 54](https://user-images.githubusercontent.com/203408/167359826-3194ca7b-9a36-4c5c-9da7-0cf2f9a94fbf.png)