### PR TITLE
Add the ability to Download external images to the Media Library

### DIFF
--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -1346,7 +1346,7 @@ class Post_Collection {
 
 		$post_data = array(
 			'ID'           => $post->ID,
-			'post_content' => $dom->saveHTML(),
+			'post_content' => wp_kses_post( $dom->saveXML( $dom->documentElement ) ),
 			'meta_input'   => array(
 				'images-downloaded' => true,
 			),

--- a/friends-post-collection.js
+++ b/friends-post-collection.js
@@ -64,5 +64,29 @@ jQuery( function( $ ) {
 			}
 		} );
 		return false;
+	} );	$document.on( 'click', 'a.friends-post-collection-download-images', function() {
+		var $this = $(this);
+		var search_indicator = $this.find( 'i' );
+		if ( search_indicator.hasClass( 'loading' ) ) {
+			return;
+		}
+		wp.ajax.send( 'friends-post-collection-download-images', {
+			data: {
+				id: $this.data( 'id' ),
+				author: $this.data( 'author' )
+			},
+			beforeSend: function() {
+				search_indicator.addClass( 'form-icon loading' );
+			},
+			success: function( response ) {
+				search_indicator.removeClass( 'form-icon loading' ).addClass( 'dashicons dashicons-saved' );
+				$this.closest( 'article' ).find( 'h4.card-title a' ).text( response.post_title );
+				$this.closest( 'article' ).find( 'div.card-body' ).html( response.post_content );
+			},
+			error: function( e ) {
+				search_indicator.removeClass( 'form-icon loading' ).addClass( 'dashicons dashicons-warning' ).prop( 'title', e );
+			}
+		} );
+		return false;
 	} );
 } );


### PR DESCRIPTION
In order to ensure that the images of a post don't get lost, this allows you to download them to your media library:

![download-images](https://github.com/akirk/friends-post-collection/assets/203408/007e6bfe-6fc5-4792-ab04-77622b72650a)

Note that these images will now reside in your media library and take up space there. They are attached to the post, so you know where they are coming from.

<img width="1431" alt="Screenshot 2023-08-04 at 13 47 25" src="https://github.com/akirk/friends-post-collection/assets/203408/d4d98a9e-e14a-4087-94da-91d2d23055e5">

The links inside the post are updated with the links to your local WordPress.

This has two implications:

1. If the site goes offline, you still have the images linked and available since they are in your own WordPress.
2. Your browser no longer makes external requests when you view the post.

It might be possible to add an option for feeds like with "fetch external content" to download the images but I am worried about the amount of data that this would add to your media library. This can quicky get out of control.