### PR TITLE
Add article notes system from send-to-e-reader plugin

### DIFF
--- a/assets/css/article-notes-admin.css
+++ b/assets/css/article-notes-admin.css
@@ -1,0 +1,207 @@
+/**
+ * Article Notes Admin Page Styles
+ *
+ * @package Send_To_E_Reader
+ */
+
+.ereader-notes-admin .ereader-notes-filters {
+	margin: 20px 0;
+}
+
+.ereader-notes-admin .subsubsub {
+	float: none;
+	margin-bottom: 10px;
+}
+
+.ereader-no-notes {
+	color: #787c82;
+	font-style: italic;
+	padding: 20px;
+	text-align: center;
+	background: #fff;
+	border: 1px solid #c3c4c7;
+}
+
+/* Table Styles */
+.ereader-notes-table {
+	margin-top: 10px;
+}
+
+.ereader-notes-table .column-title {
+	width: 25%;
+}
+
+.ereader-notes-table .column-status {
+	width: 20%;
+}
+
+.ereader-notes-table .column-rating {
+	width: 10%;
+}
+
+.ereader-notes-table .column-notes {
+	width: 30%;
+}
+
+.ereader-notes-table .column-date {
+	width: 15%;
+}
+
+.ereader-notes-table .column-title a {
+	font-weight: 600;
+	color: #2271b1;
+	text-decoration: none;
+}
+
+.ereader-notes-table .column-title a:hover {
+	color: #135e96;
+	text-decoration: underline;
+}
+
+.ereader-article-author {
+	color: #787c82;
+	font-size: 12px;
+	margin-top: 4px;
+}
+
+/* Status Buttons */
+.ereader-notes-table .ereader-status-buttons {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	margin-bottom: 8px;
+}
+
+.ereader-notes-table .ereader-status-btn {
+	padding: 4px 8px;
+	font-size: 11px;
+	background: #f6f7f7;
+	border: 1px solid #c3c4c7;
+	border-radius: 3px;
+	cursor: pointer;
+	color: #50575e;
+	transition: all 0.2s ease;
+}
+
+.ereader-notes-table .ereader-status-btn:hover {
+	background: #f0f0f1;
+	border-color: #8c8f94;
+}
+
+.ereader-notes-table .ereader-status-btn.active {
+	background: #2271b1;
+	border-color: #2271b1;
+	color: #fff;
+}
+
+.ereader-notes-table .ereader-status-btn.active:hover {
+	background: #135e96;
+	border-color: #135e96;
+}
+
+/* Archive Button */
+.ereader-notes-table .ereader-archive-btn {
+	padding: 4px 8px;
+	font-size: 11px;
+	background: #f6f7f7;
+	border: 1px solid #c3c4c7;
+	border-radius: 3px;
+	cursor: pointer;
+	color: #787c82;
+	transition: all 0.2s ease;
+}
+
+.ereader-notes-table .ereader-archive-btn:hover {
+	background: #f0f0f1;
+	border-color: #8c8f94;
+	color: #50575e;
+}
+
+/* Star Rating */
+.ereader-notes-table .ereader-rating {
+	display: flex;
+	gap: 2px;
+}
+
+.ereader-notes-table .ereader-star {
+	background: none;
+	border: none;
+	cursor: pointer;
+	font-size: 18px;
+	color: #dcdcde;
+	padding: 0;
+	line-height: 1;
+	transition: color 0.15s ease;
+}
+
+.ereader-notes-table .ereader-star:hover,
+.ereader-notes-table .ereader-star.active {
+	color: #ffb900;
+}
+
+.ereader-notes-table .ereader-rating:hover .ereader-star {
+	color: #ffb900;
+}
+
+.ereader-notes-table .ereader-rating:hover .ereader-star:hover ~ .ereader-star {
+	color: #dcdcde;
+}
+
+/* Notes */
+.ereader-notes-table .ereader-notes-wrapper {
+	margin-bottom: 4px;
+}
+
+.ereader-notes-table .ereader-notes {
+	width: 100%;
+	min-height: 60px;
+	padding: 8px;
+	border: 1px solid #c3c4c7;
+	border-radius: 4px;
+	font-size: 13px;
+	resize: vertical;
+	box-sizing: border-box;
+}
+
+.ereader-notes-table .ereader-notes:focus {
+	border-color: #2271b1;
+	box-shadow: 0 0 0 1px #2271b1;
+	outline: none;
+}
+
+/* Save Status */
+.ereader-notes-table .ereader-save-status {
+	font-size: 11px;
+	min-height: 16px;
+}
+
+.ereader-notes-table .ereader-save-status.saving {
+	color: #787c82;
+}
+
+.ereader-notes-table .ereader-save-status.saved {
+	color: #00a32a;
+}
+
+.ereader-notes-table .ereader-save-status.error {
+	color: #d63638;
+}
+
+/* Pagination */
+.ereader-notes-admin .tablenav-pages {
+	float: right;
+}
+
+.ereader-notes-admin .displaying-num {
+	margin-right: 10px;
+}
+
+/* Row animations */
+.ereader-notes-table .ereader-article-item {
+	transition: opacity 0.3s ease, background-color 0.3s ease;
+}
+
+.ereader-notes-table .ereader-article-item.ereader-moving {
+	opacity: 0.5;
+	background-color: #fffbcc;
+}

--- a/assets/css/article-notes-admin.css
+++ b/assets/css/article-notes-admin.css
@@ -1,19 +1,19 @@
 /**
  * Article Notes Admin Page Styles
  *
- * @package Send_To_E_Reader
+ * @package Post_Collection
  */
 
-.ereader-notes-admin .ereader-notes-filters {
+.post-collection-notes-admin .post-collection-notes-filters {
 	margin: 20px 0;
 }
 
-.ereader-notes-admin .subsubsub {
+.post-collection-notes-admin .subsubsub {
 	float: none;
 	margin-bottom: 10px;
 }
 
-.ereader-no-notes {
+.post-collection-no-notes {
 	color: #787c82;
 	font-style: italic;
 	padding: 20px;
@@ -23,56 +23,56 @@
 }
 
 /* Table Styles */
-.ereader-notes-table {
+.post-collection-notes-table {
 	margin-top: 10px;
 }
 
-.ereader-notes-table .column-title {
+.post-collection-notes-table .column-title {
 	width: 25%;
 }
 
-.ereader-notes-table .column-status {
+.post-collection-notes-table .column-status {
 	width: 20%;
 }
 
-.ereader-notes-table .column-rating {
+.post-collection-notes-table .column-rating {
 	width: 10%;
 }
 
-.ereader-notes-table .column-notes {
+.post-collection-notes-table .column-notes {
 	width: 30%;
 }
 
-.ereader-notes-table .column-date {
+.post-collection-notes-table .column-date {
 	width: 15%;
 }
 
-.ereader-notes-table .column-title a {
+.post-collection-notes-table .column-title a {
 	font-weight: 600;
 	color: #2271b1;
 	text-decoration: none;
 }
 
-.ereader-notes-table .column-title a:hover {
+.post-collection-notes-table .column-title a:hover {
 	color: #135e96;
 	text-decoration: underline;
 }
 
-.ereader-article-author {
+.post-collection-article-author {
 	color: #787c82;
 	font-size: 12px;
 	margin-top: 4px;
 }
 
 /* Status Buttons */
-.ereader-notes-table .ereader-status-buttons {
+.post-collection-notes-table .post-collection-status-buttons {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 4px;
 	margin-bottom: 8px;
 }
 
-.ereader-notes-table .ereader-status-btn {
+.post-collection-notes-table .post-collection-status-btn {
 	padding: 4px 8px;
 	font-size: 11px;
 	background: #f6f7f7;
@@ -83,24 +83,24 @@
 	transition: all 0.2s ease;
 }
 
-.ereader-notes-table .ereader-status-btn:hover {
+.post-collection-notes-table .post-collection-status-btn:hover {
 	background: #f0f0f1;
 	border-color: #8c8f94;
 }
 
-.ereader-notes-table .ereader-status-btn.active {
+.post-collection-notes-table .post-collection-status-btn.active {
 	background: #2271b1;
 	border-color: #2271b1;
 	color: #fff;
 }
 
-.ereader-notes-table .ereader-status-btn.active:hover {
+.post-collection-notes-table .post-collection-status-btn.active:hover {
 	background: #135e96;
 	border-color: #135e96;
 }
 
 /* Archive Button */
-.ereader-notes-table .ereader-archive-btn {
+.post-collection-notes-table .post-collection-archive-btn {
 	padding: 4px 8px;
 	font-size: 11px;
 	background: #f6f7f7;
@@ -111,19 +111,19 @@
 	transition: all 0.2s ease;
 }
 
-.ereader-notes-table .ereader-archive-btn:hover {
+.post-collection-notes-table .post-collection-archive-btn:hover {
 	background: #f0f0f1;
 	border-color: #8c8f94;
 	color: #50575e;
 }
 
 /* Star Rating */
-.ereader-notes-table .ereader-rating {
+.post-collection-notes-table .post-collection-rating {
 	display: flex;
 	gap: 2px;
 }
 
-.ereader-notes-table .ereader-star {
+.post-collection-notes-table .post-collection-star {
 	background: none;
 	border: none;
 	cursor: pointer;
@@ -134,25 +134,25 @@
 	transition: color 0.15s ease;
 }
 
-.ereader-notes-table .ereader-star:hover,
-.ereader-notes-table .ereader-star.active {
+.post-collection-notes-table .post-collection-star:hover,
+.post-collection-notes-table .post-collection-star.active {
 	color: #ffb900;
 }
 
-.ereader-notes-table .ereader-rating:hover .ereader-star {
+.post-collection-notes-table .post-collection-rating:hover .post-collection-star {
 	color: #ffb900;
 }
 
-.ereader-notes-table .ereader-rating:hover .ereader-star:hover ~ .ereader-star {
+.post-collection-notes-table .post-collection-rating:hover .post-collection-star:hover ~ .post-collection-star {
 	color: #dcdcde;
 }
 
 /* Notes */
-.ereader-notes-table .ereader-notes-wrapper {
+.post-collection-notes-table .post-collection-notes-wrapper {
 	margin-bottom: 4px;
 }
 
-.ereader-notes-table .ereader-notes {
+.post-collection-notes-table .post-collection-notes {
 	width: 100%;
 	min-height: 60px;
 	padding: 8px;
@@ -163,45 +163,45 @@
 	box-sizing: border-box;
 }
 
-.ereader-notes-table .ereader-notes:focus {
+.post-collection-notes-table .post-collection-notes:focus {
 	border-color: #2271b1;
 	box-shadow: 0 0 0 1px #2271b1;
 	outline: none;
 }
 
 /* Save Status */
-.ereader-notes-table .ereader-save-status {
+.post-collection-notes-table .post-collection-save-status {
 	font-size: 11px;
 	min-height: 16px;
 }
 
-.ereader-notes-table .ereader-save-status.saving {
+.post-collection-notes-table .post-collection-save-status.saving {
 	color: #787c82;
 }
 
-.ereader-notes-table .ereader-save-status.saved {
+.post-collection-notes-table .post-collection-save-status.saved {
 	color: #00a32a;
 }
 
-.ereader-notes-table .ereader-save-status.error {
+.post-collection-notes-table .post-collection-save-status.error {
 	color: #d63638;
 }
 
 /* Pagination */
-.ereader-notes-admin .tablenav-pages {
+.post-collection-notes-admin .tablenav-pages {
 	float: right;
 }
 
-.ereader-notes-admin .displaying-num {
+.post-collection-notes-admin .displaying-num {
 	margin-right: 10px;
 }
 
 /* Row animations */
-.ereader-notes-table .ereader-article-item {
+.post-collection-notes-table .post-collection-article-item {
 	transition: opacity 0.3s ease, background-color 0.3s ease;
 }
 
-.ereader-notes-table .ereader-article-item.ereader-moving {
+.post-collection-notes-table .post-collection-article-item.post-collection-moving {
 	opacity: 0.5;
 	background-color: #fffbcc;
 }

--- a/assets/css/article-notes.css
+++ b/assets/css/article-notes.css
@@ -1,0 +1,377 @@
+/**
+ * Article Notes Widget Styles
+ *
+ * @package Send_To_E_Reader
+ */
+
+.ereader-article-notes-widget {
+	margin: -11px -12px;
+}
+
+/* Tabs */
+.ereader-widget-tabs {
+	display: flex;
+	border-bottom: 1px solid #c3c4c7;
+	background: #f6f7f7;
+	margin-bottom: 0;
+}
+
+.ereader-tab {
+	flex: 1;
+	padding: 10px 12px;
+	background: none;
+	border: none;
+	border-bottom: 2px solid transparent;
+	cursor: pointer;
+	font-size: 13px;
+	color: #50575e;
+	transition: all 0.2s ease;
+}
+
+.ereader-tab:hover {
+	color: #2271b1;
+	background: #fff;
+}
+
+.ereader-tab.active {
+	color: #1d2327;
+	border-bottom-color: #2271b1;
+	background: #fff;
+}
+
+.ereader-tab .count {
+	color: #787c82;
+	font-size: 12px;
+}
+
+/* Tab Content */
+.ereader-tab-content {
+	display: none;
+	padding: 12px;
+}
+
+.ereader-tab-content.active {
+	display: block;
+}
+
+/* No articles message */
+.ereader-no-articles {
+	color: #787c82;
+	font-style: italic;
+	margin: 0;
+	padding: 20px;
+	text-align: center;
+}
+
+/* Tab hint */
+.ereader-tab-hint {
+	color: #787c82;
+	font-size: 12px;
+	margin: 0 0 12px;
+	padding: 8px;
+	background: #f6f7f7;
+	border-radius: 3px;
+}
+
+/* Article item animations */
+.ereader-article-item {
+	transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.ereader-article-item.ereader-moving {
+	opacity: 0.5;
+	transform: translateX(10px);
+}
+
+.ereader-article-item.ereader-removed {
+	opacity: 0;
+	transform: translateX(100%);
+	max-height: 0;
+	padding: 0;
+	margin: 0;
+	overflow: hidden;
+}
+
+/* Article List */
+.ereader-article-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+.ereader-article-item {
+	padding: 12px 0;
+	border-bottom: 1px solid #f0f0f1;
+}
+
+.ereader-article-item:last-child {
+	border-bottom: none;
+	padding-bottom: 0;
+}
+
+.ereader-article-item:first-child {
+	padding-top: 0;
+}
+
+/* Article Header */
+.ereader-article-header {
+	margin-bottom: 8px;
+}
+
+.ereader-article-title {
+	display: block;
+	font-weight: 600;
+	color: #2271b1;
+	text-decoration: none;
+	line-height: 1.4;
+	margin-bottom: 2px;
+}
+
+.ereader-article-title:hover {
+	color: #135e96;
+	text-decoration: underline;
+}
+
+.ereader-article-meta {
+	display: block;
+	font-size: 12px;
+	color: #787c82;
+}
+
+/* Select article checkbox */
+.ereader-select-article {
+	display: flex;
+	align-items: flex-start;
+	gap: 6px;
+}
+
+.ereader-select-article input[type="checkbox"] {
+	margin-top: 3px;
+}
+
+/* Controls Row */
+.ereader-article-controls {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 12px;
+	align-items: center;
+	margin-bottom: 8px;
+}
+
+/* Status Buttons */
+.ereader-status-buttons {
+	display: flex;
+	gap: 4px;
+}
+
+.ereader-status-btn {
+	padding: 4px 8px;
+	font-size: 11px;
+	background: #f6f7f7;
+	border: 1px solid #c3c4c7;
+	border-radius: 3px;
+	cursor: pointer;
+	color: #50575e;
+	transition: all 0.2s ease;
+}
+
+.ereader-status-btn:hover {
+	background: #f0f0f1;
+	border-color: #8c8f94;
+}
+
+.ereader-status-btn.active {
+	background: #2271b1;
+	border-color: #2271b1;
+	color: #fff;
+}
+
+.ereader-status-btn.active:hover {
+	background: #135e96;
+	border-color: #135e96;
+}
+
+/* Star Rating */
+.ereader-rating {
+	display: flex;
+	gap: 2px;
+}
+
+.ereader-star {
+	background: none;
+	border: none;
+	cursor: pointer;
+	font-size: 18px;
+	color: #dcdcde;
+	padding: 0;
+	line-height: 1;
+	transition: color 0.15s ease;
+}
+
+.ereader-star:hover,
+.ereader-star.active {
+	color: #ffb900;
+}
+
+.ereader-rating:hover .ereader-star {
+	color: #dcdcde;
+}
+
+.ereader-rating:hover .ereader-star:hover,
+.ereader-rating:hover .ereader-star:hover ~ .ereader-star {
+	color: #dcdcde;
+}
+
+.ereader-rating .ereader-star:hover,
+.ereader-rating .ereader-star:hover ~ .ereader-star {
+	color: #dcdcde;
+}
+
+.ereader-rating:hover .ereader-star:hover,
+.ereader-rating:hover .ereader-star.hovered {
+	color: #ffb900;
+}
+
+/* Make stars highlight up to hovered star */
+.ereader-rating:hover .ereader-star {
+	color: #ffb900;
+}
+
+.ereader-rating:hover .ereader-star:hover ~ .ereader-star {
+	color: #dcdcde;
+}
+
+/* Notes */
+.ereader-notes-wrapper {
+	margin-top: 8px;
+}
+
+.ereader-notes {
+	width: 100%;
+	min-height: 50px;
+	padding: 8px;
+	border: 1px solid #c3c4c7;
+	border-radius: 4px;
+	font-size: 13px;
+	resize: vertical;
+	box-sizing: border-box;
+}
+
+.ereader-notes:focus {
+	border-color: #2271b1;
+	box-shadow: 0 0 0 1px #2271b1;
+	outline: none;
+}
+
+.ereader-notes-preview {
+	font-size: 12px;
+	color: #787c82;
+	font-style: italic;
+	cursor: pointer;
+	padding: 4px;
+	margin-top: 4px;
+	background: #f9f9f9;
+	border-radius: 3px;
+}
+
+.ereader-notes-preview:hover {
+	background: #f0f0f1;
+}
+
+/* Save Status */
+.ereader-save-status {
+	font-size: 11px;
+	min-height: 16px;
+	margin-top: 4px;
+}
+
+.ereader-save-status.saving {
+	color: #787c82;
+}
+
+.ereader-save-status.saved {
+	color: #00a32a;
+}
+
+.ereader-save-status.error {
+	color: #d63638;
+}
+
+/* Create Post Section */
+.ereader-create-post-section {
+	margin-top: 16px;
+	padding-top: 16px;
+	border-top: 1px solid #f0f0f1;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.ereader-post-title-input {
+	width: 100%;
+	padding: 8px;
+	border: 1px solid #c3c4c7;
+	border-radius: 4px;
+	font-size: 13px;
+	box-sizing: border-box;
+}
+
+.ereader-post-title-input:focus {
+	border-color: #2271b1;
+	box-shadow: 0 0 0 1px #2271b1;
+	outline: none;
+}
+
+.ereader-create-post-btn {
+	align-self: flex-start;
+}
+
+.ereader-create-post-btn:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+/* Reviewed list specific */
+.ereader-reviewed-list .ereader-article-item {
+	background: #fafafa;
+	padding: 12px;
+	margin-bottom: 8px;
+	border: 1px solid #f0f0f1;
+	border-radius: 4px;
+}
+
+.ereader-reviewed-list .ereader-article-item:last-child {
+	margin-bottom: 0;
+}
+
+/* Load More Section */
+.ereader-load-more-section {
+	text-align: center;
+	padding: 12px 0 0;
+	border-top: 1px solid #f0f0f1;
+	margin-top: 12px;
+}
+
+.ereader-load-more-btn:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+/* Archive Button */
+.ereader-archive-btn {
+	padding: 4px 8px;
+	font-size: 11px;
+	background: #f6f7f7;
+	border: 1px solid #c3c4c7;
+	border-radius: 3px;
+	cursor: pointer;
+	color: #787c82;
+	transition: all 0.2s ease;
+	margin-left: auto;
+}
+
+.ereader-archive-btn:hover {
+	background: #f0f0f1;
+	border-color: #8c8f94;
+	color: #50575e;
+}

--- a/assets/css/article-notes.css
+++ b/assets/css/article-notes.css
@@ -491,3 +491,12 @@
 	border-color: #8c8f94;
 	color: #50575e;
 }
+
+/* Frontend single post notes */
+.post-collection-frontend-notes {
+	margin-top: 12px;
+	padding: 12px;
+	background: #f6f7f7;
+	border: 1px solid #e0e0e0;
+	border-radius: 4px;
+}

--- a/assets/css/article-notes.css
+++ b/assets/css/article-notes.css
@@ -148,28 +148,46 @@
 	margin-top: 3px;
 }
 
-/* Notes toggle and Archive buttons — hidden in pending list */
-.post-collection-pending-list .post-collection-toggle-notes-btn,
+/* Archive button — hidden in pending list */
 .post-collection-pending-list .post-collection-archive-btn {
 	display: none;
 }
 
-/* Notes toggle button style */
-.post-collection-toggle-notes-btn {
-	padding: 4px 8px;
-	font-size: 11px;
-	background: #f6f7f7;
-	border: 1px solid #c3c4c7;
+/* Article Preview */
+.post-collection-article-preview {
+	margin: 8px 0;
+	border: 1px solid #f0f0f1;
 	border-radius: 3px;
-	cursor: pointer;
-	color: #787c82;
-	transition: all 0.2s ease;
 }
 
-.post-collection-toggle-notes-btn:hover {
+.post-collection-article-preview summary {
+	padding: 6px 8px;
+	font-size: 12px;
+	color: #787c82;
+	cursor: pointer;
+	background: #f9f9f9;
+}
+
+.post-collection-article-preview summary:hover {
 	background: #f0f0f1;
-	border-color: #8c8f94;
 	color: #50575e;
+}
+
+.post-collection-article-preview-content {
+	max-height: 200px;
+	overflow-y: auto;
+	padding: 8px 12px;
+	font-size: 13px;
+	line-height: 1.6;
+	border-top: 1px solid #f0f0f1;
+}
+
+.post-collection-article-preview-content p {
+	margin: 0 0 0.8em;
+}
+
+.post-collection-article-preview-content p:last-child {
+	margin-bottom: 0;
 }
 
 /* Controls Row */
@@ -250,15 +268,6 @@
 	margin-top: 8px;
 }
 
-/* Notes hidden by default in reviewed list, shown on click */
-.post-collection-reviewed-list .post-collection-notes-wrapper {
-	display: none;
-}
-
-.post-collection-reviewed-list .post-collection-article-item.post-collection-notes-open .post-collection-notes-wrapper {
-	display: block;
-}
-
 .post-collection-notes {
 	width: 100%;
 	min-height: 50px;
@@ -299,22 +308,6 @@
 
 .post-collection-save-status.error {
 	color: #d63638;
-}
-
-/* Notes preview in reviewed list */
-.post-collection-notes-preview {
-	font-size: 12px;
-	color: #787c82;
-	font-style: italic;
-	cursor: pointer;
-	padding: 4px;
-	margin-top: 4px;
-	background: #f9f9f9;
-	border-radius: 3px;
-}
-
-.post-collection-notes-preview:hover {
-	background: #f0f0f1;
 }
 
 /* Create Post Section */

--- a/assets/css/article-notes.css
+++ b/assets/css/article-notes.css
@@ -39,11 +39,6 @@
 	background: #fff;
 }
 
-.post-collection-tab .count {
-	color: #787c82;
-	font-size: 12px;
-}
-
 /* Tab Content */
 .post-collection-tab-content {
 	display: none;
@@ -73,7 +68,7 @@
 	border-radius: 3px;
 }
 
-/* Article item animations */
+/* Article item */
 .post-collection-article-item {
 	transition: opacity 0.3s ease, transform 0.3s ease;
 }
@@ -138,15 +133,24 @@
 	color: #787c82;
 }
 
-/* Select article checkbox */
+/* Select article checkbox — hidden in pending list, visible in reviewed list */
 .post-collection-select-article {
 	display: flex;
 	align-items: flex-start;
 	gap: 6px;
 }
 
+.post-collection-pending-list .post-collection-select-article input[type="checkbox"] {
+	display: none;
+}
+
 .post-collection-select-article input[type="checkbox"] {
 	margin-top: 3px;
+}
+
+/* Archive button — hidden in pending list */
+.post-collection-pending-list .post-collection-archive-btn {
+	display: none;
 }
 
 /* Controls Row */
@@ -213,25 +217,6 @@
 	color: #ffb900;
 }
 
-.post-collection-rating:hover .post-collection-star {
-	color: #dcdcde;
-}
-
-.post-collection-rating:hover .post-collection-star:hover,
-.post-collection-rating:hover .post-collection-star:hover ~ .post-collection-star {
-	color: #dcdcde;
-}
-
-.post-collection-rating .post-collection-star:hover,
-.post-collection-rating .post-collection-star:hover ~ .post-collection-star {
-	color: #dcdcde;
-}
-
-.post-collection-rating:hover .post-collection-star:hover,
-.post-collection-rating:hover .post-collection-star.hovered {
-	color: #ffb900;
-}
-
 /* Make stars highlight up to hovered star */
 .post-collection-rating:hover .post-collection-star {
 	color: #ffb900;
@@ -246,6 +231,15 @@
 	margin-top: 8px;
 }
 
+/* Notes hidden by default in reviewed list, shown on click */
+.post-collection-reviewed-list .post-collection-notes-wrapper {
+	display: none;
+}
+
+.post-collection-reviewed-list .post-collection-article-item.post-collection-notes-open .post-collection-notes-wrapper {
+	display: block;
+}
+
 .post-collection-notes {
 	width: 100%;
 	min-height: 50px;
@@ -257,16 +251,38 @@
 	box-sizing: border-box;
 }
 
-.post-collection-save-notes-btn {
-	margin-top: 4px;
-}
-
 .post-collection-notes:focus {
 	border-color: #2271b1;
 	box-shadow: 0 0 0 1px #2271b1;
 	outline: none;
 }
 
+/* Notes actions row — save button and status inline */
+.post-collection-notes-actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-top: 4px;
+}
+
+.post-collection-save-status {
+	font-size: 11px;
+	line-height: 1;
+}
+
+.post-collection-save-status.saving {
+	color: #787c82;
+}
+
+.post-collection-save-status.saved {
+	color: #00a32a;
+}
+
+.post-collection-save-status.error {
+	color: #d63638;
+}
+
+/* Notes preview in reviewed list */
 .post-collection-notes-preview {
 	font-size: 12px;
 	color: #787c82;
@@ -280,25 +296,6 @@
 
 .post-collection-notes-preview:hover {
 	background: #f0f0f1;
-}
-
-/* Save Status */
-.post-collection-save-status {
-	font-size: 11px;
-	min-height: 16px;
-	margin-top: 4px;
-}
-
-.post-collection-save-status.saving {
-	color: #787c82;
-}
-
-.post-collection-save-status.saved {
-	color: #00a32a;
-}
-
-.post-collection-save-status.error {
-	color: #d63638;
 }
 
 /* Create Post Section */

--- a/assets/css/article-notes.css
+++ b/assets/css/article-notes.css
@@ -1,22 +1,22 @@
 /**
  * Article Notes Widget Styles
  *
- * @package Send_To_E_Reader
+ * @package Post_Collection
  */
 
-.ereader-article-notes-widget {
+.post-collection-article-notes-widget {
 	margin: -11px -12px;
 }
 
 /* Tabs */
-.ereader-widget-tabs {
+.post-collection-widget-tabs {
 	display: flex;
 	border-bottom: 1px solid #c3c4c7;
 	background: #f6f7f7;
 	margin-bottom: 0;
 }
 
-.ereader-tab {
+.post-collection-tab {
 	flex: 1;
 	padding: 10px 12px;
 	background: none;
@@ -28,34 +28,34 @@
 	transition: all 0.2s ease;
 }
 
-.ereader-tab:hover {
+.post-collection-tab:hover {
 	color: #2271b1;
 	background: #fff;
 }
 
-.ereader-tab.active {
+.post-collection-tab.active {
 	color: #1d2327;
 	border-bottom-color: #2271b1;
 	background: #fff;
 }
 
-.ereader-tab .count {
+.post-collection-tab .count {
 	color: #787c82;
 	font-size: 12px;
 }
 
 /* Tab Content */
-.ereader-tab-content {
+.post-collection-tab-content {
 	display: none;
 	padding: 12px;
 }
 
-.ereader-tab-content.active {
+.post-collection-tab-content.active {
 	display: block;
 }
 
 /* No articles message */
-.ereader-no-articles {
+.post-collection-no-articles {
 	color: #787c82;
 	font-style: italic;
 	margin: 0;
@@ -64,7 +64,7 @@
 }
 
 /* Tab hint */
-.ereader-tab-hint {
+.post-collection-tab-hint {
 	color: #787c82;
 	font-size: 12px;
 	margin: 0 0 12px;
@@ -74,16 +74,16 @@
 }
 
 /* Article item animations */
-.ereader-article-item {
+.post-collection-article-item {
 	transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
-.ereader-article-item.ereader-moving {
+.post-collection-article-item.post-collection-moving {
 	opacity: 0.5;
 	transform: translateX(10px);
 }
 
-.ereader-article-item.ereader-removed {
+.post-collection-article-item.post-collection-removed {
 	opacity: 0;
 	transform: translateX(100%);
 	max-height: 0;
@@ -93,32 +93,32 @@
 }
 
 /* Article List */
-.ereader-article-list {
+.post-collection-article-list {
 	list-style: none;
 	margin: 0;
 	padding: 0;
 }
 
-.ereader-article-item {
+.post-collection-article-item {
 	padding: 12px 0;
 	border-bottom: 1px solid #f0f0f1;
 }
 
-.ereader-article-item:last-child {
+.post-collection-article-item:last-child {
 	border-bottom: none;
 	padding-bottom: 0;
 }
 
-.ereader-article-item:first-child {
+.post-collection-article-item:first-child {
 	padding-top: 0;
 }
 
 /* Article Header */
-.ereader-article-header {
+.post-collection-article-header {
 	margin-bottom: 8px;
 }
 
-.ereader-article-title {
+.post-collection-article-title {
 	display: block;
 	font-weight: 600;
 	color: #2271b1;
@@ -127,30 +127,30 @@
 	margin-bottom: 2px;
 }
 
-.ereader-article-title:hover {
+.post-collection-article-title:hover {
 	color: #135e96;
 	text-decoration: underline;
 }
 
-.ereader-article-meta {
+.post-collection-article-meta {
 	display: block;
 	font-size: 12px;
 	color: #787c82;
 }
 
 /* Select article checkbox */
-.ereader-select-article {
+.post-collection-select-article {
 	display: flex;
 	align-items: flex-start;
 	gap: 6px;
 }
 
-.ereader-select-article input[type="checkbox"] {
+.post-collection-select-article input[type="checkbox"] {
 	margin-top: 3px;
 }
 
 /* Controls Row */
-.ereader-article-controls {
+.post-collection-article-controls {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 12px;
@@ -159,12 +159,12 @@
 }
 
 /* Status Buttons */
-.ereader-status-buttons {
+.post-collection-status-buttons {
 	display: flex;
 	gap: 4px;
 }
 
-.ereader-status-btn {
+.post-collection-status-btn {
 	padding: 4px 8px;
 	font-size: 11px;
 	background: #f6f7f7;
@@ -175,29 +175,29 @@
 	transition: all 0.2s ease;
 }
 
-.ereader-status-btn:hover {
+.post-collection-status-btn:hover {
 	background: #f0f0f1;
 	border-color: #8c8f94;
 }
 
-.ereader-status-btn.active {
+.post-collection-status-btn.active {
 	background: #2271b1;
 	border-color: #2271b1;
 	color: #fff;
 }
 
-.ereader-status-btn.active:hover {
+.post-collection-status-btn.active:hover {
 	background: #135e96;
 	border-color: #135e96;
 }
 
 /* Star Rating */
-.ereader-rating {
+.post-collection-rating {
 	display: flex;
 	gap: 2px;
 }
 
-.ereader-star {
+.post-collection-star {
 	background: none;
 	border: none;
 	cursor: pointer;
@@ -208,45 +208,45 @@
 	transition: color 0.15s ease;
 }
 
-.ereader-star:hover,
-.ereader-star.active {
+.post-collection-star:hover,
+.post-collection-star.active {
 	color: #ffb900;
 }
 
-.ereader-rating:hover .ereader-star {
+.post-collection-rating:hover .post-collection-star {
 	color: #dcdcde;
 }
 
-.ereader-rating:hover .ereader-star:hover,
-.ereader-rating:hover .ereader-star:hover ~ .ereader-star {
+.post-collection-rating:hover .post-collection-star:hover,
+.post-collection-rating:hover .post-collection-star:hover ~ .post-collection-star {
 	color: #dcdcde;
 }
 
-.ereader-rating .ereader-star:hover,
-.ereader-rating .ereader-star:hover ~ .ereader-star {
+.post-collection-rating .post-collection-star:hover,
+.post-collection-rating .post-collection-star:hover ~ .post-collection-star {
 	color: #dcdcde;
 }
 
-.ereader-rating:hover .ereader-star:hover,
-.ereader-rating:hover .ereader-star.hovered {
+.post-collection-rating:hover .post-collection-star:hover,
+.post-collection-rating:hover .post-collection-star.hovered {
 	color: #ffb900;
 }
 
 /* Make stars highlight up to hovered star */
-.ereader-rating:hover .ereader-star {
+.post-collection-rating:hover .post-collection-star {
 	color: #ffb900;
 }
 
-.ereader-rating:hover .ereader-star:hover ~ .ereader-star {
+.post-collection-rating:hover .post-collection-star:hover ~ .post-collection-star {
 	color: #dcdcde;
 }
 
 /* Notes */
-.ereader-notes-wrapper {
+.post-collection-notes-wrapper {
 	margin-top: 8px;
 }
 
-.ereader-notes {
+.post-collection-notes {
 	width: 100%;
 	min-height: 50px;
 	padding: 8px;
@@ -257,13 +257,13 @@
 	box-sizing: border-box;
 }
 
-.ereader-notes:focus {
+.post-collection-notes:focus {
 	border-color: #2271b1;
 	box-shadow: 0 0 0 1px #2271b1;
 	outline: none;
 }
 
-.ereader-notes-preview {
+.post-collection-notes-preview {
 	font-size: 12px;
 	color: #787c82;
 	font-style: italic;
@@ -274,31 +274,31 @@
 	border-radius: 3px;
 }
 
-.ereader-notes-preview:hover {
+.post-collection-notes-preview:hover {
 	background: #f0f0f1;
 }
 
 /* Save Status */
-.ereader-save-status {
+.post-collection-save-status {
 	font-size: 11px;
 	min-height: 16px;
 	margin-top: 4px;
 }
 
-.ereader-save-status.saving {
+.post-collection-save-status.saving {
 	color: #787c82;
 }
 
-.ereader-save-status.saved {
+.post-collection-save-status.saved {
 	color: #00a32a;
 }
 
-.ereader-save-status.error {
+.post-collection-save-status.error {
 	color: #d63638;
 }
 
 /* Create Post Section */
-.ereader-create-post-section {
+.post-collection-create-post-section {
 	margin-top: 16px;
 	padding-top: 16px;
 	border-top: 1px solid #f0f0f1;
@@ -307,7 +307,7 @@
 	gap: 8px;
 }
 
-.ereader-post-title-input {
+.post-collection-post-title-input {
 	width: 100%;
 	padding: 8px;
 	border: 1px solid #c3c4c7;
@@ -316,23 +316,23 @@
 	box-sizing: border-box;
 }
 
-.ereader-post-title-input:focus {
+.post-collection-post-title-input:focus {
 	border-color: #2271b1;
 	box-shadow: 0 0 0 1px #2271b1;
 	outline: none;
 }
 
-.ereader-create-post-btn {
+.post-collection-create-post-btn {
 	align-self: flex-start;
 }
 
-.ereader-create-post-btn:disabled {
+.post-collection-create-post-btn:disabled {
 	opacity: 0.6;
 	cursor: not-allowed;
 }
 
 /* Reviewed list specific */
-.ereader-reviewed-list .ereader-article-item {
+.post-collection-reviewed-list .post-collection-article-item {
 	background: #fafafa;
 	padding: 12px;
 	margin-bottom: 8px;
@@ -340,25 +340,25 @@
 	border-radius: 4px;
 }
 
-.ereader-reviewed-list .ereader-article-item:last-child {
+.post-collection-reviewed-list .post-collection-article-item:last-child {
 	margin-bottom: 0;
 }
 
 /* Load More Section */
-.ereader-load-more-section {
+.post-collection-load-more-section {
 	text-align: center;
 	padding: 12px 0 0;
 	border-top: 1px solid #f0f0f1;
 	margin-top: 12px;
 }
 
-.ereader-load-more-btn:disabled {
+.post-collection-load-more-btn:disabled {
 	opacity: 0.6;
 	cursor: not-allowed;
 }
 
 /* Archive Button */
-.ereader-archive-btn {
+.post-collection-archive-btn {
 	padding: 4px 8px;
 	font-size: 11px;
 	background: #f6f7f7;
@@ -370,7 +370,7 @@
 	margin-left: auto;
 }
 
-.ereader-archive-btn:hover {
+.post-collection-archive-btn:hover {
 	background: #f0f0f1;
 	border-color: #8c8f94;
 	color: #50575e;

--- a/assets/css/article-notes.css
+++ b/assets/css/article-notes.css
@@ -8,6 +8,67 @@
 	margin: -11px -12px;
 }
 
+/* Remember section */
+.post-collection-remember {
+	padding: 12px;
+	border-bottom: 1px solid #c3c4c7;
+	background: #f6f7f7;
+}
+
+.post-collection-remember-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 4px;
+}
+
+.post-collection-remember-label {
+	font-size: 11px;
+	color: #787c82;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+}
+
+.post-collection-remember-another {
+	font-size: 11px;
+	color: #787c82;
+	text-decoration: none;
+}
+
+.post-collection-remember-another:hover {
+	color: #2271b1;
+}
+
+.post-collection-remember-title {
+	display: block;
+	font-weight: 600;
+	color: #2271b1;
+	text-decoration: none;
+	line-height: 1.4;
+}
+
+.post-collection-remember-title:hover {
+	color: #135e96;
+	text-decoration: underline;
+}
+
+.post-collection-remember-meta {
+	display: block;
+	font-size: 12px;
+	color: #787c82;
+	margin-bottom: 6px;
+}
+
+.post-collection-remember-notes {
+	margin: 6px 0 0;
+	padding: 6px 10px;
+	border-left: 3px solid #c3c4c7;
+	color: #50575e;
+	font-size: 13px;
+	font-style: italic;
+	line-height: 1.5;
+}
+
 /* Tabs */
 .post-collection-widget-tabs {
 	display: flex;

--- a/assets/css/article-notes.css
+++ b/assets/css/article-notes.css
@@ -148,9 +148,28 @@
 	margin-top: 3px;
 }
 
-/* Archive button — hidden in pending list */
+/* Notes toggle and Archive buttons — hidden in pending list */
+.post-collection-pending-list .post-collection-toggle-notes-btn,
 .post-collection-pending-list .post-collection-archive-btn {
 	display: none;
+}
+
+/* Notes toggle button style */
+.post-collection-toggle-notes-btn {
+	padding: 4px 8px;
+	font-size: 11px;
+	background: #f6f7f7;
+	border: 1px solid #c3c4c7;
+	border-radius: 3px;
+	cursor: pointer;
+	color: #787c82;
+	transition: all 0.2s ease;
+}
+
+.post-collection-toggle-notes-btn:hover {
+	background: #f0f0f1;
+	border-color: #8c8f94;
+	color: #50575e;
 }
 
 /* Controls Row */

--- a/assets/css/article-notes.css
+++ b/assets/css/article-notes.css
@@ -174,6 +174,45 @@
 	margin-bottom: 8px;
 }
 
+/* Title editing */
+.post-collection-title-wrapper {
+	display: flex;
+	align-items: baseline;
+	gap: 4px;
+	flex: 1;
+}
+
+.post-collection-edit-title-btn {
+	background: none;
+	border: none;
+	cursor: pointer;
+	color: #c3c4c7;
+	font-size: 13px;
+	padding: 0;
+	line-height: 1;
+	transition: color 0.15s ease;
+}
+
+.post-collection-edit-title-btn:hover {
+	color: #2271b1;
+}
+
+.post-collection-title-input {
+	display: none;
+	width: 100%;
+	padding: 4px 6px;
+	font-size: 14px;
+	font-weight: 600;
+	border: 1px solid #2271b1;
+	border-radius: 3px;
+	box-sizing: border-box;
+}
+
+.post-collection-title-input:focus {
+	outline: none;
+	box-shadow: 0 0 0 1px #2271b1;
+}
+
 .post-collection-article-title {
 	display: block;
 	font-weight: 600;

--- a/assets/css/article-notes.css
+++ b/assets/css/article-notes.css
@@ -160,7 +160,7 @@
 	border-bottom: 1px solid #f0f0f1;
 }
 
-.post-collection-article-item:last-child {
+.post-collection-article-item:last-child:not(.post-collection-remember) {
 	border-bottom: none;
 	padding-bottom: 0;
 }

--- a/assets/css/article-notes.css
+++ b/assets/css/article-notes.css
@@ -257,6 +257,10 @@
 	box-sizing: border-box;
 }
 
+.post-collection-save-notes-btn {
+	margin-top: 4px;
+}
+
 .post-collection-notes:focus {
 	border-color: #2271b1;
 	box-shadow: 0 0 0 1px #2271b1;

--- a/assets/css/article-notes.css
+++ b/assets/css/article-notes.css
@@ -9,7 +9,7 @@
 }
 
 /* Remember section */
-.post-collection-remember {
+.post-collection-remember.post-collection-article-item {
 	padding: 12px;
 	border-bottom: 1px solid #c3c4c7;
 	background: #f6f7f7;
@@ -165,7 +165,7 @@
 	padding-bottom: 0;
 }
 
-.post-collection-article-item:first-child {
+.post-collection-article-item:first-child:not(.post-collection-remember) {
 	padding-top: 0;
 }
 
@@ -240,7 +240,8 @@
 	gap: 6px;
 }
 
-.post-collection-pending-list .post-collection-select-article input[type="checkbox"] {
+.post-collection-pending-list .post-collection-select-article input[type="checkbox"],
+.post-collection-remember .post-collection-select-article input[type="checkbox"] {
 	display: none;
 }
 
@@ -248,8 +249,10 @@
 	margin-top: 3px;
 }
 
-/* Archive button — hidden in pending list */
-.post-collection-pending-list .post-collection-archive-btn {
+/* Hide elements that don't belong in certain contexts */
+.post-collection-pending-list .post-collection-archive-btn,
+.post-collection-remember .post-collection-archive-btn,
+.post-collection-remember .post-collection-article-controls {
 	display: none;
 }
 

--- a/assets/js/article-notes.js
+++ b/assets/js/article-notes.js
@@ -1,0 +1,391 @@
+/**
+ * Article Notes Widget JavaScript
+ *
+ * @package Send_To_E_Reader
+ */
+
+(function($) {
+	'use strict';
+
+	var ArticleNotes = {
+		/**
+		 * Debounce timer for notes saving.
+		 */
+		saveTimers: {},
+
+		/**
+		 * Initialize the widget.
+		 */
+		init: function() {
+			this.bindEvents();
+		},
+
+		/**
+		 * Bind event handlers.
+		 */
+		bindEvents: function() {
+			var self = this;
+
+			// Tab switching.
+			$(document).on('click', '.ereader-tab', function(e) {
+				e.preventDefault();
+				self.switchTab($(this).data('tab'));
+			});
+
+			// Status button clicks.
+			$(document).on('click', '.ereader-status-btn', function(e) {
+				e.preventDefault();
+				var $btn = $(this);
+				var $item = $btn.closest('.ereader-article-item');
+				var articleId = $item.data('article-id');
+				var status = $btn.data('status');
+				var currentTab = $('.ereader-tab.active').data('tab');
+
+				self.saveNote(articleId, { status: status }, $item);
+
+				// Update UI.
+				$item.find('.ereader-status-btn').removeClass('active');
+				$btn.addClass('active');
+
+				// Check if item should move to another tab.
+				var shouldMove = false;
+				if (currentTab === 'pending') {
+					// Any status in pending moves the item out.
+					shouldMove = true;
+				} else if (currentTab === 'unread' && (status === 'read' || status === 'skipped' || status === 'archived')) {
+					// Read, Skipped, or Archived in unread moves to reviewed.
+					shouldMove = true;
+				} else if (currentTab === 'reviewed' && status === 'unread') {
+					// Changing back to unread moves to unread tab.
+					shouldMove = true;
+				}
+
+				if (shouldMove) {
+					self.animateItemRemoval($item);
+				}
+			});
+
+			// Star rating clicks.
+			$(document).on('click', '.ereader-star', function(e) {
+				e.preventDefault();
+				var $star = $(this);
+				var $item = $star.closest('.ereader-article-item');
+				var $ratingContainer = $star.closest('.ereader-rating');
+				var articleId = $item.data('article-id');
+				var rating = $star.data('rating');
+
+				self.saveNote(articleId, { rating: rating }, $item);
+
+				// Update UI.
+				self.updateStars($ratingContainer, rating);
+			});
+
+			// Notes textarea - save on blur with debounce.
+			$(document).on('input', '.ereader-notes', function() {
+				var $textarea = $(this);
+				var $item = $textarea.closest('.ereader-article-item');
+				var articleId = $item.data('article-id');
+
+				// Clear existing timer for this article.
+				if (self.saveTimers[articleId]) {
+					clearTimeout(self.saveTimers[articleId]);
+				}
+
+				// Set new debounced save.
+				self.saveTimers[articleId] = setTimeout(function() {
+					self.saveNote(articleId, { notes: $textarea.val() }, $item);
+				}, 1000);
+			});
+
+			// Also save on blur.
+			$(document).on('blur', '.ereader-notes', function() {
+				var $textarea = $(this);
+				var $item = $textarea.closest('.ereader-article-item');
+				var articleId = $item.data('article-id');
+
+				// Clear pending timer and save immediately.
+				if (self.saveTimers[articleId]) {
+					clearTimeout(self.saveTimers[articleId]);
+					delete self.saveTimers[articleId];
+				}
+
+				self.saveNote(articleId, { notes: $textarea.val() }, $item);
+			});
+
+			// Toggle notes in reviewed list.
+			$(document).on('click', '.ereader-notes-preview', function() {
+				var $item = $(this).closest('.ereader-article-item');
+				$(this).hide();
+				$item.find('.ereader-notes-wrapper').show();
+				$item.find('.ereader-notes').focus();
+			});
+
+			// Create post from selected.
+			$(document).on('click', '.ereader-create-post-btn', function(e) {
+				e.preventDefault();
+				self.createPostFromSelected();
+			});
+
+			// Select all toggle for reviewed list.
+			$(document).on('change', '.ereader-select-all', function() {
+				var checked = $(this).prop('checked');
+				$('.ereader-reviewed-list input[type="checkbox"]').prop('checked', checked);
+			});
+
+			// Load more pending articles.
+			$(document).on('click', '.ereader-load-more-btn', function(e) {
+				e.preventDefault();
+				self.loadMorePending($(this));
+			});
+
+			// Archive button clicks.
+			$(document).on('click', '.ereader-archive-btn', function(e) {
+				e.preventDefault();
+				var $btn = $(this);
+				var $item = $btn.closest('.ereader-article-item');
+				var articleId = $item.data('article-id');
+
+				self.saveNote(articleId, { status: 'archived' }, $item);
+				self.animateItemRemoval($item);
+			});
+		},
+
+		/**
+		 * Switch between tabs.
+		 *
+		 * @param {string} tab Tab name.
+		 */
+		switchTab: function(tab) {
+			$('.ereader-tab').removeClass('active');
+			$('.ereader-tab[data-tab="' + tab + '"]').addClass('active');
+
+			$('.ereader-tab-content').removeClass('active');
+			$('.ereader-tab-content[data-tab="' + tab + '"]').addClass('active');
+		},
+
+		/**
+		 * Update star display.
+		 *
+		 * @param {jQuery} $container Rating container.
+		 * @param {number} rating Current rating.
+		 */
+		updateStars: function($container, rating) {
+			$container.data('rating', rating);
+			$container.find('.ereader-star').each(function(index) {
+				var $star = $(this);
+				var starRating = index + 1;
+				if (starRating <= rating) {
+					$star.addClass('active').html('&#9733;');
+				} else {
+					$star.removeClass('active').html('&#9734;');
+				}
+			});
+		},
+
+		/**
+		 * Animate item removal from list.
+		 *
+		 * @param {jQuery} $item The article item to remove.
+		 */
+		animateItemRemoval: function($item) {
+			$item.addClass('ereader-moving');
+			setTimeout(function() {
+				$item.addClass('ereader-removed');
+				setTimeout(function() {
+					$item.remove();
+				}, 300);
+			}, 500);
+		},
+
+		/**
+		 * Save note via AJAX.
+		 *
+		 * @param {number} articleId Article post ID.
+		 * @param {object} data Data to save.
+		 * @param {jQuery} $item Article item element.
+		 */
+		saveNote: function(articleId, data, $item) {
+			var $status = $item.find('.ereader-save-status');
+
+			$status.text(ereaderArticleNotes.i18n.saving).addClass('saving');
+
+			var postData = $.extend({
+				action: 'ereader_save_note',
+				_ajax_nonce: ereaderArticleNotes.nonce,
+				article_id: articleId
+			}, data);
+
+			$.post(ereaderArticleNotes.ajaxurl, postData)
+				.done(function(response) {
+					if (response.success) {
+						$status.text(ereaderArticleNotes.i18n.saved)
+							.removeClass('saving error')
+							.addClass('saved');
+
+						setTimeout(function() {
+							$status.text('').removeClass('saved');
+						}, 2000);
+					} else {
+						$status.text(ereaderArticleNotes.i18n.error)
+							.removeClass('saving saved')
+							.addClass('error');
+					}
+				})
+				.fail(function() {
+					$status.text(ereaderArticleNotes.i18n.error)
+						.removeClass('saving saved')
+						.addClass('error');
+				});
+		},
+
+		/**
+		 * Load more articles.
+		 *
+		 * @param {jQuery} $btn The load more button.
+		 */
+		loadMorePending: function($btn) {
+			var self = this;
+			var offset = $btn.data('offset');
+			var type = $btn.data('type') || 'pending';
+			var originalText = $btn.text();
+
+			$btn.prop('disabled', true).text(ereaderArticleNotes.i18n.loading || 'Loading...');
+
+			$.post(ereaderArticleNotes.ajaxurl, {
+				action: 'ereader_load_more_pending',
+				_ajax_nonce: ereaderArticleNotes.nonce,
+				offset: offset,
+				type: type
+			})
+				.done(function(response) {
+					if (response.success && response.data.articles) {
+						var $list = $('.ereader-' + type + '-list');
+
+						// Append new articles.
+						response.data.articles.forEach(function(article) {
+							$list.append(self.renderArticleItem(article));
+						});
+
+						// Update button offset or hide if no more.
+						if (response.data.has_more) {
+							$btn.data('offset', response.data.offset);
+							$btn.prop('disabled', false).text(originalText);
+						} else {
+							$btn.closest('.ereader-load-more-section').remove();
+						}
+					} else {
+						$btn.prop('disabled', false).text(originalText);
+					}
+				})
+				.fail(function() {
+					$btn.prop('disabled', false).text(originalText);
+				});
+		},
+
+		/**
+		 * Render an article item HTML.
+		 *
+		 * @param {object} article Article data.
+		 * @return {string} HTML string.
+		 */
+		renderArticleItem: function(article) {
+			var statuses = ereaderArticleNotes.statuses || {
+				'unread': 'Not read yet',
+				'read': 'Read',
+				'skipped': 'Skipped'
+			};
+
+			var html = '<li class="ereader-article-item" data-article-id="' + article.id + '">';
+			html += '<div class="ereader-article-header">';
+			html += '<a href="' + article.permalink + '" class="ereader-article-title" target="_blank">' + this.escapeHtml(article.title) + '</a>';
+			html += '<span class="ereader-article-meta">' + this.escapeHtml(article.author);
+			if (article.sent_date) {
+				html += ' &bull; ' + this.escapeHtml(article.sent_date);
+			}
+			html += '</span></div>';
+
+			html += '<div class="ereader-article-controls">';
+			html += '<div class="ereader-status-buttons">';
+			for (var key in statuses) {
+				var activeClass = article.status === key ? ' active' : '';
+				html += '<button type="button" class="ereader-status-btn' + activeClass + '" data-status="' + key + '" title="' + statuses[key] + '">' + statuses[key] + '</button>';
+			}
+			html += '</div>';
+
+			html += '<div class="ereader-rating" data-rating="' + article.rating + '">';
+			for (var i = 1; i <= 5; i++) {
+				var starActive = i <= article.rating ? ' active' : '';
+				var starChar = i <= article.rating ? '&#9733;' : '&#9734;';
+				html += '<button type="button" class="ereader-star' + starActive + '" data-rating="' + i + '" title="' + i + ' stars">' + starChar + '</button>';
+			}
+			html += '</div></div>';
+
+			html += '<div class="ereader-notes-wrapper">';
+			html += '<textarea class="ereader-notes" placeholder="Add your notes..." rows="2">' + this.escapeHtml(article.notes || '') + '</textarea>';
+			html += '</div>';
+
+			html += '<div class="ereader-save-status"></div>';
+			html += '</li>';
+
+			return html;
+		},
+
+		/**
+		 * Escape HTML entities.
+		 *
+		 * @param {string} str String to escape.
+		 * @return {string} Escaped string.
+		 */
+		escapeHtml: function(str) {
+			if (!str) return '';
+			var div = document.createElement('div');
+			div.textContent = str;
+			return div.innerHTML;
+		},
+
+		/**
+		 * Create a post from selected reviewed articles.
+		 */
+		createPostFromSelected: function() {
+			var selectedIds = [];
+			$('.ereader-reviewed-list input[type="checkbox"]:checked').each(function() {
+				selectedIds.push($(this).val());
+			});
+
+			if (selectedIds.length === 0) {
+				alert('Please select at least one article.');
+				return;
+			}
+
+			var postTitle = $('#ereader-post-title').val();
+			var $btn = $('.ereader-create-post-btn');
+
+			$btn.prop('disabled', true).text('Creating...');
+
+			$.post(ereaderArticleNotes.ajaxurl, {
+				action: 'ereader_create_post_from_notes',
+				_ajax_nonce: ereaderArticleNotes.nonce,
+				article_ids: selectedIds,
+				post_title: postTitle
+			})
+				.done(function(response) {
+					if (response.success && response.data.edit_url) {
+						window.location.href = response.data.edit_url;
+					} else {
+						alert(response.data || 'Error creating post');
+						$btn.prop('disabled', false).text('Create Post from Selected');
+					}
+				})
+				.fail(function() {
+					alert('Error creating post');
+					$btn.prop('disabled', false).text('Create Post from Selected');
+				});
+		}
+	};
+
+	// Initialize when DOM is ready.
+	$(document).ready(function() {
+		ArticleNotes.init();
+	});
+
+})(jQuery);

--- a/assets/js/article-notes.js
+++ b/assets/js/article-notes.js
@@ -32,7 +32,7 @@
 				self.switchTab($(this).data('tab'));
 			});
 
-			// Status button clicks — radio-style, no auto-dismiss.
+			// Status button clicks — radio-style, stay in place.
 			$(document).on('click', '.post-collection-status-btn', function(e) {
 				e.preventDefault();
 				var $btn = $(this);
@@ -45,6 +45,9 @@
 				// Update UI — toggle like radio buttons.
 				$item.find('.post-collection-status-btn').removeClass('active');
 				$btn.addClass('active');
+
+				// Track the new status on the element for tab-switch sorting.
+				$item.data('status', status);
 			});
 
 			// Star rating clicks.
@@ -111,12 +114,14 @@
 				self.saveNote(articleId, { notes: $textarea.val() }, $item);
 			});
 
-			// Toggle notes in reviewed list.
-			$(document).on('click', '.post-collection-notes-preview', function() {
+			// Toggle notes in reviewed list by clicking the article title area.
+			$(document).on('click', '.post-collection-reviewed-list .post-collection-article-header', function(e) {
+				// Don't toggle if clicking a link or checkbox.
+				if ($(e.target).is('a, input')) {
+					return;
+				}
 				var $item = $(this).closest('.post-collection-article-item');
-				$(this).hide();
-				$item.find('.post-collection-notes-wrapper').show();
-				$item.find('.post-collection-notes').focus();
+				$item.toggleClass('post-collection-notes-open');
 			});
 
 			// Create post from selected.
@@ -155,11 +160,65 @@
 		 * @param {string} tab Tab name.
 		 */
 		switchTab: function(tab) {
+			// Before showing the new tab, move articles to their correct lists.
+			this.relocateArticles();
+
 			$('.post-collection-tab').removeClass('active');
 			$('.post-collection-tab[data-tab="' + tab + '"]').addClass('active');
 
 			$('.post-collection-tab-content').removeClass('active');
 			$('.post-collection-tab-content[data-tab="' + tab + '"]').addClass('active');
+		},
+
+		/**
+		 * Move articles between pending and reviewed lists based on their current status.
+		 */
+		relocateArticles: function() {
+			var self = this;
+
+			// Move read/skipped items from pending to reviewed.
+			$('.post-collection-pending-list .post-collection-article-item').each(function() {
+				var $item = $(this);
+				var status = self.getItemStatus($item);
+				if (status === 'read' || status === 'skipped') {
+					self.ensureReviewedList();
+					$item.addClass('post-collection-reviewed').detach();
+					$('.post-collection-reviewed-list').prepend($item);
+				}
+			});
+
+			// Move unread items from reviewed back to pending.
+			$('.post-collection-reviewed-list .post-collection-article-item').each(function() {
+				var $item = $(this);
+				var status = self.getItemStatus($item);
+				if (status === 'unread') {
+					$item.removeClass('post-collection-reviewed').detach();
+					$('.post-collection-pending-list').prepend($item);
+				}
+			});
+		},
+
+		/**
+		 * Get the current status of an article item from its active button.
+		 *
+		 * @param {jQuery} $item The article item.
+		 * @return {string} Status value, or empty string if none selected.
+		 */
+		getItemStatus: function($item) {
+			var $active = $item.find('.post-collection-status-btn.active');
+			return $active.length ? $active.data('status') : '';
+		},
+
+		/**
+		 * Ensure the reviewed list element exists, creating it if needed.
+		 */
+		ensureReviewedList: function() {
+			if ($('.post-collection-reviewed-list').length) {
+				return;
+			}
+			var $reviewedTab = $('.post-collection-tab-content[data-tab="reviewed"]');
+			$reviewedTab.find('.post-collection-no-articles').remove();
+			$reviewedTab.prepend('<ul class="post-collection-article-list post-collection-reviewed-list"></ul>');
 		},
 
 		/**
@@ -295,10 +354,15 @@
 			};
 
 			var hasNote = article.note_id > 0;
+			var isReviewed = hasNote && (article.status === 'read' || article.status === 'skipped');
+			var itemClass = 'post-collection-article-item' + (isReviewed ? ' post-collection-reviewed' : '');
 
-			var html = '<li class="post-collection-article-item" data-article-id="' + article.id + '">';
+			var html = '<li class="' + itemClass + '" data-article-id="' + article.id + '">';
 			html += '<div class="post-collection-article-header">';
+			html += '<label class="post-collection-select-article">';
+			html += '<input type="checkbox" name="selected_articles[]" value="' + article.id + '">';
 			html += '<a href="' + article.permalink + '" class="post-collection-article-title" target="_blank">' + this.escapeHtml(article.title) + '</a>';
+			html += '</label>';
 			html += '<span class="post-collection-article-meta">' + this.escapeHtml(article.author);
 			if (article.sent_date) {
 				html += ' &bull; ' + this.escapeHtml(article.sent_date);
@@ -319,14 +383,18 @@
 				var starChar = i <= article.rating ? '&#9733;' : '&#9734;';
 				html += '<button type="button" class="post-collection-star' + starActive + '" data-rating="' + i + '" title="' + i + ' stars">' + starChar + '</button>';
 			}
-			html += '</div></div>';
+			html += '</div>';
+
+			html += '<button type="button" class="post-collection-archive-btn" title="Archive">Archive</button>';
+			html += '</div>';
 
 			html += '<div class="post-collection-notes-wrapper">';
 			html += '<textarea class="post-collection-notes" placeholder="Add your notes..." rows="2">' + this.escapeHtml(article.notes || '') + '</textarea>';
+			html += '<div class="post-collection-notes-actions">';
 			html += '<button type="button" class="button button-small post-collection-save-notes-btn">Save</button>';
-			html += '</div>';
+			html += '<span class="post-collection-save-status"></span>';
+			html += '</div></div>';
 
-			html += '<div class="post-collection-save-status"></div>';
 			html += '</li>';
 
 			return html;

--- a/assets/js/article-notes.js
+++ b/assets/js/article-notes.js
@@ -1,7 +1,7 @@
 /**
  * Article Notes Widget JavaScript
  *
- * @package Send_To_E_Reader
+ * @package Post_Collection
  */
 
 (function($) {
@@ -27,24 +27,24 @@
 			var self = this;
 
 			// Tab switching.
-			$(document).on('click', '.ereader-tab', function(e) {
+			$(document).on('click', '.post-collection-tab', function(e) {
 				e.preventDefault();
 				self.switchTab($(this).data('tab'));
 			});
 
 			// Status button clicks.
-			$(document).on('click', '.ereader-status-btn', function(e) {
+			$(document).on('click', '.post-collection-status-btn', function(e) {
 				e.preventDefault();
 				var $btn = $(this);
-				var $item = $btn.closest('.ereader-article-item');
+				var $item = $btn.closest('.post-collection-article-item');
 				var articleId = $item.data('article-id');
 				var status = $btn.data('status');
-				var currentTab = $('.ereader-tab.active').data('tab');
+				var currentTab = $('.post-collection-tab.active').data('tab');
 
 				self.saveNote(articleId, { status: status }, $item);
 
 				// Update UI.
-				$item.find('.ereader-status-btn').removeClass('active');
+				$item.find('.post-collection-status-btn').removeClass('active');
 				$btn.addClass('active');
 
 				// Check if item should move to another tab.
@@ -66,11 +66,11 @@
 			});
 
 			// Star rating clicks.
-			$(document).on('click', '.ereader-star', function(e) {
+			$(document).on('click', '.post-collection-star', function(e) {
 				e.preventDefault();
 				var $star = $(this);
-				var $item = $star.closest('.ereader-article-item');
-				var $ratingContainer = $star.closest('.ereader-rating');
+				var $item = $star.closest('.post-collection-article-item');
+				var $ratingContainer = $star.closest('.post-collection-rating');
 				var articleId = $item.data('article-id');
 				var rating = $star.data('rating');
 
@@ -81,9 +81,9 @@
 			});
 
 			// Notes textarea - save on blur with debounce.
-			$(document).on('input', '.ereader-notes', function() {
+			$(document).on('input', '.post-collection-notes', function() {
 				var $textarea = $(this);
-				var $item = $textarea.closest('.ereader-article-item');
+				var $item = $textarea.closest('.post-collection-article-item');
 				var articleId = $item.data('article-id');
 
 				// Clear existing timer for this article.
@@ -98,9 +98,9 @@
 			});
 
 			// Also save on blur.
-			$(document).on('blur', '.ereader-notes', function() {
+			$(document).on('blur', '.post-collection-notes', function() {
 				var $textarea = $(this);
-				var $item = $textarea.closest('.ereader-article-item');
+				var $item = $textarea.closest('.post-collection-article-item');
 				var articleId = $item.data('article-id');
 
 				// Clear pending timer and save immediately.
@@ -113,36 +113,36 @@
 			});
 
 			// Toggle notes in reviewed list.
-			$(document).on('click', '.ereader-notes-preview', function() {
-				var $item = $(this).closest('.ereader-article-item');
+			$(document).on('click', '.post-collection-notes-preview', function() {
+				var $item = $(this).closest('.post-collection-article-item');
 				$(this).hide();
-				$item.find('.ereader-notes-wrapper').show();
-				$item.find('.ereader-notes').focus();
+				$item.find('.post-collection-notes-wrapper').show();
+				$item.find('.post-collection-notes').focus();
 			});
 
 			// Create post from selected.
-			$(document).on('click', '.ereader-create-post-btn', function(e) {
+			$(document).on('click', '.post-collection-create-post-btn', function(e) {
 				e.preventDefault();
 				self.createPostFromSelected();
 			});
 
 			// Select all toggle for reviewed list.
-			$(document).on('change', '.ereader-select-all', function() {
+			$(document).on('change', '.post-collection-select-all', function() {
 				var checked = $(this).prop('checked');
-				$('.ereader-reviewed-list input[type="checkbox"]').prop('checked', checked);
+				$('.post-collection-reviewed-list input[type="checkbox"]').prop('checked', checked);
 			});
 
 			// Load more pending articles.
-			$(document).on('click', '.ereader-load-more-btn', function(e) {
+			$(document).on('click', '.post-collection-load-more-btn', function(e) {
 				e.preventDefault();
 				self.loadMorePending($(this));
 			});
 
 			// Archive button clicks.
-			$(document).on('click', '.ereader-archive-btn', function(e) {
+			$(document).on('click', '.post-collection-archive-btn', function(e) {
 				e.preventDefault();
 				var $btn = $(this);
-				var $item = $btn.closest('.ereader-article-item');
+				var $item = $btn.closest('.post-collection-article-item');
 				var articleId = $item.data('article-id');
 
 				self.saveNote(articleId, { status: 'archived' }, $item);
@@ -156,11 +156,11 @@
 		 * @param {string} tab Tab name.
 		 */
 		switchTab: function(tab) {
-			$('.ereader-tab').removeClass('active');
-			$('.ereader-tab[data-tab="' + tab + '"]').addClass('active');
+			$('.post-collection-tab').removeClass('active');
+			$('.post-collection-tab[data-tab="' + tab + '"]').addClass('active');
 
-			$('.ereader-tab-content').removeClass('active');
-			$('.ereader-tab-content[data-tab="' + tab + '"]').addClass('active');
+			$('.post-collection-tab-content').removeClass('active');
+			$('.post-collection-tab-content[data-tab="' + tab + '"]').addClass('active');
 		},
 
 		/**
@@ -171,7 +171,7 @@
 		 */
 		updateStars: function($container, rating) {
 			$container.data('rating', rating);
-			$container.find('.ereader-star').each(function(index) {
+			$container.find('.post-collection-star').each(function(index) {
 				var $star = $(this);
 				var starRating = index + 1;
 				if (starRating <= rating) {
@@ -188,9 +188,9 @@
 		 * @param {jQuery} $item The article item to remove.
 		 */
 		animateItemRemoval: function($item) {
-			$item.addClass('ereader-moving');
+			$item.addClass('post-collection-moving');
 			setTimeout(function() {
-				$item.addClass('ereader-removed');
+				$item.addClass('post-collection-removed');
 				setTimeout(function() {
 					$item.remove();
 				}, 300);
@@ -205,20 +205,20 @@
 		 * @param {jQuery} $item Article item element.
 		 */
 		saveNote: function(articleId, data, $item) {
-			var $status = $item.find('.ereader-save-status');
+			var $status = $item.find('.post-collection-save-status');
 
-			$status.text(ereaderArticleNotes.i18n.saving).addClass('saving');
+			$status.text(postCollectionArticleNotes.i18n.saving).addClass('saving');
 
 			var postData = $.extend({
-				action: 'ereader_save_note',
-				_ajax_nonce: ereaderArticleNotes.nonce,
+				action: 'post_collection_save_note',
+				_ajax_nonce: postCollectionArticleNotes.nonce,
 				article_id: articleId
 			}, data);
 
-			$.post(ereaderArticleNotes.ajaxurl, postData)
+			$.post(postCollectionArticleNotes.ajaxurl, postData)
 				.done(function(response) {
 					if (response.success) {
-						$status.text(ereaderArticleNotes.i18n.saved)
+						$status.text(postCollectionArticleNotes.i18n.saved)
 							.removeClass('saving error')
 							.addClass('saved');
 
@@ -226,13 +226,13 @@
 							$status.text('').removeClass('saved');
 						}, 2000);
 					} else {
-						$status.text(ereaderArticleNotes.i18n.error)
+						$status.text(postCollectionArticleNotes.i18n.error)
 							.removeClass('saving saved')
 							.addClass('error');
 					}
 				})
 				.fail(function() {
-					$status.text(ereaderArticleNotes.i18n.error)
+					$status.text(postCollectionArticleNotes.i18n.error)
 						.removeClass('saving saved')
 						.addClass('error');
 				});
@@ -249,17 +249,17 @@
 			var type = $btn.data('type') || 'pending';
 			var originalText = $btn.text();
 
-			$btn.prop('disabled', true).text(ereaderArticleNotes.i18n.loading || 'Loading...');
+			$btn.prop('disabled', true).text(postCollectionArticleNotes.i18n.loading || 'Loading...');
 
-			$.post(ereaderArticleNotes.ajaxurl, {
-				action: 'ereader_load_more_pending',
-				_ajax_nonce: ereaderArticleNotes.nonce,
+			$.post(postCollectionArticleNotes.ajaxurl, {
+				action: 'post_collection_load_more_pending',
+				_ajax_nonce: postCollectionArticleNotes.nonce,
 				offset: offset,
 				type: type
 			})
 				.done(function(response) {
 					if (response.success && response.data.articles) {
-						var $list = $('.ereader-' + type + '-list');
+						var $list = $('.post-collection-' + type + '-list');
 
 						// Append new articles.
 						response.data.articles.forEach(function(article) {
@@ -271,7 +271,7 @@
 							$btn.data('offset', response.data.offset);
 							$btn.prop('disabled', false).text(originalText);
 						} else {
-							$btn.closest('.ereader-load-more-section').remove();
+							$btn.closest('.post-collection-load-more-section').remove();
 						}
 					} else {
 						$btn.prop('disabled', false).text(originalText);
@@ -289,42 +289,42 @@
 		 * @return {string} HTML string.
 		 */
 		renderArticleItem: function(article) {
-			var statuses = ereaderArticleNotes.statuses || {
+			var statuses = postCollectionArticleNotes.statuses || {
 				'unread': 'Not read yet',
 				'read': 'Read',
 				'skipped': 'Skipped'
 			};
 
-			var html = '<li class="ereader-article-item" data-article-id="' + article.id + '">';
-			html += '<div class="ereader-article-header">';
-			html += '<a href="' + article.permalink + '" class="ereader-article-title" target="_blank">' + this.escapeHtml(article.title) + '</a>';
-			html += '<span class="ereader-article-meta">' + this.escapeHtml(article.author);
+			var html = '<li class="post-collection-article-item" data-article-id="' + article.id + '">';
+			html += '<div class="post-collection-article-header">';
+			html += '<a href="' + article.permalink + '" class="post-collection-article-title" target="_blank">' + this.escapeHtml(article.title) + '</a>';
+			html += '<span class="post-collection-article-meta">' + this.escapeHtml(article.author);
 			if (article.sent_date) {
 				html += ' &bull; ' + this.escapeHtml(article.sent_date);
 			}
 			html += '</span></div>';
 
-			html += '<div class="ereader-article-controls">';
-			html += '<div class="ereader-status-buttons">';
+			html += '<div class="post-collection-article-controls">';
+			html += '<div class="post-collection-status-buttons">';
 			for (var key in statuses) {
 				var activeClass = article.status === key ? ' active' : '';
-				html += '<button type="button" class="ereader-status-btn' + activeClass + '" data-status="' + key + '" title="' + statuses[key] + '">' + statuses[key] + '</button>';
+				html += '<button type="button" class="post-collection-status-btn' + activeClass + '" data-status="' + key + '" title="' + statuses[key] + '">' + statuses[key] + '</button>';
 			}
 			html += '</div>';
 
-			html += '<div class="ereader-rating" data-rating="' + article.rating + '">';
+			html += '<div class="post-collection-rating" data-rating="' + article.rating + '">';
 			for (var i = 1; i <= 5; i++) {
 				var starActive = i <= article.rating ? ' active' : '';
 				var starChar = i <= article.rating ? '&#9733;' : '&#9734;';
-				html += '<button type="button" class="ereader-star' + starActive + '" data-rating="' + i + '" title="' + i + ' stars">' + starChar + '</button>';
+				html += '<button type="button" class="post-collection-star' + starActive + '" data-rating="' + i + '" title="' + i + ' stars">' + starChar + '</button>';
 			}
 			html += '</div></div>';
 
-			html += '<div class="ereader-notes-wrapper">';
-			html += '<textarea class="ereader-notes" placeholder="Add your notes..." rows="2">' + this.escapeHtml(article.notes || '') + '</textarea>';
+			html += '<div class="post-collection-notes-wrapper">';
+			html += '<textarea class="post-collection-notes" placeholder="Add your notes..." rows="2">' + this.escapeHtml(article.notes || '') + '</textarea>';
 			html += '</div>';
 
-			html += '<div class="ereader-save-status"></div>';
+			html += '<div class="post-collection-save-status"></div>';
 			html += '</li>';
 
 			return html;
@@ -348,7 +348,7 @@
 		 */
 		createPostFromSelected: function() {
 			var selectedIds = [];
-			$('.ereader-reviewed-list input[type="checkbox"]:checked').each(function() {
+			$('.post-collection-reviewed-list input[type="checkbox"]:checked').each(function() {
 				selectedIds.push($(this).val());
 			});
 
@@ -357,14 +357,14 @@
 				return;
 			}
 
-			var postTitle = $('#ereader-post-title').val();
-			var $btn = $('.ereader-create-post-btn');
+			var postTitle = $('#post-collection-post-title').val();
+			var $btn = $('.post-collection-create-post-btn');
 
 			$btn.prop('disabled', true).text('Creating...');
 
-			$.post(ereaderArticleNotes.ajaxurl, {
-				action: 'ereader_create_post_from_notes',
-				_ajax_nonce: ereaderArticleNotes.nonce,
+			$.post(postCollectionArticleNotes.ajaxurl, {
+				action: 'post_collection_create_post_from_notes',
+				_ajax_nonce: postCollectionArticleNotes.nonce,
 				article_ids: selectedIds,
 				post_title: postTitle
 			})

--- a/assets/js/article-notes.js
+++ b/assets/js/article-notes.js
@@ -114,13 +114,6 @@
 				self.saveNote(articleId, { notes: $textarea.val() }, $item);
 			});
 
-			// Toggle notes visibility.
-			$(document).on('click', '.post-collection-toggle-notes-btn', function(e) {
-				e.preventDefault();
-				var $item = $(this).closest('.post-collection-article-item');
-				$item.toggleClass('post-collection-notes-open');
-			});
-
 			// Create post from selected.
 			$(document).on('click', '.post-collection-create-post-btn', function(e) {
 				e.preventDefault();
@@ -382,7 +375,6 @@
 			}
 			html += '</div>';
 
-			html += '<button type="button" class="post-collection-toggle-notes-btn" title="Toggle notes">Notes</button>';
 			html += '<button type="button" class="post-collection-archive-btn" title="Archive">Archive</button>';
 			html += '</div>';
 

--- a/assets/js/article-notes.js
+++ b/assets/js/article-notes.js
@@ -176,7 +176,7 @@
 				var $input = $(this);
 				var $wrapper = $input.closest('.post-collection-title-wrapper');
 				var $title = $wrapper.find('.post-collection-article-title');
-				var $item = $input.closest('.post-collection-article-item');
+				var $item = $input.closest('[data-article-id]');
 				var newTitle = $.trim($input.val());
 
 				if (newTitle && newTitle !== $title.text()) {
@@ -204,11 +204,18 @@
 				.done(function(response) {
 					if (response.success && response.data) {
 						var article = response.data;
-						$container.find('.post-collection-remember-title')
+						$container.data('article-id', article.id);
+						$container.find('.post-collection-article-title')
 							.attr('href', article.permalink)
 							.text(article.title);
+						$container.find('.post-collection-title-input')
+							.val(article.title);
+						var meta = article.author;
+						if (article.collection && article.collection !== article.author) {
+							meta += ' \u2022 ' + article.collection;
+						}
 						$container.find('.post-collection-remember-meta')
-							.text(article.author);
+							.text(meta);
 						$container.find('.post-collection-remember-notes')
 							.html(article.notes);
 
@@ -481,6 +488,9 @@
 			html += '</span>';
 			html += '</label>';
 			html += '<span class="post-collection-article-meta">' + this.escapeHtml(article.author);
+			if (article.collection && article.collection !== article.author) {
+				html += ' &bull; ' + this.escapeHtml(article.collection);
+			}
 			if (article.sent_date) {
 				html += ' &bull; ' + this.escapeHtml(article.sent_date);
 			}

--- a/assets/js/article-notes.js
+++ b/assets/js/article-notes.js
@@ -32,37 +32,19 @@
 				self.switchTab($(this).data('tab'));
 			});
 
-			// Status button clicks.
+			// Status button clicks — radio-style, no auto-dismiss.
 			$(document).on('click', '.post-collection-status-btn', function(e) {
 				e.preventDefault();
 				var $btn = $(this);
 				var $item = $btn.closest('.post-collection-article-item');
 				var articleId = $item.data('article-id');
 				var status = $btn.data('status');
-				var currentTab = $('.post-collection-tab.active').data('tab');
 
 				self.saveNote(articleId, { status: status }, $item);
 
-				// Update UI.
+				// Update UI — toggle like radio buttons.
 				$item.find('.post-collection-status-btn').removeClass('active');
 				$btn.addClass('active');
-
-				// Check if item should move to another tab.
-				var shouldMove = false;
-				if (currentTab === 'pending') {
-					// Any status in pending moves the item out.
-					shouldMove = true;
-				} else if (currentTab === 'unread' && (status === 'read' || status === 'skipped' || status === 'archived')) {
-					// Read, Skipped, or Archived in unread moves to reviewed.
-					shouldMove = true;
-				} else if (currentTab === 'reviewed' && status === 'unread') {
-					// Changing back to unread moves to unread tab.
-					shouldMove = true;
-				}
-
-				if (shouldMove) {
-					self.animateItemRemoval($item);
-				}
 			});
 
 			// Star rating clicks.
@@ -80,7 +62,7 @@
 				self.updateStars($ratingContainer, rating);
 			});
 
-			// Notes textarea - save on blur with debounce.
+			// Notes textarea - auto-save with debounce.
 			$(document).on('input', '.post-collection-notes', function() {
 				var $textarea = $(this);
 				var $item = $textarea.closest('.post-collection-article-item');
@@ -97,13 +79,30 @@
 				}, 1000);
 			});
 
-			// Also save on blur.
+			// Save on blur.
 			$(document).on('blur', '.post-collection-notes', function() {
 				var $textarea = $(this);
 				var $item = $textarea.closest('.post-collection-article-item');
 				var articleId = $item.data('article-id');
 
 				// Clear pending timer and save immediately.
+				if (self.saveTimers[articleId]) {
+					clearTimeout(self.saveTimers[articleId]);
+					delete self.saveTimers[articleId];
+				}
+
+				self.saveNote(articleId, { notes: $textarea.val() }, $item);
+			});
+
+			// Explicit save button for notes.
+			$(document).on('click', '.post-collection-save-notes-btn', function(e) {
+				e.preventDefault();
+				var $btn = $(this);
+				var $item = $btn.closest('.post-collection-article-item');
+				var $textarea = $item.find('.post-collection-notes');
+				var articleId = $item.data('article-id');
+
+				// Clear any pending debounce timer.
 				if (self.saveTimers[articleId]) {
 					clearTimeout(self.saveTimers[articleId]);
 					delete self.saveTimers[articleId];
@@ -132,7 +131,7 @@
 				$('.post-collection-reviewed-list input[type="checkbox"]').prop('checked', checked);
 			});
 
-			// Load more pending articles.
+			// Load more articles.
 			$(document).on('click', '.post-collection-load-more-btn', function(e) {
 				e.preventDefault();
 				self.loadMorePending($(this));
@@ -259,7 +258,7 @@
 			})
 				.done(function(response) {
 					if (response.success && response.data.articles) {
-						var $list = $('.post-collection-' + type + '-list');
+						var $list = $('.post-collection-pending-list');
 
 						// Append new articles.
 						response.data.articles.forEach(function(article) {
@@ -295,6 +294,8 @@
 				'skipped': 'Skipped'
 			};
 
+			var hasNote = article.note_id > 0;
+
 			var html = '<li class="post-collection-article-item" data-article-id="' + article.id + '">';
 			html += '<div class="post-collection-article-header">';
 			html += '<a href="' + article.permalink + '" class="post-collection-article-title" target="_blank">' + this.escapeHtml(article.title) + '</a>';
@@ -307,7 +308,7 @@
 			html += '<div class="post-collection-article-controls">';
 			html += '<div class="post-collection-status-buttons">';
 			for (var key in statuses) {
-				var activeClass = article.status === key ? ' active' : '';
+				var activeClass = (hasNote && article.status === key) ? ' active' : '';
 				html += '<button type="button" class="post-collection-status-btn' + activeClass + '" data-status="' + key + '" title="' + statuses[key] + '">' + statuses[key] + '</button>';
 			}
 			html += '</div>';
@@ -322,6 +323,7 @@
 
 			html += '<div class="post-collection-notes-wrapper">';
 			html += '<textarea class="post-collection-notes" placeholder="Add your notes..." rows="2">' + this.escapeHtml(article.notes || '') + '</textarea>';
+			html += '<button type="button" class="button button-small post-collection-save-notes-btn">Save</button>';
 			html += '</div>';
 
 			html += '<div class="post-collection-save-status"></div>';

--- a/assets/js/article-notes.js
+++ b/assets/js/article-notes.js
@@ -148,6 +148,47 @@
 				e.preventDefault();
 				self.loadRandomRemembered();
 			});
+
+			// Edit title — show input.
+			$(document).on('click', '.post-collection-edit-title-btn', function(e) {
+				e.preventDefault();
+				e.stopPropagation();
+				var $wrapper = $(this).closest('.post-collection-title-wrapper');
+				$wrapper.find('.post-collection-article-title, .post-collection-edit-title-btn').hide();
+				$wrapper.find('.post-collection-title-input').show().focus().select();
+			});
+
+			// Save title on Enter.
+			$(document).on('keydown', '.post-collection-title-input', function(e) {
+				if (e.key === 'Enter') {
+					e.preventDefault();
+					$(this).blur();
+				} else if (e.key === 'Escape') {
+					// Revert.
+					var $wrapper = $(this).closest('.post-collection-title-wrapper');
+					var original = $wrapper.find('.post-collection-article-title').text();
+					$(this).val(original).blur();
+				}
+			});
+
+			// Save title on blur.
+			$(document).on('blur', '.post-collection-title-input', function() {
+				var $input = $(this);
+				var $wrapper = $input.closest('.post-collection-title-wrapper');
+				var $title = $wrapper.find('.post-collection-article-title');
+				var $item = $input.closest('.post-collection-article-item');
+				var newTitle = $.trim($input.val());
+
+				if (newTitle && newTitle !== $title.text()) {
+					$title.text(newTitle);
+					var articleId = $item.data('article-id');
+					self.saveTitle(articleId, newTitle, $item);
+				}
+
+				$input.hide();
+				$title.show();
+				$wrapper.find('.post-collection-edit-title-btn').show();
+			});
 		},
 
 		/**
@@ -188,6 +229,41 @@
 							$details.remove();
 						}
 					}
+				});
+		},
+
+		/**
+		 * Save article title via AJAX.
+		 *
+		 * @param {number} articleId Article post ID.
+		 * @param {string} title New title.
+		 * @param {jQuery} $item Article item element.
+		 */
+		saveTitle: function(articleId, title, $item) {
+			var $status = $item.find('.post-collection-save-status');
+			$status.text(postCollectionArticleNotes.i18n.saving).addClass('saving');
+
+			$.post(postCollectionArticleNotes.ajaxurl, {
+				action: 'post_collection_save_title',
+				_ajax_nonce: postCollectionArticleNotes.nonce,
+				article_id: articleId,
+				title: title
+			})
+				.done(function(response) {
+					if (response.success) {
+						$status.text(postCollectionArticleNotes.i18n.saved)
+							.removeClass('saving error').addClass('saved');
+						setTimeout(function() {
+							$status.text('').removeClass('saved');
+						}, 2000);
+					} else {
+						$status.text(postCollectionArticleNotes.i18n.error)
+							.removeClass('saving saved').addClass('error');
+					}
+				})
+				.fail(function() {
+					$status.text(postCollectionArticleNotes.i18n.error)
+						.removeClass('saving saved').addClass('error');
 				});
 		},
 
@@ -398,7 +474,11 @@
 			html += '<div class="post-collection-article-header">';
 			html += '<label class="post-collection-select-article">';
 			html += '<input type="checkbox" name="selected_articles[]" value="' + article.id + '">';
+			html += '<span class="post-collection-title-wrapper">';
 			html += '<a href="' + article.permalink + '" class="post-collection-article-title" target="_blank">' + this.escapeHtml(article.title) + '</a>';
+			html += '<button type="button" class="post-collection-edit-title-btn" title="Edit title">&#9998;</button>';
+			html += '<input type="text" class="post-collection-title-input" value="' + this.escapeHtml(article.title) + '">';
+			html += '</span>';
 			html += '</label>';
 			html += '<span class="post-collection-article-meta">' + this.escapeHtml(article.author);
 			if (article.sent_date) {

--- a/assets/js/article-notes.js
+++ b/assets/js/article-notes.js
@@ -114,12 +114,9 @@
 				self.saveNote(articleId, { notes: $textarea.val() }, $item);
 			});
 
-			// Toggle notes in reviewed list by clicking the article title area.
-			$(document).on('click', '.post-collection-reviewed-list .post-collection-article-header', function(e) {
-				// Don't toggle if clicking a link or checkbox.
-				if ($(e.target).is('a, input')) {
-					return;
-				}
+			// Toggle notes visibility.
+			$(document).on('click', '.post-collection-toggle-notes-btn', function(e) {
+				e.preventDefault();
 				var $item = $(this).closest('.post-collection-article-item');
 				$item.toggleClass('post-collection-notes-open');
 			});
@@ -385,6 +382,7 @@
 			}
 			html += '</div>';
 
+			html += '<button type="button" class="post-collection-toggle-notes-btn" title="Toggle notes">Notes</button>';
 			html += '<button type="button" class="post-collection-archive-btn" title="Archive">Archive</button>';
 			html += '</div>';
 

--- a/assets/js/article-notes.js
+++ b/assets/js/article-notes.js
@@ -288,6 +288,7 @@
 
 			$('.post-collection-tab-content').removeClass('active');
 			$('.post-collection-tab-content[data-tab="' + tab + '"]').addClass('active');
+
 		},
 
 		/**

--- a/assets/js/article-notes.js
+++ b/assets/js/article-notes.js
@@ -142,6 +142,53 @@
 				self.saveNote(articleId, { status: 'archived' }, $item);
 				self.animateItemRemoval($item);
 			});
+
+			// Show another random remembered article.
+			$(document).on('click', '.post-collection-remember-another', function(e) {
+				e.preventDefault();
+				self.loadRandomRemembered();
+			});
+		},
+
+		/**
+		 * Load a random remembered article via AJAX.
+		 */
+		loadRandomRemembered: function() {
+			var $container = $('.post-collection-remember');
+
+			$.get(postCollectionArticleNotes.ajaxurl, {
+				action: 'post_collection_random_remembered',
+				_ajax_nonce: postCollectionArticleNotes.nonce
+			})
+				.done(function(response) {
+					if (response.success && response.data) {
+						var article = response.data;
+						$container.find('.post-collection-remember-title')
+							.attr('href', article.permalink)
+							.text(article.title);
+						$container.find('.post-collection-remember-meta')
+							.text(article.author);
+						$container.find('.post-collection-remember-notes')
+							.html(article.notes);
+
+						// Update the article preview if present.
+						var $details = $container.find('.post-collection-article-preview');
+						if (article.content) {
+							if ($details.length) {
+								$details.find('.post-collection-article-preview-content').html(article.content);
+								$details.removeAttr('open');
+							} else {
+								var detailsHtml = '<details class="post-collection-article-preview">';
+								detailsHtml += '<summary>' + (postCollectionArticleNotes.i18n.showArticle || 'Show article') + '</summary>';
+								detailsHtml += '<div class="post-collection-article-preview-content">' + article.content + '</div>';
+								detailsHtml += '</details>';
+								$container.find('.post-collection-remember-notes').after(detailsHtml);
+							}
+						} else if ($details.length) {
+							$details.remove();
+						}
+					}
+				});
 		},
 
 		/**

--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -198,39 +198,6 @@ class Post_Collection {
 	}
 
 	/**
-	 * Get the template loader.
-	 *
-	 * @return object Template loader instance.
-	 */
-	public function get_template_loader() {
-		if ( $this->friends ) {
-			return \Friends\Friends::template_loader();
-		}
-		return $this->get_fallback_template_loader();
-	}
-
-	/**
-	 * Get a simple fallback template loader for standalone mode.
-	 *
-	 * @return object Template loader instance.
-	 */
-	private function get_fallback_template_loader() {
-		static $loader = null;
-		if ( null === $loader ) {
-			$loader = new class {
-				public function get_template_part( $slug, $name = null, $args = array() ) {
-					$template_file = POST_COLLECTION_PLUGIN_DIR . 'templates/' . $slug . '.php';
-					if ( file_exists( $template_file ) ) {
-						extract( $args );
-						include $template_file;
-					}
-				}
-			};
-		}
-		return $loader;
-	}
-
-	/**
 	 * Register the WordPress hooks
 	 */
 	private function register_hooks() {

--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -53,12 +53,20 @@ class Post_Collection {
 	private $site_configs = array();
 
 	/**
+	 * Contains the article notes instance
+	 *
+	 * @var Article_Notes
+	 */
+	private $article_notes;
+
+	/**
 	 * Constructor
 	 *
 	 * @param Friends|null $friends A reference to the Friends object (optional).
 	 */
 	public function __construct( ?Friends $friends = null ) {
 		$this->friends = $friends;
+		$this->article_notes = new Article_Notes( $this );
 		$this->register_hooks();
 	}
 
@@ -164,6 +172,62 @@ class Post_Collection {
 		);
 
 		return $post_id ? intval( $post_id ) : null;
+	}
+
+	/**
+	 * Get the article notes instance.
+	 *
+	 * @return Article_Notes The article notes instance.
+	 */
+	public function get_article_notes() {
+		return $this->article_notes;
+	}
+
+	/**
+	 * Get the post author name.
+	 *
+	 * @param \WP_Post $post The post object.
+	 * @return string The author display name.
+	 */
+	public function get_post_author_name( \WP_Post $post ) {
+		if ( $this->friends && class_exists( '\Friends\User' ) ) {
+			$author = \Friends\User::get_post_author( $post );
+			return $author->display_name;
+		}
+		return get_the_author_meta( 'display_name', $post->post_author );
+	}
+
+	/**
+	 * Get the template loader.
+	 *
+	 * @return object Template loader instance.
+	 */
+	public function get_template_loader() {
+		if ( $this->friends ) {
+			return \Friends\Friends::template_loader();
+		}
+		return $this->get_fallback_template_loader();
+	}
+
+	/**
+	 * Get a simple fallback template loader for standalone mode.
+	 *
+	 * @return object Template loader instance.
+	 */
+	private function get_fallback_template_loader() {
+		static $loader = null;
+		if ( null === $loader ) {
+			$loader = new class {
+				public function get_template_part( $slug, $name = null, $args = array() ) {
+					$template_file = POST_COLLECTION_PLUGIN_DIR . 'templates/' . $slug . '.php';
+					if ( file_exists( $template_file ) ) {
+						extract( $args );
+						include $template_file;
+					}
+				}
+			};
+		}
+		return $loader;
 	}
 
 	/**

--- a/includes/class-article-notes.php
+++ b/includes/class-article-notes.php
@@ -114,7 +114,7 @@ class Article_Notes {
 		}
 
 		$post = get_post();
-		if ( ! $post ) {
+		if ( ! $post || Post_Collection::CPT !== $post->post_type ) {
 			return;
 		}
 

--- a/includes/class-article-notes.php
+++ b/includes/class-article-notes.php
@@ -67,8 +67,8 @@ class Article_Notes {
 	public function register_admin_menu() {
 		add_submenu_page(
 			'edit.php?post_type=' . Post_Collection::CPT,
-			__( 'Article Notes', 'post-collection' ),
-			__( 'Article Notes', 'post-collection' ),
+			__( 'Collected Posts Notes', 'post-collection' ),
+			__( 'Notes', 'post-collection' ),
 			'edit_posts',
 			'post-collection-article-notes',
 			array( $this, 'render_admin_page' )
@@ -251,7 +251,7 @@ class Article_Notes {
 
 		wp_add_dashboard_widget(
 			'post_collection_article_notes',
-			__( 'Article Notes', 'post-collection' ),
+			__( 'Collected Posts Notes', 'post-collection' ),
 			array( $this, 'render_dashboard_widget' )
 		);
 	}
@@ -611,11 +611,21 @@ class Article_Notes {
 		$content = preg_replace( '/<img[^>]*>/i', '', $content );
 		$content = preg_replace( '/<figure[^>]*>.*?<\/figure>/is', '', $content );
 
+		// Use the per-post author meta if available.
+		$author = get_post_meta( $post->ID, 'author', true );
+		if ( ! $author ) {
+			$author = $this->plugin->get_post_author_name( $post );
+		}
+
+		$user = new User( $post->post_author );
+		$permalink = $user->get_local_friends_page_url( $post->ID );
+
 		return array(
 			'id'          => $post->ID,
 			'title'       => get_the_title( $post ),
-			'permalink'   => get_permalink( $post ),
-			'author'      => $this->plugin->get_post_author_name( $post ),
+			'permalink'   => $permalink,
+			'author'      => $author,
+			'collection'  => $user->display_name,
 			'sent_date'   => $sent_date,
 			'excerpt'     => get_the_excerpt( $post ),
 			'content'     => wp_kses_post( $content ),

--- a/includes/class-article-notes.php
+++ b/includes/class-article-notes.php
@@ -59,7 +59,7 @@ class Article_Notes {
 		add_action( 'before_delete_post', array( $this, 'maybe_delete_note' ) );
 		add_action( 'wp_dashboard_setup', array( $this, 'register_dashboard_widget' ) );
 		add_action( 'admin_menu', array( $this, 'register_admin_menu' ) );
-		add_action( 'friends_post_footer_first', array( $this, 'render_frontend_notes' ) );
+		add_action( 'friends_post_after_footer', array( $this, 'render_frontend_notes' ) );
 	}
 
 	/**

--- a/includes/class-article-notes.php
+++ b/includes/class-article-notes.php
@@ -260,8 +260,8 @@ class Article_Notes {
 	 */
 	public function render_dashboard_widget() {
 		$this->enqueue_widget_assets();
-		$pending_limit = 10;
-		$review_limit = 10;
+		$pending_limit = 1;
+		$review_limit = 5;
 
 		$pending_articles = $this->get_pending_and_unread_articles( $pending_limit + 1 );
 		$has_more_pending = count( $pending_articles ) > $pending_limit;

--- a/includes/class-article-notes.php
+++ b/includes/class-article-notes.php
@@ -252,8 +252,69 @@ class Article_Notes {
 		wp_add_dashboard_widget(
 			'post_collection_article_notes',
 			__( 'Collected Posts Notes', 'post-collection' ),
-			array( $this, 'render_dashboard_widget' )
+			array( $this, 'render_dashboard_widget' ),
+			array( $this, 'render_dashboard_widget_config' )
 		);
+	}
+
+	/**
+	 * Get widget options for the current user.
+	 *
+	 * @return array Widget options.
+	 */
+	private function get_widget_options() {
+		$defaults = array(
+			'pending_count'      => 1,
+			'reviewed_count'     => 5,
+			'show_random_note'   => true,
+			'show_tabs'          => true,
+		);
+		$options = get_user_option( 'post_collection_widget_options' );
+		if ( ! is_array( $options ) ) {
+			$options = array();
+		}
+		return array_merge( $defaults, $options );
+	}
+
+	/**
+	 * Render the dashboard widget configuration form.
+	 */
+	public function render_dashboard_widget_config() {
+		$options = $this->get_widget_options();
+
+		if ( isset( $_POST['post_collection_widget_config_nonce'] )
+			&& wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['post_collection_widget_config_nonce'] ) ), 'post_collection_widget_config' )
+		) {
+			$options['pending_count']    = isset( $_POST['pending_count'] ) ? max( 1, (int) $_POST['pending_count'] ) : 1;
+			$options['reviewed_count']   = isset( $_POST['reviewed_count'] ) ? max( 1, (int) $_POST['reviewed_count'] ) : 5;
+			$options['show_random_note'] = ! empty( $_POST['show_random_note'] );
+			$options['show_tabs']        = ! empty( $_POST['show_tabs'] );
+			update_user_option( get_current_user_id(), 'post_collection_widget_options', $options );
+		}
+
+		?>
+		<?php wp_nonce_field( 'post_collection_widget_config', 'post_collection_widget_config_nonce' ); ?>
+		<p>
+			<label>
+				<input type="checkbox" name="show_random_note" value="1" <?php checked( $options['show_random_note'] ); ?>>
+				<?php esc_html_e( 'Show "From your notes" section', 'post-collection' ); ?>
+			</label>
+		</p>
+		<p>
+			<label>
+				<input type="checkbox" name="show_tabs" value="1" <?php checked( $options['show_tabs'] ); ?>>
+				<?php esc_html_e( 'Show Pending / Reviewed tabs', 'post-collection' ); ?>
+			</label>
+		</p>
+		<p>
+			<label for="post-collection-pending-count"><?php esc_html_e( 'Pending articles to show:', 'post-collection' ); ?></label>
+			<input type="number" id="post-collection-pending-count" name="pending_count" value="<?php echo esc_attr( $options['pending_count'] ); ?>" min="1" max="50" class="small-text">
+		</p>
+		<p>
+			<label for="post-collection-reviewed-count"><?php esc_html_e( 'Reviewed articles to show:', 'post-collection' ); ?></label>
+			<input type="number" id="post-collection-reviewed-count" name="reviewed_count" value="<?php echo esc_attr( $options['reviewed_count'] ); ?>" min="1" max="50" class="small-text">
+		</p>
+		<?php
 	}
 
 	/**
@@ -261,8 +322,10 @@ class Article_Notes {
 	 */
 	public function render_dashboard_widget() {
 		$this->enqueue_widget_assets();
-		$pending_limit = 1;
-		$review_limit = 5;
+		$options = $this->get_widget_options();
+
+		$pending_limit = (int) $options['pending_count'];
+		$review_limit  = (int) $options['reviewed_count'];
 
 		$pending_articles = $this->get_pending_and_unread_articles( $pending_limit + 1 );
 		$has_more_pending = count( $pending_articles ) > $pending_limit;
@@ -274,10 +337,11 @@ class Article_Notes {
 			'admin/article-notes-widget',
 			null,
 			array(
-				'pending_articles'  => $pending_articles,
-				'has_more_pending'  => $has_more_pending,
-				'reviewed_articles' => $this->get_reviewed_articles( $review_limit ),
-				'random_remembered' => $this->get_random_remembered_article(),
+				'pending_articles'  => $options['show_tabs'] ? $pending_articles : array(),
+				'has_more_pending'  => $options['show_tabs'] && $has_more_pending,
+				'reviewed_articles' => $options['show_tabs'] ? $this->get_reviewed_articles( $review_limit ) : array(),
+				'show_tabs'         => $options['show_tabs'],
+				'random_remembered' => $options['show_random_note'] ? $this->get_random_remembered_article() : null,
 				'nonce'             => wp_create_nonce( 'post-collection-article-notes' ),
 			)
 		);
@@ -622,7 +686,7 @@ class Article_Notes {
 
 		return array(
 			'id'          => $post->ID,
-			'title'       => get_the_title( $post ),
+			'title'       => html_entity_decode( get_the_title( $post ), ENT_QUOTES, 'UTF-8' ),
 			'permalink'   => $permalink,
 			'author'      => $author,
 			'collection'  => $user->display_name,

--- a/includes/class-article-notes.php
+++ b/includes/class-article-notes.php
@@ -64,7 +64,7 @@ class Article_Notes {
 	 */
 	public function register_admin_menu() {
 		add_submenu_page(
-			'options-general.php',
+			'edit.php?post_type=' . Post_Collection::CPT,
 			__( 'Article Notes', 'post-collection' ),
 			__( 'Article Notes', 'post-collection' ),
 			'edit_posts',
@@ -548,6 +548,11 @@ class Article_Notes {
 			}
 		}
 
+		// Strip images from content for the preview.
+		$content = $post->post_content;
+		$content = preg_replace( '/<img[^>]*>/i', '', $content );
+		$content = preg_replace( '/<figure[^>]*>.*?<\/figure>/is', '', $content );
+
 		return array(
 			'id'          => $post->ID,
 			'title'       => get_the_title( $post ),
@@ -555,6 +560,7 @@ class Article_Notes {
 			'author'      => $this->plugin->get_post_author_name( $post ),
 			'sent_date'   => $sent_date,
 			'excerpt'     => get_the_excerpt( $post ),
+			'content'     => wp_kses_post( $content ),
 			'note_id'     => $note ? $note['id'] : 0,
 			'status'      => $note ? $note['status'] : self::STATUS_UNREAD,
 			'rating'      => $note ? $note['rating'] : 0,

--- a/includes/class-article-notes.php
+++ b/includes/class-article-notes.php
@@ -59,6 +59,7 @@ class Article_Notes {
 		add_action( 'before_delete_post', array( $this, 'maybe_delete_note' ) );
 		add_action( 'wp_dashboard_setup', array( $this, 'register_dashboard_widget' ) );
 		add_action( 'admin_menu', array( $this, 'register_admin_menu' ) );
+		add_action( 'friends_post_footer_first', array( $this, 'render_frontend_notes' ) );
 	}
 
 	/**
@@ -100,6 +101,64 @@ class Article_Notes {
 				'status_filter' => $status_filter,
 				'statuses'      => self::get_statuses(),
 				'nonce'         => wp_create_nonce( 'post-collection-article-notes' ),
+			)
+		);
+	}
+
+	/**
+	 * Render the notes UI on the Friends frontend single post view.
+	 */
+	public function render_frontend_notes() {
+		if ( ! is_single() || ! current_user_can( 'edit_posts' ) ) {
+			return;
+		}
+
+		$post = get_post();
+		if ( ! $post ) {
+			return;
+		}
+
+		$article = $this->prepare_article_data( $post );
+		$statuses = self::get_statuses();
+		$nonce = wp_create_nonce( 'post-collection-article-notes' );
+
+		$version = POST_COLLECTION_VERSION;
+		wp_enqueue_style(
+			'post-collection-article-notes',
+			plugins_url( 'assets/css/article-notes.css', dirname( __FILE__ ) ),
+			array(),
+			$version
+		);
+		wp_enqueue_script(
+			'post-collection-article-notes',
+			plugins_url( 'assets/js/article-notes.js', dirname( __FILE__ ) ),
+			array( 'jquery' ),
+			$version,
+			true
+		);
+		wp_localize_script(
+			'post-collection-article-notes',
+			'postCollectionArticleNotes',
+			array(
+				'ajaxurl'  => admin_url( 'admin-ajax.php' ),
+				'nonce'    => $nonce,
+				'statuses' => $statuses,
+				'i18n'     => array(
+					'saving'      => __( 'Saving...', 'post-collection' ),
+					'saved'       => __( 'Saved', 'post-collection' ),
+					'error'       => __( 'Error saving', 'post-collection' ),
+					'showArticle' => __( 'Show article', 'post-collection' ),
+				),
+			)
+		);
+
+		Post_Collection::template_loader()->get_template_part(
+			'frontend/article-notes',
+			null,
+			array(
+				'article'  => $article,
+				'statuses' => $statuses,
+				'nonce'    => $nonce,
 			)
 		);
 	}

--- a/includes/class-article-notes.php
+++ b/includes/class-article-notes.php
@@ -9,16 +9,18 @@
 
 namespace PostCollection;
 
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Class for managing article notes and reviews.
  *
  * @since 1.1.0
  */
 class Article_Notes {
-	const POST_TYPE = 'ereader_note';
-	const NOTE_ID_META = 'ereader_note_id';
-	const RATING_META = 'ereader_rating';
-	const STATUS_META = 'ereader_status';
+	const POST_TYPE = 'post_collection_note';
+	const NOTE_ID_META = 'post_collection_note_id';
+	const RATING_META = 'post_collection_rating';
+	const STATUS_META = 'post_collection_status';
 
 	const STATUS_UNREAD = 'unread';
 	const STATUS_READ = 'read';
@@ -47,11 +49,11 @@ class Article_Notes {
 	 */
 	private function register_hooks() {
 		add_action( 'init', array( $this, 'register_post_type' ) );
-		add_action( 'wp_ajax_ereader_save_note', array( $this, 'ajax_save_note' ) );
-		add_action( 'wp_ajax_ereader_get_notes', array( $this, 'ajax_get_notes' ) );
-		add_action( 'wp_ajax_ereader_load_more_pending', array( $this, 'ajax_load_more_pending' ) );
-		add_action( 'wp_ajax_ereader_create_post_from_notes', array( $this, 'ajax_create_post_from_notes' ) );
-		add_action( 'wp_ajax_ereader_dismiss_old_articles', array( $this, 'ajax_dismiss_old_articles' ) );
+		add_action( 'wp_ajax_post_collection_save_note', array( $this, 'ajax_save_note' ) );
+		add_action( 'wp_ajax_post_collection_get_notes', array( $this, 'ajax_get_notes' ) );
+		add_action( 'wp_ajax_post_collection_load_more_pending', array( $this, 'ajax_load_more_pending' ) );
+		add_action( 'wp_ajax_post_collection_create_post_from_notes', array( $this, 'ajax_create_post_from_notes' ) );
+		add_action( 'wp_ajax_post_collection_dismiss_old_articles', array( $this, 'ajax_dismiss_old_articles' ) );
 		add_action( 'before_delete_post', array( $this, 'maybe_delete_note' ) );
 		add_action( 'wp_dashboard_setup', array( $this, 'register_dashboard_widget' ) );
 		add_action( 'admin_menu', array( $this, 'register_admin_menu' ) );
@@ -66,7 +68,7 @@ class Article_Notes {
 			__( 'Article Notes', 'post-collection' ),
 			__( 'Article Notes', 'post-collection' ),
 			'edit_posts',
-			'ereader-article-notes',
+			'post-collection-article-notes',
 			array( $this, 'render_admin_page' )
 		);
 	}
@@ -95,7 +97,7 @@ class Article_Notes {
 				'per_page'      => $per_page,
 				'status_filter' => $status_filter,
 				'statuses'      => self::get_statuses(),
-				'nonce'         => wp_create_nonce( 'ereader-article-notes' ),
+				'nonce'         => wp_create_nonce( 'post-collection-article-notes' ),
 			)
 		);
 	}
@@ -107,14 +109,14 @@ class Article_Notes {
 		$version = POST_COLLECTION_VERSION;
 
 		wp_enqueue_style(
-			'ereader-article-notes-admin',
+			'post-collection-article-notes-admin',
 			plugins_url( 'assets/css/article-notes-admin.css', dirname( __FILE__ ) ),
 			array(),
 			$version
 		);
 
 		wp_enqueue_script(
-			'ereader-article-notes',
+			'post-collection-article-notes',
 			plugins_url( 'assets/js/article-notes.js', dirname( __FILE__ ) ),
 			array( 'jquery' ),
 			$version,
@@ -122,11 +124,11 @@ class Article_Notes {
 		);
 
 		wp_localize_script(
-			'ereader-article-notes',
-			'ereaderArticleNotes',
+			'post-collection-article-notes',
+			'postCollectionArticleNotes',
 			array(
 				'ajaxurl'  => admin_url( 'admin-ajax.php' ),
-				'nonce'    => wp_create_nonce( 'ereader-article-notes' ),
+				'nonce'    => wp_create_nonce( 'post-collection-article-notes' ),
 				'statuses' => self::get_statuses(),
 				'i18n'     => array(
 					'saving'  => __( 'Saving...', 'post-collection' ),
@@ -246,8 +248,8 @@ class Article_Notes {
 		}
 
 		wp_add_dashboard_widget(
-			'ereader_article_notes',
-			__( 'E-Reader Article Notes', 'post-collection' ),
+			'post_collection_article_notes',
+			__( 'Article Notes', 'post-collection' ),
 			array( $this, 'render_dashboard_widget' )
 		);
 	}
@@ -282,7 +284,7 @@ class Article_Notes {
 				'unread_articles'   => $unread_articles,
 				'has_more_unread'   => $has_more_unread,
 				'reviewed_articles' => $this->get_reviewed_articles( $other_limit ),
-				'nonce'             => wp_create_nonce( 'ereader-article-notes' ),
+				'nonce'             => wp_create_nonce( 'post-collection-article-notes' ),
 			)
 		);
 	}
@@ -294,14 +296,14 @@ class Article_Notes {
 		$version = POST_COLLECTION_VERSION;
 
 		wp_enqueue_style(
-			'ereader-article-notes',
+			'post-collection-article-notes',
 			plugins_url( 'assets/css/article-notes.css', dirname( __FILE__ ) ),
 			array(),
 			$version
 		);
 
 		wp_enqueue_script(
-			'ereader-article-notes',
+			'post-collection-article-notes',
 			plugins_url( 'assets/js/article-notes.js', dirname( __FILE__ ) ),
 			array( 'jquery' ),
 			$version,
@@ -309,11 +311,11 @@ class Article_Notes {
 		);
 
 		wp_localize_script(
-			'ereader-article-notes',
-			'ereaderArticleNotes',
+			'post-collection-article-notes',
+			'postCollectionArticleNotes',
 			array(
 				'ajaxurl'  => admin_url( 'admin-ajax.php' ),
-				'nonce'    => wp_create_nonce( 'ereader-article-notes' ),
+				'nonce'    => wp_create_nonce( 'post-collection-article-notes' ),
 				'statuses' => self::get_statuses(),
 				'i18n'     => array(
 					'saving'        => __( 'Saving...', 'post-collection' ),
@@ -655,7 +657,7 @@ class Article_Notes {
 	 * AJAX handler for saving a note.
 	 */
 	public function ajax_save_note() {
-		check_ajax_referer( 'ereader-article-notes' );
+		check_ajax_referer( 'post-collection-article-notes' );
 
 		if ( ! current_user_can( 'edit_posts' ) ) {
 			wp_send_json_error( __( 'Permission denied.', 'post-collection' ) );
@@ -689,7 +691,7 @@ class Article_Notes {
 	 * AJAX handler for getting notes data.
 	 */
 	public function ajax_get_notes() {
-		check_ajax_referer( 'ereader-article-notes' );
+		check_ajax_referer( 'post-collection-article-notes' );
 
 		if ( ! current_user_can( 'edit_posts' ) ) {
 			wp_send_json_error( __( 'Permission denied.', 'post-collection' ) );
@@ -711,7 +713,7 @@ class Article_Notes {
 	 * AJAX handler for loading more pending articles.
 	 */
 	public function ajax_load_more_pending() {
-		check_ajax_referer( 'ereader-article-notes' );
+		check_ajax_referer( 'post-collection-article-notes' );
 
 		if ( ! current_user_can( 'edit_posts' ) ) {
 			wp_send_json_error( __( 'Permission denied.', 'post-collection' ) );
@@ -745,7 +747,7 @@ class Article_Notes {
 	 * AJAX handler for creating a post from selected notes.
 	 */
 	public function ajax_create_post_from_notes() {
-		check_ajax_referer( 'ereader-article-notes' );
+		check_ajax_referer( 'post-collection-article-notes' );
 
 		if ( ! current_user_can( 'edit_posts' ) ) {
 			wp_send_json_error( __( 'Permission denied.', 'post-collection' ) );
@@ -866,7 +868,7 @@ class Article_Notes {
 	 * AJAX handler for dismissing old articles (marking all pending as skipped).
 	 */
 	public function ajax_dismiss_old_articles() {
-		check_ajax_referer( 'ereader-article-notes' );
+		check_ajax_referer( 'post-collection-article-notes' );
 
 		if ( ! current_user_can( 'edit_posts' ) ) {
 			wp_send_json_error( __( 'Permission denied.', 'post-collection' ) );

--- a/includes/class-article-notes.php
+++ b/includes/class-article-notes.php
@@ -55,6 +55,7 @@ class Article_Notes {
 		add_action( 'wp_ajax_post_collection_create_post_from_notes', array( $this, 'ajax_create_post_from_notes' ) );
 		add_action( 'wp_ajax_post_collection_dismiss_old_articles', array( $this, 'ajax_dismiss_old_articles' ) );
 		add_action( 'wp_ajax_post_collection_random_remembered', array( $this, 'ajax_random_remembered' ) );
+		add_action( 'wp_ajax_post_collection_save_title', array( $this, 'ajax_save_title' ) );
 		add_action( 'before_delete_post', array( $this, 'maybe_delete_note' ) );
 		add_action( 'wp_dashboard_setup', array( $this, 'register_dashboard_widget' ) );
 		add_action( 'admin_menu', array( $this, 'register_admin_menu' ) );
@@ -1019,6 +1020,37 @@ class Article_Notes {
 		}
 
 		wp_send_json_success( $article );
+	}
+
+	/**
+	 * AJAX handler for saving an article title.
+	 */
+	public function ajax_save_title() {
+		check_ajax_referer( 'post-collection-article-notes' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( __( 'Permission denied.', 'post-collection' ) );
+		}
+
+		$article_id = isset( $_POST['article_id'] ) ? (int) $_POST['article_id'] : 0;
+		$title = isset( $_POST['title'] ) ? sanitize_text_field( wp_unslash( $_POST['title'] ) ) : '';
+
+		if ( ! $article_id || ! $title ) {
+			wp_send_json_error( __( 'Invalid article ID or title.', 'post-collection' ) );
+		}
+
+		$result = wp_update_post(
+			array(
+				'ID'         => $article_id,
+				'post_title' => $title,
+			)
+		);
+
+		if ( is_wp_error( $result ) ) {
+			wp_send_json_error( $result->get_error_message() );
+		}
+
+		wp_send_json_success( array( 'title' => $title ) );
 	}
 
 	/**

--- a/includes/class-article-notes.php
+++ b/includes/class-article-notes.php
@@ -87,7 +87,7 @@ class Article_Notes {
 		// Get notes based on filter.
 		$notes_data = $this->get_all_notes( $status_filter, $per_page, ( $paged - 1 ) * $per_page );
 
-		$this->plugin->get_template_loader()->get_template_part(
+		Post_Collection::template_loader()->get_template_part(
 			'admin/article-notes-page',
 			null,
 			array(
@@ -274,7 +274,7 @@ class Article_Notes {
 			$unread_articles = array_slice( $unread_articles, 0, $other_limit );
 		}
 
-		$this->plugin->get_template_loader()->get_template_part(
+		Post_Collection::template_loader()->get_template_part(
 			'admin/article-notes-widget',
 			null,
 			array(

--- a/includes/class-article-notes.php
+++ b/includes/class-article-notes.php
@@ -1,0 +1,941 @@
+<?php
+/**
+ * Article Notes
+ *
+ * Manages article notes/reviews as a custom post type.
+ *
+ * @package Post_Collection
+ */
+
+namespace PostCollection;
+
+/**
+ * Class for managing article notes and reviews.
+ *
+ * @since 1.1.0
+ */
+class Article_Notes {
+	const POST_TYPE = 'ereader_note';
+	const NOTE_ID_META = 'ereader_note_id';
+	const RATING_META = 'ereader_rating';
+	const STATUS_META = 'ereader_status';
+
+	const STATUS_UNREAD = 'unread';
+	const STATUS_READ = 'read';
+	const STATUS_SKIPPED = 'skipped';
+	const STATUS_ARCHIVED = 'archived';
+
+	/**
+	 * Reference to the main plugin instance.
+	 *
+	 * @var Post_Collection
+	 */
+	private $plugin;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Post_Collection $plugin The main plugin instance.
+	 */
+	public function __construct( Post_Collection $plugin ) {
+		$this->plugin = $plugin;
+		$this->register_hooks();
+	}
+
+	/**
+	 * Register WordPress hooks.
+	 */
+	private function register_hooks() {
+		add_action( 'init', array( $this, 'register_post_type' ) );
+		add_action( 'wp_ajax_ereader_save_note', array( $this, 'ajax_save_note' ) );
+		add_action( 'wp_ajax_ereader_get_notes', array( $this, 'ajax_get_notes' ) );
+		add_action( 'wp_ajax_ereader_load_more_pending', array( $this, 'ajax_load_more_pending' ) );
+		add_action( 'wp_ajax_ereader_create_post_from_notes', array( $this, 'ajax_create_post_from_notes' ) );
+		add_action( 'wp_ajax_ereader_dismiss_old_articles', array( $this, 'ajax_dismiss_old_articles' ) );
+		add_action( 'before_delete_post', array( $this, 'maybe_delete_note' ) );
+		add_action( 'wp_dashboard_setup', array( $this, 'register_dashboard_widget' ) );
+		add_action( 'admin_menu', array( $this, 'register_admin_menu' ) );
+	}
+
+	/**
+	 * Register admin menu page.
+	 */
+	public function register_admin_menu() {
+		add_submenu_page(
+			'options-general.php',
+			__( 'Article Notes', 'post-collection' ),
+			__( 'Article Notes', 'post-collection' ),
+			'edit_posts',
+			'ereader-article-notes',
+			array( $this, 'render_admin_page' )
+		);
+	}
+
+	/**
+	 * Render the admin page.
+	 */
+	public function render_admin_page() {
+		$this->enqueue_admin_page_assets();
+
+		// Get current filter.
+		$status_filter = isset( $_GET['status'] ) ? sanitize_text_field( wp_unslash( $_GET['status'] ) ) : 'all';
+		$paged = isset( $_GET['paged'] ) ? max( 1, (int) $_GET['paged'] ) : 1;
+		$per_page = 20;
+
+		// Get notes based on filter.
+		$notes_data = $this->get_all_notes( $status_filter, $per_page, ( $paged - 1 ) * $per_page );
+
+		$this->plugin->get_template_loader()->get_template_part(
+			'admin/article-notes-page',
+			null,
+			array(
+				'notes'         => $notes_data['notes'],
+				'total'         => $notes_data['total'],
+				'paged'         => $paged,
+				'per_page'      => $per_page,
+				'status_filter' => $status_filter,
+				'statuses'      => self::get_statuses(),
+				'nonce'         => wp_create_nonce( 'ereader-article-notes' ),
+			)
+		);
+	}
+
+	/**
+	 * Enqueue assets for the admin page.
+	 */
+	private function enqueue_admin_page_assets() {
+		$version = POST_COLLECTION_VERSION;
+
+		wp_enqueue_style(
+			'ereader-article-notes-admin',
+			plugins_url( 'assets/css/article-notes-admin.css', dirname( __FILE__ ) ),
+			array(),
+			$version
+		);
+
+		wp_enqueue_script(
+			'ereader-article-notes',
+			plugins_url( 'assets/js/article-notes.js', dirname( __FILE__ ) ),
+			array( 'jquery' ),
+			$version,
+			true
+		);
+
+		wp_localize_script(
+			'ereader-article-notes',
+			'ereaderArticleNotes',
+			array(
+				'ajaxurl'  => admin_url( 'admin-ajax.php' ),
+				'nonce'    => wp_create_nonce( 'ereader-article-notes' ),
+				'statuses' => self::get_statuses(),
+				'i18n'     => array(
+					'saving'  => __( 'Saving...', 'post-collection' ),
+					'saved'   => __( 'Saved', 'post-collection' ),
+					'error'   => __( 'Error saving', 'post-collection' ),
+					'loading' => __( 'Loading...', 'post-collection' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get all notes with optional filtering.
+	 *
+	 * @param string $status Status filter ('all', 'unread', 'read', 'skipped', 'archived').
+	 * @param int    $limit  Number of items per page.
+	 * @param int    $offset Offset for pagination.
+	 * @return array Array with 'notes' and 'total' keys.
+	 */
+	public function get_all_notes( $status = 'all', $limit = 20, $offset = 0 ) {
+		$meta_query = array();
+
+		if ( 'all' !== $status && in_array( $status, self::get_all_status_values(), true ) ) {
+			$meta_query[] = array(
+				'key'   => self::STATUS_META,
+				'value' => $status,
+			);
+		}
+
+		$args = array(
+			'post_type'      => self::POST_TYPE,
+			'posts_per_page' => $limit,
+			'offset'         => $offset,
+			'post_status'    => 'publish',
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+		);
+
+		if ( ! empty( $meta_query ) ) {
+			$args['meta_query'] = $meta_query;
+		}
+
+		$query = new \WP_Query( $args );
+		$notes = array();
+
+		foreach ( $query->posts as $note_post ) {
+			$parent_id = $note_post->post_parent;
+			$parent = get_post( $parent_id );
+
+			if ( ! $parent ) {
+				continue;
+			}
+
+			$notes[] = array(
+				'id'          => $parent_id,
+				'note_id'     => $note_post->ID,
+				'title'       => get_the_title( $parent ),
+				'permalink'   => get_permalink( $parent ),
+				'author'      => $this->plugin->get_post_author_name( $parent ),
+				'status'      => get_post_meta( $note_post->ID, self::STATUS_META, true ) ?: self::STATUS_UNREAD,
+				'rating'      => (int) get_post_meta( $note_post->ID, self::RATING_META, true ),
+				'notes'       => $note_post->post_content,
+				'updated'     => $note_post->post_modified,
+			);
+		}
+
+		// Get total count.
+		$count_args = array(
+			'post_type'      => self::POST_TYPE,
+			'posts_per_page' => -1,
+			'post_status'    => 'publish',
+			'fields'         => 'ids',
+		);
+
+		if ( ! empty( $meta_query ) ) {
+			$count_args['meta_query'] = $meta_query;
+		}
+
+		$total = count( get_posts( $count_args ) );
+
+		return array(
+			'notes' => $notes,
+			'total' => $total,
+		);
+	}
+
+	/**
+	 * Register the article notes custom post type.
+	 */
+	public function register_post_type() {
+		register_post_type(
+			self::POST_TYPE,
+			array(
+				'labels'              => array(
+					'name'          => __( 'Article Notes', 'post-collection' ),
+					'singular_name' => __( 'Article Note', 'post-collection' ),
+				),
+				'public'              => false,
+				'show_ui'             => false,
+				'show_in_menu'        => false,
+				'show_in_rest'        => false,
+				'exclude_from_search' => true,
+				'publicly_queryable'  => false,
+				'supports'            => array( 'editor' ),
+				'hierarchical'        => false,
+				'can_export'          => true,
+			)
+		);
+	}
+
+	/**
+	 * Register the dashboard widget.
+	 */
+	public function register_dashboard_widget() {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return;
+		}
+
+		wp_add_dashboard_widget(
+			'ereader_article_notes',
+			__( 'E-Reader Article Notes', 'post-collection' ),
+			array( $this, 'render_dashboard_widget' )
+		);
+	}
+
+	/**
+	 * Render the dashboard widget.
+	 */
+	public function render_dashboard_widget() {
+		$this->enqueue_widget_assets();
+		$pending_limit = 5;
+		$other_limit = 10;
+
+		$pending_articles = $this->get_pending_articles( $pending_limit + 1 );
+		$has_more_pending = count( $pending_articles ) > $pending_limit;
+		if ( $has_more_pending ) {
+			$pending_articles = array_slice( $pending_articles, 0, $pending_limit );
+		}
+
+		$unread_articles = $this->get_unread_articles( $other_limit + 1 );
+		$has_more_unread = count( $unread_articles ) > $other_limit;
+		if ( $has_more_unread ) {
+			$unread_articles = array_slice( $unread_articles, 0, $other_limit );
+		}
+
+		$this->plugin->get_template_loader()->get_template_part(
+			'admin/article-notes-widget',
+			null,
+			array(
+				'pending_articles'  => $pending_articles,
+				'has_more_pending'  => $has_more_pending,
+				'pending_limit'     => $pending_limit,
+				'unread_articles'   => $unread_articles,
+				'has_more_unread'   => $has_more_unread,
+				'reviewed_articles' => $this->get_reviewed_articles( $other_limit ),
+				'nonce'             => wp_create_nonce( 'ereader-article-notes' ),
+			)
+		);
+	}
+
+	/**
+	 * Enqueue assets for the widget.
+	 */
+	private function enqueue_widget_assets() {
+		$version = POST_COLLECTION_VERSION;
+
+		wp_enqueue_style(
+			'ereader-article-notes',
+			plugins_url( 'assets/css/article-notes.css', dirname( __FILE__ ) ),
+			array(),
+			$version
+		);
+
+		wp_enqueue_script(
+			'ereader-article-notes',
+			plugins_url( 'assets/js/article-notes.js', dirname( __FILE__ ) ),
+			array( 'jquery' ),
+			$version,
+			true
+		);
+
+		wp_localize_script(
+			'ereader-article-notes',
+			'ereaderArticleNotes',
+			array(
+				'ajaxurl'  => admin_url( 'admin-ajax.php' ),
+				'nonce'    => wp_create_nonce( 'ereader-article-notes' ),
+				'statuses' => self::get_statuses(),
+				'i18n'     => array(
+					'saving'        => __( 'Saving...', 'post-collection' ),
+					'saved'         => __( 'Saved', 'post-collection' ),
+					'error'         => __( 'Error saving', 'post-collection' ),
+					'loading'       => __( 'Loading...', 'post-collection' ),
+					'confirmCreate' => __( 'Create a post from the selected reviews?', 'post-collection' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get post types to query for articles.
+	 *
+	 * @return array Array of post type names.
+	 */
+	private function get_article_post_types() {
+		// Get all registered post types to ensure we don't miss any.
+		$post_types = get_post_types( array(), 'names' );
+
+		// Exclude our own note post type and some WordPress internals.
+		$exclude = array(
+			self::POST_TYPE,
+			'revision',
+			'nav_menu_item',
+			'custom_css',
+			'customize_changeset',
+			'oembed_cache',
+			'user_request',
+			'wp_block',
+			'wp_template',
+			'wp_template_part',
+			'wp_global_styles',
+			'wp_navigation',
+			'wp_font_family',
+			'wp_font_face',
+		);
+
+		return array_values( array_diff( $post_types, $exclude ) );
+	}
+
+	/**
+	 * Get articles that have been downloaded but not yet reviewed.
+	 *
+	 * @param int $limit  Maximum number of articles to return.
+	 * @param int $offset Number of articles to skip.
+	 * @return array Array of post objects with note data.
+	 */
+	public function get_pending_articles( $limit = 20, $offset = 0 ) {
+		$meta_query = apply_filters( 'post_collection_article_queued_meta_query', array() );
+		$meta_query[] = array(
+			'key'     => self::NOTE_ID_META,
+			'compare' => 'NOT EXISTS',
+		);
+
+		if ( count( $meta_query ) > 1 ) {
+			array_unshift( $meta_query, array( 'relation' => 'AND' ) );
+		}
+
+		$args = array(
+			'post_type'      => $this->get_article_post_types(),
+			'posts_per_page' => $limit,
+			'offset'         => $offset,
+			'post_status'    => 'any',
+			'meta_query'     => $meta_query,
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+		);
+
+		$queued_meta_key = apply_filters( 'post_collection_article_queued_orderby_meta_key', '' );
+		if ( ! empty( $queued_meta_key ) ) {
+			$args['orderby'] = 'meta_value_num';
+			$args['meta_key'] = $queued_meta_key;
+		}
+
+		$posts = get_posts( $args );
+
+		return array_map( array( $this, 'prepare_article_data' ), $posts );
+	}
+
+	/**
+	 * Get articles marked as unread (has note but status is unread).
+	 *
+	 * @param int $limit  Maximum number of articles to return.
+	 * @param int $offset Number of articles to skip.
+	 * @return array Array of post objects with note data.
+	 */
+	public function get_unread_articles( $limit = 20, $offset = 0 ) {
+		// Get note IDs with unread status.
+		$note_ids = get_posts(
+			array(
+				'post_type'      => self::POST_TYPE,
+				'posts_per_page' => -1,
+				'post_status'    => 'publish',
+				'fields'         => 'ids',
+				'meta_query'     => array(
+					array(
+						'key'   => self::STATUS_META,
+						'value' => self::STATUS_UNREAD,
+					),
+				),
+			)
+		);
+
+		if ( empty( $note_ids ) ) {
+			return array();
+		}
+
+		// Get the parent article IDs.
+		$article_ids = array();
+		foreach ( $note_ids as $note_id ) {
+			$parent_id = wp_get_post_parent_id( $note_id );
+			if ( $parent_id ) {
+				$article_ids[] = $parent_id;
+			}
+		}
+
+		if ( empty( $article_ids ) ) {
+			return array();
+		}
+
+		$args = array(
+			'post_type'      => $this->get_article_post_types(),
+			'posts_per_page' => $limit,
+			'offset'         => $offset,
+			'post_status'    => 'any',
+			'post__in'       => $article_ids,
+			'orderby'        => 'post__in',
+		);
+
+		$posts = get_posts( $args );
+
+		return array_map( array( $this, 'prepare_article_data' ), $posts );
+	}
+
+	/**
+	 * Get articles that have been reviewed (read or skipped).
+	 *
+	 * @param int $limit Maximum number of articles to return.
+	 * @return array Array of post objects with note data.
+	 */
+	public function get_reviewed_articles( $limit = 20 ) {
+		// Get note IDs with read or skipped status.
+		$note_ids = get_posts(
+			array(
+				'post_type'      => self::POST_TYPE,
+				'posts_per_page' => -1,
+				'post_status'    => 'publish',
+				'fields'         => 'ids',
+				'meta_query'     => array(
+					array(
+						'key'     => self::STATUS_META,
+						'value'   => array( self::STATUS_READ, self::STATUS_SKIPPED ),
+						'compare' => 'IN',
+					),
+				),
+			)
+		);
+
+		if ( empty( $note_ids ) ) {
+			return array();
+		}
+
+		// Get the parent article IDs.
+		$article_ids = array();
+		foreach ( $note_ids as $note_id ) {
+			$parent_id = wp_get_post_parent_id( $note_id );
+			if ( $parent_id ) {
+				$article_ids[] = $parent_id;
+			}
+		}
+
+		if ( empty( $article_ids ) ) {
+			return array();
+		}
+
+		$args = array(
+			'post_type'      => $this->get_article_post_types(),
+			'posts_per_page' => $limit,
+			'post_status'    => 'any',
+			'post__in'       => $article_ids,
+			'orderby'        => 'post__in',
+		);
+
+		$posts = get_posts( $args );
+
+		return array_map( array( $this, 'prepare_article_data' ), $posts );
+	}
+
+	/**
+	 * Prepare article data for display.
+	 *
+	 * @param \WP_Post $post The post object.
+	 * @return array Prepared article data.
+	 */
+	private function prepare_article_data( $post ) {
+		$note = $this->get_note( $post->ID );
+		$queued_meta_key = apply_filters( 'post_collection_article_queued_orderby_meta_key', '' );
+		$sent_date = '';
+		if ( ! empty( $queued_meta_key ) ) {
+			$timestamp = get_post_meta( $post->ID, $queued_meta_key, true );
+			if ( $timestamp ) {
+				$sent_date = date_i18n( get_option( 'date_format' ), $timestamp );
+			}
+		}
+
+		return array(
+			'id'          => $post->ID,
+			'title'       => get_the_title( $post ),
+			'permalink'   => get_permalink( $post ),
+			'author'      => $this->plugin->get_post_author_name( $post ),
+			'sent_date'   => $sent_date,
+			'excerpt'     => get_the_excerpt( $post ),
+			'note_id'     => $note ? $note['id'] : 0,
+			'status'      => $note ? $note['status'] : self::STATUS_UNREAD,
+			'rating'      => $note ? $note['rating'] : 0,
+			'notes'       => $note ? $note['notes'] : '',
+		);
+	}
+
+	/**
+	 * Get note for an article.
+	 *
+	 * @param int $article_id The article post ID.
+	 * @return array|null Note data or null if not found.
+	 */
+	public function get_note( $article_id ) {
+		$note_id = get_post_meta( $article_id, self::NOTE_ID_META, true );
+
+		if ( ! $note_id ) {
+			return null;
+		}
+
+		$note_post = get_post( $note_id );
+
+		if ( ! $note_post || self::POST_TYPE !== $note_post->post_type ) {
+			// Clean up orphaned reference.
+			delete_post_meta( $article_id, self::NOTE_ID_META );
+			return null;
+		}
+
+		return array(
+			'id'      => $note_post->ID,
+			'status'  => get_post_meta( $note_post->ID, self::STATUS_META, true ) ?: self::STATUS_UNREAD,
+			'rating'  => (int) get_post_meta( $note_post->ID, self::RATING_META, true ),
+			'notes'   => $note_post->post_content,
+			'updated' => $note_post->post_modified,
+		);
+	}
+
+	/**
+	 * Save or update a note for an article.
+	 *
+	 * @param int    $article_id The article post ID.
+	 * @param string $status     Reading status (unread, read, skipped).
+	 * @param int    $rating     Star rating (0-5).
+	 * @param string $notes      Notes text.
+	 * @return int|false Note post ID on success, false on failure.
+	 */
+	public function save_note( $article_id, $status = null, $rating = null, $notes = null ) {
+		$existing_note_id = get_post_meta( $article_id, self::NOTE_ID_META, true );
+
+		$note_data = array(
+			'post_type'   => self::POST_TYPE,
+			'post_parent' => $article_id,
+			'post_status' => 'publish',
+		);
+
+		if ( null !== $notes ) {
+			$note_data['post_content'] = wp_kses_post( $notes );
+		}
+
+		if ( $existing_note_id ) {
+			$note_data['ID'] = $existing_note_id;
+			$note_id = wp_update_post( $note_data );
+		} else {
+			$note_id = wp_insert_post( $note_data );
+
+			if ( $note_id && ! is_wp_error( $note_id ) ) {
+				update_post_meta( $article_id, self::NOTE_ID_META, $note_id );
+			}
+		}
+
+		if ( ! $note_id || is_wp_error( $note_id ) ) {
+			return false;
+		}
+
+		if ( null !== $status && in_array( $status, self::get_all_status_values(), true ) ) {
+			update_post_meta( $note_id, self::STATUS_META, $status );
+		}
+
+		if ( null !== $rating ) {
+			$rating = max( 0, min( 5, (int) $rating ) );
+			update_post_meta( $note_id, self::RATING_META, $rating );
+		}
+
+		return $note_id;
+	}
+
+	/**
+	 * Delete a note.
+	 *
+	 * @param int $article_id The article post ID.
+	 * @return bool True on success, false on failure.
+	 */
+	public function delete_note( $article_id ) {
+		$note_id = get_post_meta( $article_id, self::NOTE_ID_META, true );
+
+		if ( ! $note_id ) {
+			return false;
+		}
+
+		delete_post_meta( $article_id, self::NOTE_ID_META );
+		wp_delete_post( $note_id, true );
+
+		return true;
+	}
+
+	/**
+	 * Maybe delete note when article is deleted.
+	 *
+	 * @param int $post_id The post ID being deleted.
+	 */
+	public function maybe_delete_note( $post_id ) {
+		$post = get_post( $post_id );
+
+		if ( ! $post ) {
+			return;
+		}
+
+		// If an article is being deleted, delete its note too.
+		if ( self::POST_TYPE !== $post->post_type ) {
+			$this->delete_note( $post_id );
+		}
+	}
+
+	/**
+	 * AJAX handler for saving a note.
+	 */
+	public function ajax_save_note() {
+		check_ajax_referer( 'ereader-article-notes' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( __( 'Permission denied.', 'post-collection' ) );
+		}
+
+		$article_id = isset( $_POST['article_id'] ) ? (int) $_POST['article_id'] : 0;
+
+		if ( ! $article_id ) {
+			wp_send_json_error( __( 'Invalid article ID.', 'post-collection' ) );
+		}
+
+		$status = isset( $_POST['status'] ) ? sanitize_text_field( wp_unslash( $_POST['status'] ) ) : null;
+		$rating = isset( $_POST['rating'] ) ? (int) $_POST['rating'] : null;
+		$notes = isset( $_POST['notes'] ) ? wp_kses_post( wp_unslash( $_POST['notes'] ) ) : null;
+
+		$note_id = $this->save_note( $article_id, $status, $rating, $notes );
+
+		if ( ! $note_id ) {
+			wp_send_json_error( __( 'Failed to save note.', 'post-collection' ) );
+		}
+
+		wp_send_json_success(
+			array(
+				'note_id' => $note_id,
+				'message' => __( 'Note saved.', 'post-collection' ),
+			)
+		);
+	}
+
+	/**
+	 * AJAX handler for getting notes data.
+	 */
+	public function ajax_get_notes() {
+		check_ajax_referer( 'ereader-article-notes' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( __( 'Permission denied.', 'post-collection' ) );
+		}
+
+		$type = isset( $_GET['type'] ) ? sanitize_text_field( wp_unslash( $_GET['type'] ) ) : 'pending';
+		$limit = isset( $_GET['limit'] ) ? (int) $_GET['limit'] : 20;
+
+		if ( 'reviewed' === $type ) {
+			$articles = $this->get_reviewed_articles( $limit );
+		} else {
+			$articles = $this->get_pending_articles( $limit );
+		}
+
+		wp_send_json_success( $articles );
+	}
+
+	/**
+	 * AJAX handler for loading more pending articles.
+	 */
+	public function ajax_load_more_pending() {
+		check_ajax_referer( 'ereader-article-notes' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( __( 'Permission denied.', 'post-collection' ) );
+		}
+
+		$offset = isset( $_POST['offset'] ) ? (int) $_POST['offset'] : 0;
+		$type = isset( $_POST['type'] ) ? sanitize_text_field( wp_unslash( $_POST['type'] ) ) : 'pending';
+		$limit = 10;
+
+		if ( 'unread' === $type ) {
+			$articles = $this->get_unread_articles( $limit + 1, $offset );
+		} else {
+			$articles = $this->get_pending_articles( $limit + 1, $offset );
+		}
+
+		$has_more = count( $articles ) > $limit;
+		if ( $has_more ) {
+			$articles = array_slice( $articles, 0, $limit );
+		}
+
+		wp_send_json_success(
+			array(
+				'articles' => $articles,
+				'has_more' => $has_more,
+				'offset'   => $offset + count( $articles ),
+			)
+		);
+	}
+
+	/**
+	 * AJAX handler for creating a post from selected notes.
+	 */
+	public function ajax_create_post_from_notes() {
+		check_ajax_referer( 'ereader-article-notes' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( __( 'Permission denied.', 'post-collection' ) );
+		}
+
+		$article_ids = isset( $_POST['article_ids'] ) ? array_map( 'intval', (array) $_POST['article_ids'] ) : array();
+		$post_title = isset( $_POST['post_title'] ) ? sanitize_text_field( wp_unslash( $_POST['post_title'] ) ) : '';
+
+		if ( empty( $article_ids ) ) {
+			wp_send_json_error( __( 'No articles selected.', 'post-collection' ) );
+		}
+
+		if ( empty( $post_title ) ) {
+			$post_title = sprintf(
+				/* translators: %s is a date */
+				__( 'Reading Notes - %s', 'post-collection' ),
+				date_i18n( get_option( 'date_format' ) )
+			);
+		}
+
+		$post_content = $this->generate_post_content( $article_ids );
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => $post_title,
+				'post_content' => $post_content,
+				'post_status'  => 'draft',
+				'post_type'    => 'post',
+			)
+		);
+
+		if ( is_wp_error( $post_id ) ) {
+			wp_send_json_error( $post_id->get_error_message() );
+		}
+
+		wp_send_json_success(
+			array(
+				'post_id'  => $post_id,
+				'edit_url' => get_edit_post_link( $post_id, 'raw' ),
+				'message'  => __( 'Post created successfully.', 'post-collection' ),
+			)
+		);
+	}
+
+	/**
+	 * Generate post content from article notes.
+	 *
+	 * @param array $article_ids Array of article IDs.
+	 * @return string Generated post content in block editor format.
+	 */
+	private function generate_post_content( $article_ids ) {
+		$blocks = array();
+
+		foreach ( $article_ids as $article_id ) {
+			$post = get_post( $article_id );
+			if ( ! $post ) {
+				continue;
+			}
+
+			$note = $this->get_note( $article_id );
+			if ( ! $note ) {
+				continue;
+			}
+
+			$permalink = esc_url( get_permalink( $post ) );
+			$title = wp_kses_post( get_the_title( $post ) );
+			$author = esc_html( $this->plugin->get_post_author_name( $post ) );
+
+			// Build star rating display.
+			$stars = '';
+			if ( $note['rating'] > 0 ) {
+				$stars = str_repeat( '★', $note['rating'] ) . str_repeat( '☆', 5 - $note['rating'] );
+			}
+
+			$group_meta = array(
+				'metadata' => array(
+					'name' => $title,
+				),
+				'layout'   => array(
+					'type' => 'constrained',
+				),
+			);
+
+			$content = '<!-- wp:group ' . wp_json_encode( $group_meta ) . ' -->' . PHP_EOL;
+			$content .= '<div class="wp-block-group">';
+
+			// Heading with link.
+			$content .= '<!-- wp:heading {"level":3} -->' . PHP_EOL;
+			$content .= '<h3><a href="' . $permalink . '">' . $title . '</a></h3>' . PHP_EOL;
+			$content .= '<!-- /wp:heading -->';
+
+			// Author and rating.
+			$meta_line = $author;
+			if ( $stars ) {
+				$meta_line .= ' — ' . $stars;
+			}
+			$content .= '<!-- wp:paragraph {"className":"article-meta"} -->' . PHP_EOL;
+			$content .= '<p class="article-meta">' . $meta_line . '</p>' . PHP_EOL;
+			$content .= '<!-- /wp:paragraph -->';
+
+			// Notes.
+			if ( ! empty( $note['notes'] ) ) {
+				$content .= '<!-- wp:quote -->' . PHP_EOL;
+				$content .= '<blockquote class="wp-block-quote"><p>' . wp_kses_post( $note['notes'] ) . '</p></blockquote>' . PHP_EOL;
+				$content .= '<!-- /wp:quote -->';
+			}
+
+			$content .= '</div>' . PHP_EOL;
+			$content .= '<!-- /wp:group -->';
+
+			$blocks[] = $content;
+		}
+
+		return implode( PHP_EOL . PHP_EOL, $blocks );
+	}
+
+	/**
+	 * AJAX handler for dismissing old articles (marking all pending as skipped).
+	 */
+	public function ajax_dismiss_old_articles() {
+		check_ajax_referer( 'ereader-article-notes' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( __( 'Permission denied.', 'post-collection' ) );
+		}
+
+		$meta_query = apply_filters( 'post_collection_article_queued_meta_query', array() );
+		$meta_query[] = array(
+			'key'     => self::NOTE_ID_META,
+			'compare' => 'NOT EXISTS',
+		);
+
+		if ( count( $meta_query ) > 1 ) {
+			array_unshift( $meta_query, array( 'relation' => 'AND' ) );
+		}
+
+		$args = array(
+			'post_type'      => $this->get_article_post_types(),
+			'posts_per_page' => -1,
+			'post_status'    => 'any',
+			'fields'         => 'ids',
+			'meta_query'     => $meta_query,
+		);
+
+		$article_ids = get_posts( $args );
+		$count = 0;
+
+		foreach ( $article_ids as $article_id ) {
+			$note_id = $this->save_note( $article_id, self::STATUS_SKIPPED, 0, '' );
+			if ( $note_id ) {
+				$count++;
+			}
+		}
+
+		wp_send_json_success(
+			array(
+				'count'   => $count,
+				'message' => sprintf(
+					/* translators: %d is the number of articles dismissed */
+					__( '%d articles marked as skipped.', 'post-collection' ),
+					$count
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get all valid reading statuses.
+	 *
+	 * @return array Associative array of status => label.
+	 */
+	public static function get_statuses() {
+		return array(
+			self::STATUS_UNREAD  => __( 'Not read yet', 'post-collection' ),
+			self::STATUS_READ    => __( 'Read', 'post-collection' ),
+			self::STATUS_SKIPPED => __( 'Skipped', 'post-collection' ),
+		);
+	}
+
+	/**
+	 * Get all valid status values including archived.
+	 *
+	 * @return array Array of status values.
+	 */
+	public static function get_all_status_values() {
+		return array(
+			self::STATUS_UNREAD,
+			self::STATUS_READ,
+			self::STATUS_SKIPPED,
+			self::STATUS_ARCHIVED,
+		);
+	}
+}

--- a/includes/class-article-notes.php
+++ b/includes/class-article-notes.php
@@ -259,19 +259,13 @@ class Article_Notes {
 	 */
 	public function render_dashboard_widget() {
 		$this->enqueue_widget_assets();
-		$pending_limit = 5;
-		$other_limit = 10;
+		$pending_limit = 10;
+		$review_limit = 10;
 
-		$pending_articles = $this->get_pending_articles( $pending_limit + 1 );
+		$pending_articles = $this->get_pending_and_unread_articles( $pending_limit + 1 );
 		$has_more_pending = count( $pending_articles ) > $pending_limit;
 		if ( $has_more_pending ) {
 			$pending_articles = array_slice( $pending_articles, 0, $pending_limit );
-		}
-
-		$unread_articles = $this->get_unread_articles( $other_limit + 1 );
-		$has_more_unread = count( $unread_articles ) > $other_limit;
-		if ( $has_more_unread ) {
-			$unread_articles = array_slice( $unread_articles, 0, $other_limit );
 		}
 
 		Post_Collection::template_loader()->get_template_part(
@@ -280,10 +274,7 @@ class Article_Notes {
 			array(
 				'pending_articles'  => $pending_articles,
 				'has_more_pending'  => $has_more_pending,
-				'pending_limit'     => $pending_limit,
-				'unread_articles'   => $unread_articles,
-				'has_more_unread'   => $has_more_unread,
-				'reviewed_articles' => $this->get_reviewed_articles( $other_limit ),
+				'reviewed_articles' => $this->get_reviewed_articles( $review_limit ),
 				'nonce'             => wp_create_nonce( 'post-collection-article-notes' ),
 			)
 		);
@@ -395,6 +386,40 @@ class Article_Notes {
 		$posts = get_posts( $args );
 
 		return array_map( array( $this, 'prepare_article_data' ), $posts );
+	}
+
+	/**
+	 * Get articles that are pending review: either no note yet, or note with unread status.
+	 *
+	 * @param int $limit  Maximum number of articles to return.
+	 * @param int $offset Number of articles to skip.
+	 * @return array Combined array of pending and unread articles.
+	 */
+	public function get_pending_and_unread_articles( $limit = 20, $offset = 0 ) {
+		$pending = $this->get_pending_articles( $limit, $offset );
+		$unread = $this->get_unread_articles( $limit, $offset );
+
+		$combined = array_merge( $pending, $unread );
+
+		// Deduplicate by article ID.
+		$seen = array();
+		$result = array();
+		foreach ( $combined as $article ) {
+			if ( ! isset( $seen[ $article['id'] ] ) ) {
+				$seen[ $article['id'] ] = true;
+				$result[] = $article;
+			}
+		}
+
+		// Sort by ID descending (newest first).
+		usort(
+			$result,
+			function ( $a, $b ) {
+				return $b['id'] - $a['id'];
+			}
+		);
+
+		return array_slice( $result, 0, $limit );
 	}
 
 	/**

--- a/includes/class-article-notes.php
+++ b/includes/class-article-notes.php
@@ -54,6 +54,7 @@ class Article_Notes {
 		add_action( 'wp_ajax_post_collection_load_more_pending', array( $this, 'ajax_load_more_pending' ) );
 		add_action( 'wp_ajax_post_collection_create_post_from_notes', array( $this, 'ajax_create_post_from_notes' ) );
 		add_action( 'wp_ajax_post_collection_dismiss_old_articles', array( $this, 'ajax_dismiss_old_articles' ) );
+		add_action( 'wp_ajax_post_collection_random_remembered', array( $this, 'ajax_random_remembered' ) );
 		add_action( 'before_delete_post', array( $this, 'maybe_delete_note' ) );
 		add_action( 'wp_dashboard_setup', array( $this, 'register_dashboard_widget' ) );
 		add_action( 'admin_menu', array( $this, 'register_admin_menu' ) );
@@ -275,6 +276,7 @@ class Article_Notes {
 				'pending_articles'  => $pending_articles,
 				'has_more_pending'  => $has_more_pending,
 				'reviewed_articles' => $this->get_reviewed_articles( $review_limit ),
+				'random_remembered' => $this->get_random_remembered_article(),
 				'nonce'             => wp_create_nonce( 'post-collection-article-notes' ),
 			)
 		);
@@ -314,6 +316,7 @@ class Article_Notes {
 					'error'         => __( 'Error saving', 'post-collection' ),
 					'loading'       => __( 'Loading...', 'post-collection' ),
 					'confirmCreate' => __( 'Create a post from the selected reviews?', 'post-collection' ),
+					'showArticle'   => __( 'Show article', 'post-collection' ),
 				),
 			)
 		);
@@ -529,6 +532,60 @@ class Article_Notes {
 		$posts = get_posts( $args );
 
 		return array_map( array( $this, 'prepare_article_data' ), $posts );
+	}
+
+	/**
+	 * Get a random reviewed article that has notes content.
+	 *
+	 * @return array|null Article data or null if none found.
+	 */
+	public function get_random_remembered_article() {
+		$note_ids = get_posts(
+			array(
+				'post_type'      => self::POST_TYPE,
+				'posts_per_page' => -1,
+				'post_status'    => 'publish',
+				'fields'         => 'ids',
+				'meta_query'     => array(
+					array(
+						'key'     => self::STATUS_META,
+						'value'   => array( self::STATUS_READ, self::STATUS_SKIPPED ),
+						'compare' => 'IN',
+					),
+				),
+			)
+		);
+
+		if ( empty( $note_ids ) ) {
+			return null;
+		}
+
+		// Filter to only notes that have actual content.
+		$notes_with_content = array();
+		foreach ( $note_ids as $note_id ) {
+			$note_post = get_post( $note_id );
+			if ( $note_post && ! empty( trim( $note_post->post_content ) ) ) {
+				$notes_with_content[] = $note_id;
+			}
+		}
+
+		if ( empty( $notes_with_content ) ) {
+			return null;
+		}
+
+		$random_note_id = $notes_with_content[ array_rand( $notes_with_content ) ];
+		$parent_id = wp_get_post_parent_id( $random_note_id );
+
+		if ( ! $parent_id ) {
+			return null;
+		}
+
+		$post = get_post( $parent_id );
+		if ( ! $post ) {
+			return null;
+		}
+
+		return $this->prepare_article_data( $post );
 	}
 
 	/**
@@ -943,6 +1000,25 @@ class Article_Notes {
 				),
 			)
 		);
+	}
+
+	/**
+	 * AJAX handler for getting a random remembered article.
+	 */
+	public function ajax_random_remembered() {
+		check_ajax_referer( 'post-collection-article-notes' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( __( 'Permission denied.', 'post-collection' ) );
+		}
+
+		$article = $this->get_random_remembered_article();
+
+		if ( ! $article ) {
+			wp_send_json_error( __( 'No articles with notes found.', 'post-collection' ) );
+		}
+
+		wp_send_json_success( $article );
 	}
 
 	/**

--- a/post-collection.php
+++ b/post-collection.php
@@ -1,9 +1,10 @@
 <?php
 /**
  * Plugin name: Post Collection
- * Plugin author: Alex Kirk
  * Plugin URI: https://github.com/akirk/post-collection
  * Version: 2.0.0
+ * Author: Alex Kirk
+ * Author URI: https://alex.kirk.at/
  *
  * Description: Collect posts from around the web.
  *
@@ -23,6 +24,7 @@ namespace PostCollection;
 defined( 'ABSPATH' ) || exit;
 define( 'POST_COLLECTION_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'POST_COLLECTION_PLUGIN_FILE', plugin_dir_path( __FILE__ ) . '/' . basename( __FILE__ ) );
+define( 'POST_COLLECTION_VERSION', '2.0.0' );
 
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/class-user.php';
@@ -31,6 +33,7 @@ require_once __DIR__ . '/class-post-collection.php';
 require_once __DIR__ . '/class-extracted-page.php';
 require_once __DIR__ . '/site-configs/class-site-config.php';
 require_once __DIR__ . '/site-configs/class-youtube.php';
+require_once __DIR__ . '/includes/class-article-notes.php';
 
 add_filter( 'post_collection_active', '__return_true' );
 

--- a/templates/admin/article-notes-item.php
+++ b/templates/admin/article-notes-item.php
@@ -13,9 +13,11 @@ defined( 'ABSPATH' ) || exit;
 <div class="post-collection-article-header">
 	<label class="post-collection-select-article">
 		<input type="checkbox" name="selected_articles[]" value="<?php echo esc_attr( $article['id'] ); ?>">
-		<a href="<?php echo esc_url( $article['permalink'] ); ?>" class="post-collection-article-title" target="_blank">
-			<?php echo esc_html( $article['title'] ); ?>
-		</a>
+		<span class="post-collection-title-wrapper">
+			<a href="<?php echo esc_url( $article['permalink'] ); ?>" class="post-collection-article-title" target="_blank"><?php echo esc_html( $article['title'] ); ?></a>
+			<button type="button" class="post-collection-edit-title-btn" title="<?php esc_attr_e( 'Edit title', 'post-collection' ); ?>">&#9998;</button>
+			<input type="text" class="post-collection-title-input" value="<?php echo esc_attr( $article['title'] ); ?>">
+		</span>
 	</label>
 	<span class="post-collection-article-meta">
 		<?php echo esc_html( $article['author'] ); ?>

--- a/templates/admin/article-notes-item.php
+++ b/templates/admin/article-notes-item.php
@@ -21,6 +21,9 @@ defined( 'ABSPATH' ) || exit;
 	</label>
 	<span class="post-collection-article-meta">
 		<?php echo esc_html( $article['author'] ); ?>
+		<?php if ( ! empty( $article['collection'] ) && $article['collection'] !== $article['author'] ) : ?>
+			&bull; <?php echo esc_html( $article['collection'] ); ?>
+		<?php endif; ?>
 		<?php if ( ! empty( $article['sent_date'] ) ) : ?>
 			&bull; <?php echo esc_html( $article['sent_date'] ); ?>
 		<?php endif; ?>

--- a/templates/admin/article-notes-item.php
+++ b/templates/admin/article-notes-item.php
@@ -25,6 +25,15 @@ defined( 'ABSPATH' ) || exit;
 	</span>
 </div>
 
+<?php if ( ! empty( $article['content'] ) ) : ?>
+	<details class="post-collection-article-preview">
+		<summary><?php esc_html_e( 'Show article', 'post-collection' ); ?></summary>
+		<div class="post-collection-article-preview-content">
+			<?php echo $article['content']; ?>
+		</div>
+	</details>
+<?php endif; ?>
+
 <div class="post-collection-article-controls">
 	<div class="post-collection-status-buttons">
 		<?php foreach ( $statuses as $status_key => $status_label ) : ?>
@@ -47,10 +56,6 @@ defined( 'ABSPATH' ) || exit;
 			</button>
 		<?php endfor; ?>
 	</div>
-
-	<button type="button" class="post-collection-toggle-notes-btn" title="<?php esc_attr_e( 'Toggle notes', 'post-collection' ); ?>">
-		<?php esc_html_e( 'Notes', 'post-collection' ); ?>
-	</button>
 
 	<button type="button" class="post-collection-archive-btn" title="<?php esc_attr_e( 'Archive - hide from this list', 'post-collection' ); ?>">
 		<?php esc_html_e( 'Archive', 'post-collection' ); ?>

--- a/templates/admin/article-notes-item.php
+++ b/templates/admin/article-notes-item.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Single Article Notes Item Template
+ *
+ * Used in both pending and reviewed lists. Parent CSS class controls visibility
+ * of elements like the checkbox (.post-collection-reviewed-list) and archive button.
+ *
+ * @package Post_Collection
+ */
+
+defined( 'ABSPATH' ) || exit;
+?>
+<div class="post-collection-article-header">
+	<label class="post-collection-select-article">
+		<input type="checkbox" name="selected_articles[]" value="<?php echo esc_attr( $article['id'] ); ?>">
+		<a href="<?php echo esc_url( $article['permalink'] ); ?>" class="post-collection-article-title" target="_blank">
+			<?php echo esc_html( $article['title'] ); ?>
+		</a>
+	</label>
+	<span class="post-collection-article-meta">
+		<?php echo esc_html( $article['author'] ); ?>
+		<?php if ( ! empty( $article['sent_date'] ) ) : ?>
+			&bull; <?php echo esc_html( $article['sent_date'] ); ?>
+		<?php endif; ?>
+	</span>
+</div>
+
+<div class="post-collection-article-controls">
+	<div class="post-collection-status-buttons">
+		<?php foreach ( $statuses as $status_key => $status_label ) : ?>
+			<button type="button"
+				class="post-collection-status-btn <?php echo ( $article['note_id'] && $article['status'] === $status_key ) ? 'active' : ''; ?>"
+				data-status="<?php echo esc_attr( $status_key ); ?>"
+				title="<?php echo esc_attr( $status_label ); ?>">
+				<?php echo esc_html( $status_label ); ?>
+			</button>
+		<?php endforeach; ?>
+	</div>
+
+	<div class="post-collection-rating" data-rating="<?php echo esc_attr( $article['rating'] ); ?>">
+		<?php for ( $i = 1; $i <= 5; $i++ ) : ?>
+			<button type="button"
+				class="post-collection-star <?php echo $i <= $article['rating'] ? 'active' : ''; ?>"
+				data-rating="<?php echo esc_attr( $i ); ?>"
+				title="<?php echo esc_attr( sprintf( __( '%d stars', 'post-collection' ), $i ) ); ?>">
+				<?php echo $i <= $article['rating'] ? '&#9733;' : '&#9734;'; ?>
+			</button>
+		<?php endfor; ?>
+	</div>
+
+	<button type="button" class="post-collection-archive-btn" title="<?php esc_attr_e( 'Archive - hide from this list', 'post-collection' ); ?>">
+		<?php esc_html_e( 'Archive', 'post-collection' ); ?>
+	</button>
+</div>
+
+<div class="post-collection-notes-wrapper">
+	<textarea
+		class="post-collection-notes"
+		placeholder="<?php esc_attr_e( 'Add your notes...', 'post-collection' ); ?>"
+		rows="2"><?php echo esc_textarea( $article['notes'] ); ?></textarea>
+	<div class="post-collection-notes-actions">
+		<button type="button" class="button button-small post-collection-save-notes-btn">
+			<?php esc_html_e( 'Save', 'post-collection' ); ?>
+		</button>
+		<span class="post-collection-save-status"></span>
+	</div>
+</div>

--- a/templates/admin/article-notes-item.php
+++ b/templates/admin/article-notes-item.php
@@ -48,6 +48,10 @@ defined( 'ABSPATH' ) || exit;
 		<?php endfor; ?>
 	</div>
 
+	<button type="button" class="post-collection-toggle-notes-btn" title="<?php esc_attr_e( 'Toggle notes', 'post-collection' ); ?>">
+		<?php esc_html_e( 'Notes', 'post-collection' ); ?>
+	</button>
+
 	<button type="button" class="post-collection-archive-btn" title="<?php esc_attr_e( 'Archive - hide from this list', 'post-collection' ); ?>">
 		<?php esc_html_e( 'Archive', 'post-collection' ); ?>
 	</button>

--- a/templates/admin/article-notes-page.php
+++ b/templates/admin/article-notes-page.php
@@ -16,7 +16,7 @@ $statuses = isset( $args['statuses'] ) ? $args['statuses'] : array();
 $nonce = isset( $args['nonce'] ) ? $args['nonce'] : '';
 
 $total_pages = ceil( $total / $per_page );
-$base_url = admin_url( 'options-general.php?page=post-collection-article-notes' );
+$base_url = admin_url( 'edit.php?post_type=post_collection&page=post-collection-article-notes' );
 ?>
 
 <div class="wrap post-collection-notes-admin">

--- a/templates/admin/article-notes-page.php
+++ b/templates/admin/article-notes-page.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Article Notes Admin Page Template
+ *
+ * @package Post_Collection
+ */
+
+$notes = isset( $args['notes'] ) ? $args['notes'] : array();
+$total = isset( $args['total'] ) ? $args['total'] : 0;
+$paged = isset( $args['paged'] ) ? $args['paged'] : 1;
+$per_page = isset( $args['per_page'] ) ? $args['per_page'] : 20;
+$status_filter = isset( $args['status_filter'] ) ? $args['status_filter'] : 'all';
+$statuses = isset( $args['statuses'] ) ? $args['statuses'] : array();
+$nonce = isset( $args['nonce'] ) ? $args['nonce'] : '';
+
+$total_pages = ceil( $total / $per_page );
+$base_url = admin_url( 'options-general.php?page=ereader-article-notes' );
+?>
+
+<div class="wrap ereader-notes-admin">
+	<h1><?php esc_html_e( 'Article Notes', 'send-to-e-reader' ); ?></h1>
+
+	<div class="ereader-notes-filters">
+		<ul class="subsubsub">
+			<li>
+				<a href="<?php echo esc_url( $base_url ); ?>" class="<?php echo 'all' === $status_filter ? 'current' : ''; ?>">
+					<?php esc_html_e( 'All', 'send-to-e-reader' ); ?>
+				</a> |
+			</li>
+			<?php foreach ( $statuses as $status_key => $status_label ) : ?>
+				<li>
+					<a href="<?php echo esc_url( add_query_arg( 'status', $status_key, $base_url ) ); ?>" class="<?php echo $status_filter === $status_key ? 'current' : ''; ?>">
+						<?php echo esc_html( $status_label ); ?>
+					</a>
+					<?php echo $status_key !== array_key_last( $statuses ) ? '|' : ''; ?>
+				</li>
+			<?php endforeach; ?>
+			<li>
+				<a href="<?php echo esc_url( add_query_arg( 'status', 'archived', $base_url ) ); ?>" class="<?php echo 'archived' === $status_filter ? 'current' : ''; ?>">
+					<?php esc_html_e( 'Archived', 'send-to-e-reader' ); ?>
+				</a>
+			</li>
+		</ul>
+	</div>
+
+	<?php if ( empty( $notes ) ) : ?>
+		<p class="ereader-no-notes">
+			<?php esc_html_e( 'No article notes found.', 'send-to-e-reader' ); ?>
+		</p>
+	<?php else : ?>
+		<table class="wp-list-table widefat fixed striped ereader-notes-table">
+			<thead>
+				<tr>
+					<th class="column-title"><?php esc_html_e( 'Article', 'send-to-e-reader' ); ?></th>
+					<th class="column-status"><?php esc_html_e( 'Status', 'send-to-e-reader' ); ?></th>
+					<th class="column-rating"><?php esc_html_e( 'Rating', 'send-to-e-reader' ); ?></th>
+					<th class="column-notes"><?php esc_html_e( 'Notes', 'send-to-e-reader' ); ?></th>
+					<th class="column-date"><?php esc_html_e( 'Updated', 'send-to-e-reader' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ( $notes as $note ) : ?>
+					<tr class="ereader-article-item" data-article-id="<?php echo esc_attr( $note['id'] ); ?>">
+						<td class="column-title">
+							<strong>
+								<a href="<?php echo esc_url( $note['permalink'] ); ?>" target="_blank">
+									<?php echo esc_html( $note['title'] ); ?>
+								</a>
+							</strong>
+							<div class="ereader-article-author">
+								<?php echo esc_html( $note['author'] ); ?>
+							</div>
+						</td>
+						<td class="column-status">
+							<div class="ereader-status-buttons">
+								<?php foreach ( $statuses as $status_key => $status_label ) : ?>
+									<button type="button"
+										class="ereader-status-btn <?php echo $note['status'] === $status_key ? 'active' : ''; ?>"
+										data-status="<?php echo esc_attr( $status_key ); ?>"
+										title="<?php echo esc_attr( $status_label ); ?>">
+										<?php echo esc_html( $status_label ); ?>
+									</button>
+								<?php endforeach; ?>
+							</div>
+							<?php if ( 'archived' !== $note['status'] ) : ?>
+								<button type="button" class="ereader-archive-btn" title="<?php esc_attr_e( 'Archive', 'send-to-e-reader' ); ?>">
+									<?php esc_html_e( 'Archive', 'send-to-e-reader' ); ?>
+								</button>
+							<?php endif; ?>
+						</td>
+						<td class="column-rating">
+							<div class="ereader-rating" data-rating="<?php echo esc_attr( $note['rating'] ); ?>">
+								<?php for ( $i = 1; $i <= 5; $i++ ) : ?>
+									<button type="button"
+										class="ereader-star <?php echo $i <= $note['rating'] ? 'active' : ''; ?>"
+										data-rating="<?php echo esc_attr( $i ); ?>"
+										title="<?php echo esc_attr( sprintf( __( '%d stars', 'send-to-e-reader' ), $i ) ); ?>">
+										<?php echo $i <= $note['rating'] ? '&#9733;' : '&#9734;'; ?>
+									</button>
+								<?php endfor; ?>
+							</div>
+						</td>
+						<td class="column-notes">
+							<div class="ereader-notes-wrapper">
+								<textarea
+									class="ereader-notes"
+									placeholder="<?php esc_attr_e( 'Add your notes...', 'send-to-e-reader' ); ?>"
+									rows="2"><?php echo esc_textarea( $note['notes'] ); ?></textarea>
+							</div>
+							<div class="ereader-save-status"></div>
+						</td>
+						<td class="column-date">
+							<?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $note['updated'] ) ) ); ?>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+
+		<?php if ( $total_pages > 1 ) : ?>
+			<div class="tablenav bottom">
+				<div class="tablenav-pages">
+					<span class="displaying-num">
+						<?php
+						printf(
+							/* translators: %s: Number of items */
+							esc_html( _n( '%s item', '%s items', $total, 'send-to-e-reader' ) ),
+							esc_html( number_format_i18n( $total ) )
+						);
+						?>
+					</span>
+					<span class="pagination-links">
+						<?php if ( $paged > 1 ) : ?>
+							<a class="prev-page button" href="<?php echo esc_url( add_query_arg( 'paged', $paged - 1, add_query_arg( 'status', $status_filter, $base_url ) ) ); ?>">
+								<span aria-hidden="true">&lsaquo;</span>
+							</a>
+						<?php else : ?>
+							<span class="tablenav-pages-navspan button disabled" aria-hidden="true">&lsaquo;</span>
+						<?php endif; ?>
+
+						<span class="paging-input">
+							<?php echo esc_html( $paged ); ?>
+							<?php esc_html_e( 'of', 'send-to-e-reader' ); ?>
+							<span class="total-pages"><?php echo esc_html( $total_pages ); ?></span>
+						</span>
+
+						<?php if ( $paged < $total_pages ) : ?>
+							<a class="next-page button" href="<?php echo esc_url( add_query_arg( 'paged', $paged + 1, add_query_arg( 'status', $status_filter, $base_url ) ) ); ?>">
+								<span aria-hidden="true">&rsaquo;</span>
+							</a>
+						<?php else : ?>
+							<span class="tablenav-pages-navspan button disabled" aria-hidden="true">&rsaquo;</span>
+						<?php endif; ?>
+					</span>
+				</div>
+			</div>
+		<?php endif; ?>
+	<?php endif; ?>
+</div>

--- a/templates/admin/article-notes-page.php
+++ b/templates/admin/article-notes-page.php
@@ -20,7 +20,7 @@ $base_url = admin_url( 'edit.php?post_type=post_collection&page=post-collection-
 ?>
 
 <div class="wrap post-collection-notes-admin">
-	<h1><?php esc_html_e( 'Article Notes', 'post-collection' ); ?></h1>
+	<h1><?php esc_html_e( 'Collected Posts Notes', 'post-collection' ); ?></h1>
 
 	<div class="post-collection-notes-filters">
 		<ul class="subsubsub">

--- a/templates/admin/article-notes-page.php
+++ b/templates/admin/article-notes-page.php
@@ -5,6 +5,8 @@
  * @package Post_Collection
  */
 
+defined( 'ABSPATH' ) || exit;
+
 $notes = isset( $args['notes'] ) ? $args['notes'] : array();
 $total = isset( $args['total'] ) ? $args['total'] : 0;
 $paged = isset( $args['paged'] ) ? $args['paged'] : 1;
@@ -14,17 +16,17 @@ $statuses = isset( $args['statuses'] ) ? $args['statuses'] : array();
 $nonce = isset( $args['nonce'] ) ? $args['nonce'] : '';
 
 $total_pages = ceil( $total / $per_page );
-$base_url = admin_url( 'options-general.php?page=ereader-article-notes' );
+$base_url = admin_url( 'options-general.php?page=post-collection-article-notes' );
 ?>
 
-<div class="wrap ereader-notes-admin">
-	<h1><?php esc_html_e( 'Article Notes', 'send-to-e-reader' ); ?></h1>
+<div class="wrap post-collection-notes-admin">
+	<h1><?php esc_html_e( 'Article Notes', 'post-collection' ); ?></h1>
 
-	<div class="ereader-notes-filters">
+	<div class="post-collection-notes-filters">
 		<ul class="subsubsub">
 			<li>
 				<a href="<?php echo esc_url( $base_url ); ?>" class="<?php echo 'all' === $status_filter ? 'current' : ''; ?>">
-					<?php esc_html_e( 'All', 'send-to-e-reader' ); ?>
+					<?php esc_html_e( 'All', 'post-collection' ); ?>
 				</a> |
 			</li>
 			<?php foreach ( $statuses as $status_key => $status_label ) : ?>
@@ -37,45 +39,45 @@ $base_url = admin_url( 'options-general.php?page=ereader-article-notes' );
 			<?php endforeach; ?>
 			<li>
 				<a href="<?php echo esc_url( add_query_arg( 'status', 'archived', $base_url ) ); ?>" class="<?php echo 'archived' === $status_filter ? 'current' : ''; ?>">
-					<?php esc_html_e( 'Archived', 'send-to-e-reader' ); ?>
+					<?php esc_html_e( 'Archived', 'post-collection' ); ?>
 				</a>
 			</li>
 		</ul>
 	</div>
 
 	<?php if ( empty( $notes ) ) : ?>
-		<p class="ereader-no-notes">
-			<?php esc_html_e( 'No article notes found.', 'send-to-e-reader' ); ?>
+		<p class="post-collection-no-notes">
+			<?php esc_html_e( 'No article notes found.', 'post-collection' ); ?>
 		</p>
 	<?php else : ?>
-		<table class="wp-list-table widefat fixed striped ereader-notes-table">
+		<table class="wp-list-table widefat fixed striped post-collection-notes-table">
 			<thead>
 				<tr>
-					<th class="column-title"><?php esc_html_e( 'Article', 'send-to-e-reader' ); ?></th>
-					<th class="column-status"><?php esc_html_e( 'Status', 'send-to-e-reader' ); ?></th>
-					<th class="column-rating"><?php esc_html_e( 'Rating', 'send-to-e-reader' ); ?></th>
-					<th class="column-notes"><?php esc_html_e( 'Notes', 'send-to-e-reader' ); ?></th>
-					<th class="column-date"><?php esc_html_e( 'Updated', 'send-to-e-reader' ); ?></th>
+					<th class="column-title"><?php esc_html_e( 'Article', 'post-collection' ); ?></th>
+					<th class="column-status"><?php esc_html_e( 'Status', 'post-collection' ); ?></th>
+					<th class="column-rating"><?php esc_html_e( 'Rating', 'post-collection' ); ?></th>
+					<th class="column-notes"><?php esc_html_e( 'Notes', 'post-collection' ); ?></th>
+					<th class="column-date"><?php esc_html_e( 'Updated', 'post-collection' ); ?></th>
 				</tr>
 			</thead>
 			<tbody>
 				<?php foreach ( $notes as $note ) : ?>
-					<tr class="ereader-article-item" data-article-id="<?php echo esc_attr( $note['id'] ); ?>">
+					<tr class="post-collection-article-item" data-article-id="<?php echo esc_attr( $note['id'] ); ?>">
 						<td class="column-title">
 							<strong>
 								<a href="<?php echo esc_url( $note['permalink'] ); ?>" target="_blank">
 									<?php echo esc_html( $note['title'] ); ?>
 								</a>
 							</strong>
-							<div class="ereader-article-author">
+							<div class="post-collection-article-author">
 								<?php echo esc_html( $note['author'] ); ?>
 							</div>
 						</td>
 						<td class="column-status">
-							<div class="ereader-status-buttons">
+							<div class="post-collection-status-buttons">
 								<?php foreach ( $statuses as $status_key => $status_label ) : ?>
 									<button type="button"
-										class="ereader-status-btn <?php echo $note['status'] === $status_key ? 'active' : ''; ?>"
+										class="post-collection-status-btn <?php echo $note['status'] === $status_key ? 'active' : ''; ?>"
 										data-status="<?php echo esc_attr( $status_key ); ?>"
 										title="<?php echo esc_attr( $status_label ); ?>">
 										<?php echo esc_html( $status_label ); ?>
@@ -83,31 +85,31 @@ $base_url = admin_url( 'options-general.php?page=ereader-article-notes' );
 								<?php endforeach; ?>
 							</div>
 							<?php if ( 'archived' !== $note['status'] ) : ?>
-								<button type="button" class="ereader-archive-btn" title="<?php esc_attr_e( 'Archive', 'send-to-e-reader' ); ?>">
-									<?php esc_html_e( 'Archive', 'send-to-e-reader' ); ?>
+								<button type="button" class="post-collection-archive-btn" title="<?php esc_attr_e( 'Archive', 'post-collection' ); ?>">
+									<?php esc_html_e( 'Archive', 'post-collection' ); ?>
 								</button>
 							<?php endif; ?>
 						</td>
 						<td class="column-rating">
-							<div class="ereader-rating" data-rating="<?php echo esc_attr( $note['rating'] ); ?>">
+							<div class="post-collection-rating" data-rating="<?php echo esc_attr( $note['rating'] ); ?>">
 								<?php for ( $i = 1; $i <= 5; $i++ ) : ?>
 									<button type="button"
-										class="ereader-star <?php echo $i <= $note['rating'] ? 'active' : ''; ?>"
+										class="post-collection-star <?php echo $i <= $note['rating'] ? 'active' : ''; ?>"
 										data-rating="<?php echo esc_attr( $i ); ?>"
-										title="<?php echo esc_attr( sprintf( __( '%d stars', 'send-to-e-reader' ), $i ) ); ?>">
+										title="<?php echo esc_attr( sprintf( __( '%d stars', 'post-collection' ), $i ) ); ?>">
 										<?php echo $i <= $note['rating'] ? '&#9733;' : '&#9734;'; ?>
 									</button>
 								<?php endfor; ?>
 							</div>
 						</td>
 						<td class="column-notes">
-							<div class="ereader-notes-wrapper">
+							<div class="post-collection-notes-wrapper">
 								<textarea
-									class="ereader-notes"
-									placeholder="<?php esc_attr_e( 'Add your notes...', 'send-to-e-reader' ); ?>"
+									class="post-collection-notes"
+									placeholder="<?php esc_attr_e( 'Add your notes...', 'post-collection' ); ?>"
 									rows="2"><?php echo esc_textarea( $note['notes'] ); ?></textarea>
 							</div>
-							<div class="ereader-save-status"></div>
+							<div class="post-collection-save-status"></div>
 						</td>
 						<td class="column-date">
 							<?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $note['updated'] ) ) ); ?>
@@ -124,7 +126,7 @@ $base_url = admin_url( 'options-general.php?page=ereader-article-notes' );
 						<?php
 						printf(
 							/* translators: %s: Number of items */
-							esc_html( _n( '%s item', '%s items', $total, 'send-to-e-reader' ) ),
+							esc_html( _n( '%s item', '%s items', $total, 'post-collection' ) ),
 							esc_html( number_format_i18n( $total ) )
 						);
 						?>
@@ -140,7 +142,7 @@ $base_url = admin_url( 'options-general.php?page=ereader-article-notes' );
 
 						<span class="paging-input">
 							<?php echo esc_html( $paged ); ?>
-							<?php esc_html_e( 'of', 'send-to-e-reader' ); ?>
+							<?php esc_html_e( 'of', 'post-collection' ); ?>
 							<span class="total-pages"><?php echo esc_html( $total_pages ); ?></span>
 						</span>
 

--- a/templates/admin/article-notes-widget.php
+++ b/templates/admin/article-notes-widget.php
@@ -9,15 +9,13 @@ defined( 'ABSPATH' ) || exit;
 
 $pending_articles = isset( $args['pending_articles'] ) ? $args['pending_articles'] : array();
 $has_more_pending = isset( $args['has_more_pending'] ) ? $args['has_more_pending'] : false;
-$unread_articles = isset( $args['unread_articles'] ) ? $args['unread_articles'] : array();
-$has_more_unread = isset( $args['has_more_unread'] ) ? $args['has_more_unread'] : false;
 $reviewed_articles = isset( $args['reviewed_articles'] ) ? $args['reviewed_articles'] : array();
 $nonce = isset( $args['nonce'] ) ? $args['nonce'] : '';
 $statuses = \PostCollection\Article_Notes::get_statuses();
 ?>
 
 <div class="post-collection-article-notes-widget" data-nonce="<?php echo esc_attr( $nonce ); ?>">
-	<?php if ( empty( $pending_articles ) && empty( $unread_articles ) && empty( $reviewed_articles ) ) : ?>
+	<?php if ( empty( $pending_articles ) && empty( $reviewed_articles ) ) : ?>
 		<p class="post-collection-no-articles">
 			<?php esc_html_e( 'No articles in your collection yet. Collect posts from the web to start adding notes and reviews.', 'post-collection' ); ?>
 		</p>
@@ -25,9 +23,6 @@ $statuses = \PostCollection\Article_Notes::get_statuses();
 		<div class="post-collection-widget-tabs">
 			<button type="button" class="post-collection-tab active" data-tab="pending">
 				<?php esc_html_e( 'Pending', 'post-collection' ); ?>
-			</button>
-			<button type="button" class="post-collection-tab" data-tab="unread">
-				<?php esc_html_e( 'Unread', 'post-collection' ); ?>
 			</button>
 			<button type="button" class="post-collection-tab" data-tab="reviewed">
 				<?php esc_html_e( 'Reviewed', 'post-collection' ); ?>
@@ -37,13 +32,13 @@ $statuses = \PostCollection\Article_Notes::get_statuses();
 		<div class="post-collection-tab-content active" data-tab="pending">
 			<?php if ( empty( $pending_articles ) ) : ?>
 				<p class="post-collection-no-articles">
-					<?php esc_html_e( 'No new articles to review.', 'post-collection' ); ?>
+					<?php esc_html_e( 'No articles to review.', 'post-collection' ); ?>
 				</p>
 			<?php else : ?>
 				<p class="post-collection-tab-hint">
-				<?php esc_html_e( 'Mark your reading status. Articles move to Unread or Reviewed tab.', 'post-collection' ); ?>
-			</p>
-			<ul class="post-collection-article-list post-collection-pending-list">
+					<?php esc_html_e( 'Mark your reading status and add notes. Articles marked as Read or Skipped will move to the Reviewed tab on next load.', 'post-collection' ); ?>
+				</p>
+				<ul class="post-collection-article-list post-collection-pending-list">
 					<?php foreach ( $pending_articles as $article ) : ?>
 						<li class="post-collection-article-item" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
 							<div class="post-collection-article-header">
@@ -62,7 +57,7 @@ $statuses = \PostCollection\Article_Notes::get_statuses();
 								<div class="post-collection-status-buttons">
 									<?php foreach ( $statuses as $status_key => $status_label ) : ?>
 										<button type="button"
-											class="post-collection-status-btn <?php echo $article['status'] === $status_key ? 'active' : ''; ?>"
+											class="post-collection-status-btn <?php echo ( $article['note_id'] && $article['status'] === $status_key ) ? 'active' : ''; ?>"
 											data-status="<?php echo esc_attr( $status_key ); ?>"
 											title="<?php echo esc_attr( $status_label ); ?>">
 											<?php echo esc_html( $status_label ); ?>
@@ -87,6 +82,9 @@ $statuses = \PostCollection\Article_Notes::get_statuses();
 									class="post-collection-notes"
 									placeholder="<?php esc_attr_e( 'Add your notes...', 'post-collection' ); ?>"
 									rows="2"><?php echo esc_textarea( $article['notes'] ); ?></textarea>
+								<button type="button" class="button button-small post-collection-save-notes-btn">
+									<?php esc_html_e( 'Save', 'post-collection' ); ?>
+								</button>
 							</div>
 
 							<div class="post-collection-save-status"></div>
@@ -103,75 +101,6 @@ $statuses = \PostCollection\Article_Notes::get_statuses();
 			<?php endif; ?>
 		</div>
 
-		<div class="post-collection-tab-content" data-tab="unread">
-			<?php if ( empty( $unread_articles ) ) : ?>
-				<p class="post-collection-no-articles">
-					<?php esc_html_e( 'No unread articles.', 'post-collection' ); ?>
-				</p>
-			<?php else : ?>
-				<p class="post-collection-tab-hint">
-				<?php esc_html_e( 'Articles marked as "Not read yet". Mark as Read or Skipped to move to Reviewed.', 'post-collection' ); ?>
-			</p>
-			<ul class="post-collection-article-list post-collection-unread-list">
-					<?php foreach ( $unread_articles as $article ) : ?>
-						<li class="post-collection-article-item" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
-							<div class="post-collection-article-header">
-								<a href="<?php echo esc_url( $article['permalink'] ); ?>" class="post-collection-article-title" target="_blank">
-									<?php echo esc_html( $article['title'] ); ?>
-								</a>
-								<span class="post-collection-article-meta">
-									<?php echo esc_html( $article['author'] ); ?>
-									<?php if ( $article['sent_date'] ) : ?>
-										&bull; <?php echo esc_html( $article['sent_date'] ); ?>
-									<?php endif; ?>
-								</span>
-							</div>
-
-							<div class="post-collection-article-controls">
-								<div class="post-collection-status-buttons">
-									<?php foreach ( $statuses as $status_key => $status_label ) : ?>
-										<button type="button"
-											class="post-collection-status-btn <?php echo $article['status'] === $status_key ? 'active' : ''; ?>"
-											data-status="<?php echo esc_attr( $status_key ); ?>"
-											title="<?php echo esc_attr( $status_label ); ?>">
-											<?php echo esc_html( $status_label ); ?>
-										</button>
-									<?php endforeach; ?>
-								</div>
-
-								<div class="post-collection-rating" data-rating="<?php echo esc_attr( $article['rating'] ); ?>">
-									<?php for ( $i = 1; $i <= 5; $i++ ) : ?>
-										<button type="button"
-											class="post-collection-star <?php echo $i <= $article['rating'] ? 'active' : ''; ?>"
-											data-rating="<?php echo esc_attr( $i ); ?>"
-											title="<?php echo esc_attr( sprintf( __( '%d stars', 'post-collection' ), $i ) ); ?>">
-											<?php echo $i <= $article['rating'] ? '&#9733;' : '&#9734;'; ?>
-										</button>
-									<?php endfor; ?>
-								</div>
-							</div>
-
-							<div class="post-collection-notes-wrapper">
-								<textarea
-									class="post-collection-notes"
-									placeholder="<?php esc_attr_e( 'Add your notes...', 'post-collection' ); ?>"
-									rows="2"><?php echo esc_textarea( $article['notes'] ); ?></textarea>
-							</div>
-
-							<div class="post-collection-save-status"></div>
-						</li>
-					<?php endforeach; ?>
-				</ul>
-				<?php if ( $has_more_unread ) : ?>
-					<div class="post-collection-load-more-section">
-						<button type="button" class="button post-collection-load-more-btn" data-type="unread" data-offset="<?php echo count( $unread_articles ); ?>">
-							<?php esc_html_e( 'Load more', 'post-collection' ); ?>
-						</button>
-					</div>
-				<?php endif; ?>
-			<?php endif; ?>
-		</div>
-
 		<div class="post-collection-tab-content" data-tab="reviewed">
 			<?php if ( empty( $reviewed_articles ) ) : ?>
 				<p class="post-collection-no-articles">
@@ -179,9 +108,9 @@ $statuses = \PostCollection\Article_Notes::get_statuses();
 				</p>
 			<?php else : ?>
 				<p class="post-collection-tab-hint">
-				<?php esc_html_e( 'Select articles to create a post, or Archive to hide from this list.', 'post-collection' ); ?>
-			</p>
-			<ul class="post-collection-article-list post-collection-reviewed-list">
+					<?php esc_html_e( 'Select articles to create a post, or Archive to hide from this list.', 'post-collection' ); ?>
+				</p>
+				<ul class="post-collection-article-list post-collection-reviewed-list">
 					<?php foreach ( $reviewed_articles as $article ) : ?>
 						<li class="post-collection-article-item" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
 							<div class="post-collection-article-header">
@@ -238,6 +167,9 @@ $statuses = \PostCollection\Article_Notes::get_statuses();
 									class="post-collection-notes"
 									placeholder="<?php esc_attr_e( 'Add your notes...', 'post-collection' ); ?>"
 									rows="2"><?php echo esc_textarea( $article['notes'] ); ?></textarea>
+								<button type="button" class="button button-small post-collection-save-notes-btn">
+									<?php esc_html_e( 'Save', 'post-collection' ); ?>
+								</button>
 							</div>
 
 							<div class="post-collection-save-status"></div>

--- a/templates/admin/article-notes-widget.php
+++ b/templates/admin/article-notes-widget.php
@@ -7,14 +7,39 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$pending_articles  = isset( $args['pending_articles'] ) ? $args['pending_articles'] : array();
-$has_more_pending  = isset( $args['has_more_pending'] ) ? $args['has_more_pending'] : false;
-$reviewed_articles = isset( $args['reviewed_articles'] ) ? $args['reviewed_articles'] : array();
-$nonce             = isset( $args['nonce'] ) ? $args['nonce'] : '';
-$statuses          = \PostCollection\Article_Notes::get_statuses();
+$pending_articles   = isset( $args['pending_articles'] ) ? $args['pending_articles'] : array();
+$has_more_pending   = isset( $args['has_more_pending'] ) ? $args['has_more_pending'] : false;
+$reviewed_articles  = isset( $args['reviewed_articles'] ) ? $args['reviewed_articles'] : array();
+$random_remembered  = isset( $args['random_remembered'] ) ? $args['random_remembered'] : null;
+$nonce              = isset( $args['nonce'] ) ? $args['nonce'] : '';
+$statuses           = \PostCollection\Article_Notes::get_statuses();
 ?>
 
 <div class="post-collection-article-notes-widget" data-nonce="<?php echo esc_attr( $nonce ); ?>">
+	<?php if ( $random_remembered ) : ?>
+		<div class="post-collection-remember">
+			<div class="post-collection-remember-header">
+				<span class="post-collection-remember-label"><?php esc_html_e( 'From your notes:', 'post-collection' ); ?></span>
+				<a href="#" class="post-collection-remember-another"><?php esc_html_e( 'Show another', 'post-collection' ); ?> &rarr;</a>
+			</div>
+			<a href="<?php echo esc_url( $random_remembered['permalink'] ); ?>" class="post-collection-remember-title" target="_blank">
+				<?php echo esc_html( $random_remembered['title'] ); ?>
+			</a>
+			<span class="post-collection-remember-meta"><?php echo esc_html( $random_remembered['author'] ); ?></span>
+			<blockquote class="post-collection-remember-notes">
+				<?php echo wp_kses_post( $random_remembered['notes'] ); ?>
+			</blockquote>
+			<?php if ( ! empty( $random_remembered['content'] ) ) : ?>
+				<details class="post-collection-article-preview">
+					<summary><?php esc_html_e( 'Show article', 'post-collection' ); ?></summary>
+					<div class="post-collection-article-preview-content">
+						<?php echo $random_remembered['content']; ?>
+					</div>
+				</details>
+			<?php endif; ?>
+		</div>
+	<?php endif; ?>
+
 	<?php if ( empty( $pending_articles ) && empty( $reviewed_articles ) ) : ?>
 		<p class="post-collection-no-articles">
 			<?php esc_html_e( 'No articles in your collection yet. Collect posts from the web to start adding notes and reviews.', 'post-collection' ); ?>

--- a/templates/admin/article-notes-widget.php
+++ b/templates/admin/article-notes-widget.php
@@ -7,11 +7,11 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$pending_articles = isset( $args['pending_articles'] ) ? $args['pending_articles'] : array();
-$has_more_pending = isset( $args['has_more_pending'] ) ? $args['has_more_pending'] : false;
+$pending_articles  = isset( $args['pending_articles'] ) ? $args['pending_articles'] : array();
+$has_more_pending  = isset( $args['has_more_pending'] ) ? $args['has_more_pending'] : false;
 $reviewed_articles = isset( $args['reviewed_articles'] ) ? $args['reviewed_articles'] : array();
-$nonce = isset( $args['nonce'] ) ? $args['nonce'] : '';
-$statuses = \PostCollection\Article_Notes::get_statuses();
+$nonce             = isset( $args['nonce'] ) ? $args['nonce'] : '';
+$statuses          = \PostCollection\Article_Notes::get_statuses();
 ?>
 
 <div class="post-collection-article-notes-widget" data-nonce="<?php echo esc_attr( $nonce ); ?>">
@@ -40,54 +40,11 @@ $statuses = \PostCollection\Article_Notes::get_statuses();
 				</p>
 				<ul class="post-collection-article-list post-collection-pending-list">
 					<?php foreach ( $pending_articles as $article ) : ?>
-						<li class="post-collection-article-item" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
-							<div class="post-collection-article-header">
-								<a href="<?php echo esc_url( $article['permalink'] ); ?>" class="post-collection-article-title" target="_blank">
-									<?php echo esc_html( $article['title'] ); ?>
-								</a>
-								<span class="post-collection-article-meta">
-									<?php echo esc_html( $article['author'] ); ?>
-									<?php if ( $article['sent_date'] ) : ?>
-										&bull; <?php echo esc_html( $article['sent_date'] ); ?>
-									<?php endif; ?>
-								</span>
-							</div>
-
-							<div class="post-collection-article-controls">
-								<div class="post-collection-status-buttons">
-									<?php foreach ( $statuses as $status_key => $status_label ) : ?>
-										<button type="button"
-											class="post-collection-status-btn <?php echo ( $article['note_id'] && $article['status'] === $status_key ) ? 'active' : ''; ?>"
-											data-status="<?php echo esc_attr( $status_key ); ?>"
-											title="<?php echo esc_attr( $status_label ); ?>">
-											<?php echo esc_html( $status_label ); ?>
-										</button>
-									<?php endforeach; ?>
-								</div>
-
-								<div class="post-collection-rating" data-rating="<?php echo esc_attr( $article['rating'] ); ?>">
-									<?php for ( $i = 1; $i <= 5; $i++ ) : ?>
-										<button type="button"
-											class="post-collection-star <?php echo $i <= $article['rating'] ? 'active' : ''; ?>"
-											data-rating="<?php echo esc_attr( $i ); ?>"
-											title="<?php echo esc_attr( sprintf( __( '%d stars', 'post-collection' ), $i ) ); ?>">
-											<?php echo $i <= $article['rating'] ? '&#9733;' : '&#9734;'; ?>
-										</button>
-									<?php endfor; ?>
-								</div>
-							</div>
-
-							<div class="post-collection-notes-wrapper">
-								<textarea
-									class="post-collection-notes"
-									placeholder="<?php esc_attr_e( 'Add your notes...', 'post-collection' ); ?>"
-									rows="2"><?php echo esc_textarea( $article['notes'] ); ?></textarea>
-								<button type="button" class="button button-small post-collection-save-notes-btn">
-									<?php esc_html_e( 'Save', 'post-collection' ); ?>
-								</button>
-							</div>
-
-							<div class="post-collection-save-status"></div>
+						<?php
+						$reviewed_class = ( $article['note_id'] && in_array( $article['status'], array( 'read', 'skipped' ), true ) ) ? ' post-collection-reviewed' : '';
+						?>
+						<li class="post-collection-article-item<?php echo esc_attr( $reviewed_class ); ?>" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
+							<?php require __DIR__ . '/article-notes-item.php'; ?>
 						</li>
 					<?php endforeach; ?>
 				</ul>
@@ -112,67 +69,8 @@ $statuses = \PostCollection\Article_Notes::get_statuses();
 				</p>
 				<ul class="post-collection-article-list post-collection-reviewed-list">
 					<?php foreach ( $reviewed_articles as $article ) : ?>
-						<li class="post-collection-article-item" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
-							<div class="post-collection-article-header">
-								<label class="post-collection-select-article">
-									<input type="checkbox" name="selected_articles[]" value="<?php echo esc_attr( $article['id'] ); ?>">
-									<a href="<?php echo esc_url( $article['permalink'] ); ?>" class="post-collection-article-title" target="_blank">
-										<?php echo esc_html( $article['title'] ); ?>
-									</a>
-								</label>
-								<span class="post-collection-article-meta">
-									<?php echo esc_html( $article['author'] ); ?>
-									<?php if ( $article['rating'] > 0 ) : ?>
-										&bull; <?php echo str_repeat( '&#9733;', $article['rating'] ); ?>
-									<?php endif; ?>
-								</span>
-							</div>
-
-							<div class="post-collection-article-controls">
-								<div class="post-collection-status-buttons">
-									<?php foreach ( $statuses as $status_key => $status_label ) : ?>
-										<button type="button"
-											class="post-collection-status-btn <?php echo $article['status'] === $status_key ? 'active' : ''; ?>"
-											data-status="<?php echo esc_attr( $status_key ); ?>"
-											title="<?php echo esc_attr( $status_label ); ?>">
-											<?php echo esc_html( $status_label ); ?>
-										</button>
-									<?php endforeach; ?>
-								</div>
-
-								<div class="post-collection-rating" data-rating="<?php echo esc_attr( $article['rating'] ); ?>">
-									<?php for ( $i = 1; $i <= 5; $i++ ) : ?>
-										<button type="button"
-											class="post-collection-star <?php echo $i <= $article['rating'] ? 'active' : ''; ?>"
-											data-rating="<?php echo esc_attr( $i ); ?>"
-											title="<?php echo esc_attr( sprintf( __( '%d stars', 'post-collection' ), $i ) ); ?>">
-											<?php echo $i <= $article['rating'] ? '&#9733;' : '&#9734;'; ?>
-										</button>
-									<?php endfor; ?>
-								</div>
-
-								<button type="button" class="post-collection-archive-btn" title="<?php esc_attr_e( 'Archive - hide from this list', 'post-collection' ); ?>">
-									<?php esc_html_e( 'Archive', 'post-collection' ); ?>
-								</button>
-							</div>
-
-							<?php if ( ! empty( $article['notes'] ) ) : ?>
-								<div class="post-collection-notes-preview">
-									<?php echo esc_html( wp_trim_words( $article['notes'], 20 ) ); ?>
-								</div>
-							<?php endif; ?>
-
-							<div class="post-collection-notes-wrapper" style="display: none;">
-								<textarea
-									class="post-collection-notes"
-									placeholder="<?php esc_attr_e( 'Add your notes...', 'post-collection' ); ?>"
-									rows="2"><?php echo esc_textarea( $article['notes'] ); ?></textarea>
-								<button type="button" class="button button-small post-collection-save-notes-btn">
-									<?php esc_html_e( 'Save', 'post-collection' ); ?>
-								</button>
-							</div>
-
-							<div class="post-collection-save-status"></div>
+						<li class="post-collection-article-item post-collection-reviewed" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
+							<?php require __DIR__ . '/article-notes-item.php'; ?>
 						</li>
 					<?php endforeach; ?>
 				</ul>

--- a/templates/admin/article-notes-widget.php
+++ b/templates/admin/article-notes-widget.php
@@ -17,36 +17,13 @@ $statuses           = \PostCollection\Article_Notes::get_statuses();
 
 <div class="post-collection-article-notes-widget" data-nonce="<?php echo esc_attr( $nonce ); ?>">
 	<?php if ( $random_remembered ) : ?>
-		<div class="post-collection-remember" data-article-id="<?php echo esc_attr( $random_remembered['id'] ); ?>">
+		<?php $article = $random_remembered; ?>
+		<div class="post-collection-remember post-collection-article-item" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
 			<div class="post-collection-remember-header">
 				<span class="post-collection-remember-label"><?php esc_html_e( 'From your notes:', 'post-collection' ); ?></span>
 				<a href="#" class="post-collection-remember-another"><?php esc_html_e( 'Show another', 'post-collection' ); ?> &rarr;</a>
 			</div>
-			<div class="post-collection-article-header">
-				<span class="post-collection-title-wrapper">
-					<a href="<?php echo esc_url( $random_remembered['permalink'] ); ?>" class="post-collection-article-title" target="_blank"><?php echo esc_html( $random_remembered['title'] ); ?></a>
-					<button type="button" class="post-collection-edit-title-btn" title="<?php esc_attr_e( 'Edit title', 'post-collection' ); ?>">&#9998;</button>
-					<input type="text" class="post-collection-title-input" value="<?php echo esc_attr( $random_remembered['title'] ); ?>">
-				</span>
-				<span class="post-collection-article-meta">
-					<?php echo esc_html( $random_remembered['author'] ); ?>
-					<?php if ( ! empty( $random_remembered['collection'] ) && $random_remembered['collection'] !== $random_remembered['author'] ) : ?>
-						&bull; <?php echo esc_html( $random_remembered['collection'] ); ?>
-					<?php endif; ?>
-				</span>
-			</div>
-			<blockquote class="post-collection-remember-notes">
-				<?php echo wp_kses_post( $random_remembered['notes'] ); ?>
-			</blockquote>
-			<?php if ( ! empty( $random_remembered['content'] ) ) : ?>
-				<details class="post-collection-article-preview">
-					<summary><?php esc_html_e( 'Show article', 'post-collection' ); ?></summary>
-					<div class="post-collection-article-preview-content">
-						<?php echo $random_remembered['content']; ?>
-					</div>
-				</details>
-			<?php endif; ?>
-			<div class="post-collection-save-status"></div>
+			<?php require __DIR__ . '/article-notes-item.php'; ?>
 		</div>
 	<?php endif; ?>
 

--- a/templates/admin/article-notes-widget.php
+++ b/templates/admin/article-notes-widget.php
@@ -5,6 +5,8 @@
  * @package Post_Collection
  */
 
+defined( 'ABSPATH' ) || exit;
+
 $pending_articles = isset( $args['pending_articles'] ) ? $args['pending_articles'] : array();
 $has_more_pending = isset( $args['has_more_pending'] ) ? $args['has_more_pending'] : false;
 $unread_articles = isset( $args['unread_articles'] ) ? $args['unread_articles'] : array();
@@ -14,41 +16,41 @@ $nonce = isset( $args['nonce'] ) ? $args['nonce'] : '';
 $statuses = \PostCollection\Article_Notes::get_statuses();
 ?>
 
-<div class="ereader-article-notes-widget" data-nonce="<?php echo esc_attr( $nonce ); ?>">
+<div class="post-collection-article-notes-widget" data-nonce="<?php echo esc_attr( $nonce ); ?>">
 	<?php if ( empty( $pending_articles ) && empty( $unread_articles ) && empty( $reviewed_articles ) ) : ?>
-		<p class="ereader-no-articles">
-			<?php esc_html_e( 'No articles have been sent to your e-reader yet.', 'send-to-e-reader' ); ?>
+		<p class="post-collection-no-articles">
+			<?php esc_html_e( 'No articles in your collection yet. Collect posts from the web to start adding notes and reviews.', 'post-collection' ); ?>
 		</p>
 	<?php else : ?>
-		<div class="ereader-widget-tabs">
-			<button type="button" class="ereader-tab active" data-tab="pending">
-				<?php esc_html_e( 'Pending', 'send-to-e-reader' ); ?>
+		<div class="post-collection-widget-tabs">
+			<button type="button" class="post-collection-tab active" data-tab="pending">
+				<?php esc_html_e( 'Pending', 'post-collection' ); ?>
 			</button>
-			<button type="button" class="ereader-tab" data-tab="unread">
-				<?php esc_html_e( 'Unread', 'send-to-e-reader' ); ?>
+			<button type="button" class="post-collection-tab" data-tab="unread">
+				<?php esc_html_e( 'Unread', 'post-collection' ); ?>
 			</button>
-			<button type="button" class="ereader-tab" data-tab="reviewed">
-				<?php esc_html_e( 'Reviewed', 'send-to-e-reader' ); ?>
+			<button type="button" class="post-collection-tab" data-tab="reviewed">
+				<?php esc_html_e( 'Reviewed', 'post-collection' ); ?>
 			</button>
 		</div>
 
-		<div class="ereader-tab-content active" data-tab="pending">
+		<div class="post-collection-tab-content active" data-tab="pending">
 			<?php if ( empty( $pending_articles ) ) : ?>
-				<p class="ereader-no-articles">
-					<?php esc_html_e( 'No new articles to review.', 'send-to-e-reader' ); ?>
+				<p class="post-collection-no-articles">
+					<?php esc_html_e( 'No new articles to review.', 'post-collection' ); ?>
 				</p>
 			<?php else : ?>
-				<p class="ereader-tab-hint">
-				<?php esc_html_e( 'Mark your reading status. Articles move to Unread or Reviewed tab.', 'send-to-e-reader' ); ?>
+				<p class="post-collection-tab-hint">
+				<?php esc_html_e( 'Mark your reading status. Articles move to Unread or Reviewed tab.', 'post-collection' ); ?>
 			</p>
-			<ul class="ereader-article-list ereader-pending-list">
+			<ul class="post-collection-article-list post-collection-pending-list">
 					<?php foreach ( $pending_articles as $article ) : ?>
-						<li class="ereader-article-item" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
-							<div class="ereader-article-header">
-								<a href="<?php echo esc_url( $article['permalink'] ); ?>" class="ereader-article-title" target="_blank">
+						<li class="post-collection-article-item" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
+							<div class="post-collection-article-header">
+								<a href="<?php echo esc_url( $article['permalink'] ); ?>" class="post-collection-article-title" target="_blank">
 									<?php echo esc_html( $article['title'] ); ?>
 								</a>
-								<span class="ereader-article-meta">
+								<span class="post-collection-article-meta">
 									<?php echo esc_html( $article['author'] ); ?>
 									<?php if ( $article['sent_date'] ) : ?>
 										&bull; <?php echo esc_html( $article['sent_date'] ); ?>
@@ -56,11 +58,11 @@ $statuses = \PostCollection\Article_Notes::get_statuses();
 								</span>
 							</div>
 
-							<div class="ereader-article-controls">
-								<div class="ereader-status-buttons">
+							<div class="post-collection-article-controls">
+								<div class="post-collection-status-buttons">
 									<?php foreach ( $statuses as $status_key => $status_label ) : ?>
 										<button type="button"
-											class="ereader-status-btn <?php echo $article['status'] === $status_key ? 'active' : ''; ?>"
+											class="post-collection-status-btn <?php echo $article['status'] === $status_key ? 'active' : ''; ?>"
 											data-status="<?php echo esc_attr( $status_key ); ?>"
 											title="<?php echo esc_attr( $status_label ); ?>">
 											<?php echo esc_html( $status_label ); ?>
@@ -68,56 +70,56 @@ $statuses = \PostCollection\Article_Notes::get_statuses();
 									<?php endforeach; ?>
 								</div>
 
-								<div class="ereader-rating" data-rating="<?php echo esc_attr( $article['rating'] ); ?>">
+								<div class="post-collection-rating" data-rating="<?php echo esc_attr( $article['rating'] ); ?>">
 									<?php for ( $i = 1; $i <= 5; $i++ ) : ?>
 										<button type="button"
-											class="ereader-star <?php echo $i <= $article['rating'] ? 'active' : ''; ?>"
+											class="post-collection-star <?php echo $i <= $article['rating'] ? 'active' : ''; ?>"
 											data-rating="<?php echo esc_attr( $i ); ?>"
-											title="<?php echo esc_attr( sprintf( __( '%d stars', 'send-to-e-reader' ), $i ) ); ?>">
+											title="<?php echo esc_attr( sprintf( __( '%d stars', 'post-collection' ), $i ) ); ?>">
 											<?php echo $i <= $article['rating'] ? '&#9733;' : '&#9734;'; ?>
 										</button>
 									<?php endfor; ?>
 								</div>
 							</div>
 
-							<div class="ereader-notes-wrapper">
+							<div class="post-collection-notes-wrapper">
 								<textarea
-									class="ereader-notes"
-									placeholder="<?php esc_attr_e( 'Add your notes...', 'send-to-e-reader' ); ?>"
+									class="post-collection-notes"
+									placeholder="<?php esc_attr_e( 'Add your notes...', 'post-collection' ); ?>"
 									rows="2"><?php echo esc_textarea( $article['notes'] ); ?></textarea>
 							</div>
 
-							<div class="ereader-save-status"></div>
+							<div class="post-collection-save-status"></div>
 						</li>
 					<?php endforeach; ?>
 				</ul>
 				<?php if ( $has_more_pending ) : ?>
-					<div class="ereader-load-more-section">
-						<button type="button" class="button ereader-load-more-btn" data-type="pending" data-offset="<?php echo count( $pending_articles ); ?>">
-							<?php esc_html_e( 'Load more', 'send-to-e-reader' ); ?>
+					<div class="post-collection-load-more-section">
+						<button type="button" class="button post-collection-load-more-btn" data-type="pending" data-offset="<?php echo count( $pending_articles ); ?>">
+							<?php esc_html_e( 'Load more', 'post-collection' ); ?>
 						</button>
 					</div>
 				<?php endif; ?>
 			<?php endif; ?>
 		</div>
 
-		<div class="ereader-tab-content" data-tab="unread">
+		<div class="post-collection-tab-content" data-tab="unread">
 			<?php if ( empty( $unread_articles ) ) : ?>
-				<p class="ereader-no-articles">
-					<?php esc_html_e( 'No unread articles.', 'send-to-e-reader' ); ?>
+				<p class="post-collection-no-articles">
+					<?php esc_html_e( 'No unread articles.', 'post-collection' ); ?>
 				</p>
 			<?php else : ?>
-				<p class="ereader-tab-hint">
-				<?php esc_html_e( 'Articles marked as "Not read yet". Mark as Read or Skipped to move to Reviewed.', 'send-to-e-reader' ); ?>
+				<p class="post-collection-tab-hint">
+				<?php esc_html_e( 'Articles marked as "Not read yet". Mark as Read or Skipped to move to Reviewed.', 'post-collection' ); ?>
 			</p>
-			<ul class="ereader-article-list ereader-unread-list">
+			<ul class="post-collection-article-list post-collection-unread-list">
 					<?php foreach ( $unread_articles as $article ) : ?>
-						<li class="ereader-article-item" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
-							<div class="ereader-article-header">
-								<a href="<?php echo esc_url( $article['permalink'] ); ?>" class="ereader-article-title" target="_blank">
+						<li class="post-collection-article-item" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
+							<div class="post-collection-article-header">
+								<a href="<?php echo esc_url( $article['permalink'] ); ?>" class="post-collection-article-title" target="_blank">
 									<?php echo esc_html( $article['title'] ); ?>
 								</a>
-								<span class="ereader-article-meta">
+								<span class="post-collection-article-meta">
 									<?php echo esc_html( $article['author'] ); ?>
 									<?php if ( $article['sent_date'] ) : ?>
 										&bull; <?php echo esc_html( $article['sent_date'] ); ?>
@@ -125,11 +127,11 @@ $statuses = \PostCollection\Article_Notes::get_statuses();
 								</span>
 							</div>
 
-							<div class="ereader-article-controls">
-								<div class="ereader-status-buttons">
+							<div class="post-collection-article-controls">
+								<div class="post-collection-status-buttons">
 									<?php foreach ( $statuses as $status_key => $status_label ) : ?>
 										<button type="button"
-											class="ereader-status-btn <?php echo $article['status'] === $status_key ? 'active' : ''; ?>"
+											class="post-collection-status-btn <?php echo $article['status'] === $status_key ? 'active' : ''; ?>"
 											data-status="<?php echo esc_attr( $status_key ); ?>"
 											title="<?php echo esc_attr( $status_label ); ?>">
 											<?php echo esc_html( $status_label ); ?>
@@ -137,59 +139,59 @@ $statuses = \PostCollection\Article_Notes::get_statuses();
 									<?php endforeach; ?>
 								</div>
 
-								<div class="ereader-rating" data-rating="<?php echo esc_attr( $article['rating'] ); ?>">
+								<div class="post-collection-rating" data-rating="<?php echo esc_attr( $article['rating'] ); ?>">
 									<?php for ( $i = 1; $i <= 5; $i++ ) : ?>
 										<button type="button"
-											class="ereader-star <?php echo $i <= $article['rating'] ? 'active' : ''; ?>"
+											class="post-collection-star <?php echo $i <= $article['rating'] ? 'active' : ''; ?>"
 											data-rating="<?php echo esc_attr( $i ); ?>"
-											title="<?php echo esc_attr( sprintf( __( '%d stars', 'send-to-e-reader' ), $i ) ); ?>">
+											title="<?php echo esc_attr( sprintf( __( '%d stars', 'post-collection' ), $i ) ); ?>">
 											<?php echo $i <= $article['rating'] ? '&#9733;' : '&#9734;'; ?>
 										</button>
 									<?php endfor; ?>
 								</div>
 							</div>
 
-							<div class="ereader-notes-wrapper">
+							<div class="post-collection-notes-wrapper">
 								<textarea
-									class="ereader-notes"
-									placeholder="<?php esc_attr_e( 'Add your notes...', 'send-to-e-reader' ); ?>"
+									class="post-collection-notes"
+									placeholder="<?php esc_attr_e( 'Add your notes...', 'post-collection' ); ?>"
 									rows="2"><?php echo esc_textarea( $article['notes'] ); ?></textarea>
 							</div>
 
-							<div class="ereader-save-status"></div>
+							<div class="post-collection-save-status"></div>
 						</li>
 					<?php endforeach; ?>
 				</ul>
 				<?php if ( $has_more_unread ) : ?>
-					<div class="ereader-load-more-section">
-						<button type="button" class="button ereader-load-more-btn" data-type="unread" data-offset="<?php echo count( $unread_articles ); ?>">
-							<?php esc_html_e( 'Load more', 'send-to-e-reader' ); ?>
+					<div class="post-collection-load-more-section">
+						<button type="button" class="button post-collection-load-more-btn" data-type="unread" data-offset="<?php echo count( $unread_articles ); ?>">
+							<?php esc_html_e( 'Load more', 'post-collection' ); ?>
 						</button>
 					</div>
 				<?php endif; ?>
 			<?php endif; ?>
 		</div>
 
-		<div class="ereader-tab-content" data-tab="reviewed">
+		<div class="post-collection-tab-content" data-tab="reviewed">
 			<?php if ( empty( $reviewed_articles ) ) : ?>
-				<p class="ereader-no-articles">
-					<?php esc_html_e( 'No reviewed articles yet.', 'send-to-e-reader' ); ?>
+				<p class="post-collection-no-articles">
+					<?php esc_html_e( 'No reviewed articles yet.', 'post-collection' ); ?>
 				</p>
 			<?php else : ?>
-				<p class="ereader-tab-hint">
-				<?php esc_html_e( 'Select articles to create a post, or Archive to hide from this list.', 'send-to-e-reader' ); ?>
+				<p class="post-collection-tab-hint">
+				<?php esc_html_e( 'Select articles to create a post, or Archive to hide from this list.', 'post-collection' ); ?>
 			</p>
-			<ul class="ereader-article-list ereader-reviewed-list">
+			<ul class="post-collection-article-list post-collection-reviewed-list">
 					<?php foreach ( $reviewed_articles as $article ) : ?>
-						<li class="ereader-article-item" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
-							<div class="ereader-article-header">
-								<label class="ereader-select-article">
+						<li class="post-collection-article-item" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
+							<div class="post-collection-article-header">
+								<label class="post-collection-select-article">
 									<input type="checkbox" name="selected_articles[]" value="<?php echo esc_attr( $article['id'] ); ?>">
-									<a href="<?php echo esc_url( $article['permalink'] ); ?>" class="ereader-article-title" target="_blank">
+									<a href="<?php echo esc_url( $article['permalink'] ); ?>" class="post-collection-article-title" target="_blank">
 										<?php echo esc_html( $article['title'] ); ?>
 									</a>
 								</label>
-								<span class="ereader-article-meta">
+								<span class="post-collection-article-meta">
 									<?php echo esc_html( $article['author'] ); ?>
 									<?php if ( $article['rating'] > 0 ) : ?>
 										&bull; <?php echo str_repeat( '&#9733;', $article['rating'] ); ?>
@@ -197,11 +199,11 @@ $statuses = \PostCollection\Article_Notes::get_statuses();
 								</span>
 							</div>
 
-							<div class="ereader-article-controls">
-								<div class="ereader-status-buttons">
+							<div class="post-collection-article-controls">
+								<div class="post-collection-status-buttons">
 									<?php foreach ( $statuses as $status_key => $status_label ) : ?>
 										<button type="button"
-											class="ereader-status-btn <?php echo $article['status'] === $status_key ? 'active' : ''; ?>"
+											class="post-collection-status-btn <?php echo $article['status'] === $status_key ? 'active' : ''; ?>"
 											data-status="<?php echo esc_attr( $status_key ); ?>"
 											title="<?php echo esc_attr( $status_label ); ?>">
 											<?php echo esc_html( $status_label ); ?>
@@ -209,47 +211,47 @@ $statuses = \PostCollection\Article_Notes::get_statuses();
 									<?php endforeach; ?>
 								</div>
 
-								<div class="ereader-rating" data-rating="<?php echo esc_attr( $article['rating'] ); ?>">
+								<div class="post-collection-rating" data-rating="<?php echo esc_attr( $article['rating'] ); ?>">
 									<?php for ( $i = 1; $i <= 5; $i++ ) : ?>
 										<button type="button"
-											class="ereader-star <?php echo $i <= $article['rating'] ? 'active' : ''; ?>"
+											class="post-collection-star <?php echo $i <= $article['rating'] ? 'active' : ''; ?>"
 											data-rating="<?php echo esc_attr( $i ); ?>"
-											title="<?php echo esc_attr( sprintf( __( '%d stars', 'send-to-e-reader' ), $i ) ); ?>">
+											title="<?php echo esc_attr( sprintf( __( '%d stars', 'post-collection' ), $i ) ); ?>">
 											<?php echo $i <= $article['rating'] ? '&#9733;' : '&#9734;'; ?>
 										</button>
 									<?php endfor; ?>
 								</div>
 
-								<button type="button" class="ereader-archive-btn" title="<?php esc_attr_e( 'Archive - hide from this list', 'send-to-e-reader' ); ?>">
-									<?php esc_html_e( 'Archive', 'send-to-e-reader' ); ?>
+								<button type="button" class="post-collection-archive-btn" title="<?php esc_attr_e( 'Archive - hide from this list', 'post-collection' ); ?>">
+									<?php esc_html_e( 'Archive', 'post-collection' ); ?>
 								</button>
 							</div>
 
 							<?php if ( ! empty( $article['notes'] ) ) : ?>
-								<div class="ereader-notes-preview">
+								<div class="post-collection-notes-preview">
 									<?php echo esc_html( wp_trim_words( $article['notes'], 20 ) ); ?>
 								</div>
 							<?php endif; ?>
 
-							<div class="ereader-notes-wrapper" style="display: none;">
+							<div class="post-collection-notes-wrapper" style="display: none;">
 								<textarea
-									class="ereader-notes"
-									placeholder="<?php esc_attr_e( 'Add your notes...', 'send-to-e-reader' ); ?>"
+									class="post-collection-notes"
+									placeholder="<?php esc_attr_e( 'Add your notes...', 'post-collection' ); ?>"
 									rows="2"><?php echo esc_textarea( $article['notes'] ); ?></textarea>
 							</div>
 
-							<div class="ereader-save-status"></div>
+							<div class="post-collection-save-status"></div>
 						</li>
 					<?php endforeach; ?>
 				</ul>
 
-				<div class="ereader-create-post-section">
+				<div class="post-collection-create-post-section">
 					<input type="text"
-						id="ereader-post-title"
-						class="ereader-post-title-input"
-						placeholder="<?php esc_attr_e( 'Post title (optional)', 'send-to-e-reader' ); ?>">
-					<button type="button" class="button button-primary ereader-create-post-btn">
-						<?php esc_html_e( 'Create Post from Selected', 'send-to-e-reader' ); ?>
+						id="post-collection-post-title"
+						class="post-collection-post-title-input"
+						placeholder="<?php esc_attr_e( 'Post title (optional)', 'post-collection' ); ?>">
+					<button type="button" class="button button-primary post-collection-create-post-btn">
+						<?php esc_html_e( 'Create Post from Selected', 'post-collection' ); ?>
 					</button>
 				</div>
 			<?php endif; ?>

--- a/templates/admin/article-notes-widget.php
+++ b/templates/admin/article-notes-widget.php
@@ -10,6 +10,7 @@ defined( 'ABSPATH' ) || exit;
 $pending_articles   = isset( $args['pending_articles'] ) ? $args['pending_articles'] : array();
 $has_more_pending   = isset( $args['has_more_pending'] ) ? $args['has_more_pending'] : false;
 $reviewed_articles  = isset( $args['reviewed_articles'] ) ? $args['reviewed_articles'] : array();
+$show_tabs          = isset( $args['show_tabs'] ) ? $args['show_tabs'] : true;
 $random_remembered  = isset( $args['random_remembered'] ) ? $args['random_remembered'] : null;
 $nonce              = isset( $args['nonce'] ) ? $args['nonce'] : '';
 $statuses           = \PostCollection\Article_Notes::get_statuses();
@@ -27,11 +28,13 @@ $statuses           = \PostCollection\Article_Notes::get_statuses();
 		</div>
 	<?php endif; ?>
 
-	<?php if ( empty( $pending_articles ) && empty( $reviewed_articles ) ) : ?>
+	<?php if ( ! $random_remembered && ! $show_tabs ) : ?>
 		<p class="post-collection-no-articles">
 			<?php esc_html_e( 'No articles in your collection yet. Collect posts from the web to start adding notes and reviews.', 'post-collection' ); ?>
 		</p>
-	<?php else : ?>
+	<?php endif; ?>
+
+	<?php if ( $show_tabs && ( ! empty( $pending_articles ) || ! empty( $reviewed_articles ) ) ) : ?>
 		<div class="post-collection-widget-tabs">
 			<button type="button" class="post-collection-tab active" data-tab="pending">
 				<?php esc_html_e( 'Pending', 'post-collection' ); ?>

--- a/templates/admin/article-notes-widget.php
+++ b/templates/admin/article-notes-widget.php
@@ -17,15 +17,24 @@ $statuses           = \PostCollection\Article_Notes::get_statuses();
 
 <div class="post-collection-article-notes-widget" data-nonce="<?php echo esc_attr( $nonce ); ?>">
 	<?php if ( $random_remembered ) : ?>
-		<div class="post-collection-remember">
+		<div class="post-collection-remember" data-article-id="<?php echo esc_attr( $random_remembered['id'] ); ?>">
 			<div class="post-collection-remember-header">
 				<span class="post-collection-remember-label"><?php esc_html_e( 'From your notes:', 'post-collection' ); ?></span>
 				<a href="#" class="post-collection-remember-another"><?php esc_html_e( 'Show another', 'post-collection' ); ?> &rarr;</a>
 			</div>
-			<a href="<?php echo esc_url( $random_remembered['permalink'] ); ?>" class="post-collection-remember-title" target="_blank">
-				<?php echo esc_html( $random_remembered['title'] ); ?>
-			</a>
-			<span class="post-collection-remember-meta"><?php echo esc_html( $random_remembered['author'] ); ?></span>
+			<div class="post-collection-article-header">
+				<span class="post-collection-title-wrapper">
+					<a href="<?php echo esc_url( $random_remembered['permalink'] ); ?>" class="post-collection-article-title" target="_blank"><?php echo esc_html( $random_remembered['title'] ); ?></a>
+					<button type="button" class="post-collection-edit-title-btn" title="<?php esc_attr_e( 'Edit title', 'post-collection' ); ?>">&#9998;</button>
+					<input type="text" class="post-collection-title-input" value="<?php echo esc_attr( $random_remembered['title'] ); ?>">
+				</span>
+				<span class="post-collection-article-meta">
+					<?php echo esc_html( $random_remembered['author'] ); ?>
+					<?php if ( ! empty( $random_remembered['collection'] ) && $random_remembered['collection'] !== $random_remembered['author'] ) : ?>
+						&bull; <?php echo esc_html( $random_remembered['collection'] ); ?>
+					<?php endif; ?>
+				</span>
+			</div>
 			<blockquote class="post-collection-remember-notes">
 				<?php echo wp_kses_post( $random_remembered['notes'] ); ?>
 			</blockquote>
@@ -37,6 +46,7 @@ $statuses           = \PostCollection\Article_Notes::get_statuses();
 					</div>
 				</details>
 			<?php endif; ?>
+			<div class="post-collection-save-status"></div>
 		</div>
 	<?php endif; ?>
 

--- a/templates/admin/article-notes-widget.php
+++ b/templates/admin/article-notes-widget.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * Article Notes Dashboard Widget Template
+ *
+ * @package Post_Collection
+ */
+
+$pending_articles = isset( $args['pending_articles'] ) ? $args['pending_articles'] : array();
+$has_more_pending = isset( $args['has_more_pending'] ) ? $args['has_more_pending'] : false;
+$unread_articles = isset( $args['unread_articles'] ) ? $args['unread_articles'] : array();
+$has_more_unread = isset( $args['has_more_unread'] ) ? $args['has_more_unread'] : false;
+$reviewed_articles = isset( $args['reviewed_articles'] ) ? $args['reviewed_articles'] : array();
+$nonce = isset( $args['nonce'] ) ? $args['nonce'] : '';
+$statuses = \PostCollection\Article_Notes::get_statuses();
+?>
+
+<div class="ereader-article-notes-widget" data-nonce="<?php echo esc_attr( $nonce ); ?>">
+	<?php if ( empty( $pending_articles ) && empty( $unread_articles ) && empty( $reviewed_articles ) ) : ?>
+		<p class="ereader-no-articles">
+			<?php esc_html_e( 'No articles have been sent to your e-reader yet.', 'send-to-e-reader' ); ?>
+		</p>
+	<?php else : ?>
+		<div class="ereader-widget-tabs">
+			<button type="button" class="ereader-tab active" data-tab="pending">
+				<?php esc_html_e( 'Pending', 'send-to-e-reader' ); ?>
+			</button>
+			<button type="button" class="ereader-tab" data-tab="unread">
+				<?php esc_html_e( 'Unread', 'send-to-e-reader' ); ?>
+			</button>
+			<button type="button" class="ereader-tab" data-tab="reviewed">
+				<?php esc_html_e( 'Reviewed', 'send-to-e-reader' ); ?>
+			</button>
+		</div>
+
+		<div class="ereader-tab-content active" data-tab="pending">
+			<?php if ( empty( $pending_articles ) ) : ?>
+				<p class="ereader-no-articles">
+					<?php esc_html_e( 'No new articles to review.', 'send-to-e-reader' ); ?>
+				</p>
+			<?php else : ?>
+				<p class="ereader-tab-hint">
+				<?php esc_html_e( 'Mark your reading status. Articles move to Unread or Reviewed tab.', 'send-to-e-reader' ); ?>
+			</p>
+			<ul class="ereader-article-list ereader-pending-list">
+					<?php foreach ( $pending_articles as $article ) : ?>
+						<li class="ereader-article-item" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
+							<div class="ereader-article-header">
+								<a href="<?php echo esc_url( $article['permalink'] ); ?>" class="ereader-article-title" target="_blank">
+									<?php echo esc_html( $article['title'] ); ?>
+								</a>
+								<span class="ereader-article-meta">
+									<?php echo esc_html( $article['author'] ); ?>
+									<?php if ( $article['sent_date'] ) : ?>
+										&bull; <?php echo esc_html( $article['sent_date'] ); ?>
+									<?php endif; ?>
+								</span>
+							</div>
+
+							<div class="ereader-article-controls">
+								<div class="ereader-status-buttons">
+									<?php foreach ( $statuses as $status_key => $status_label ) : ?>
+										<button type="button"
+											class="ereader-status-btn <?php echo $article['status'] === $status_key ? 'active' : ''; ?>"
+											data-status="<?php echo esc_attr( $status_key ); ?>"
+											title="<?php echo esc_attr( $status_label ); ?>">
+											<?php echo esc_html( $status_label ); ?>
+										</button>
+									<?php endforeach; ?>
+								</div>
+
+								<div class="ereader-rating" data-rating="<?php echo esc_attr( $article['rating'] ); ?>">
+									<?php for ( $i = 1; $i <= 5; $i++ ) : ?>
+										<button type="button"
+											class="ereader-star <?php echo $i <= $article['rating'] ? 'active' : ''; ?>"
+											data-rating="<?php echo esc_attr( $i ); ?>"
+											title="<?php echo esc_attr( sprintf( __( '%d stars', 'send-to-e-reader' ), $i ) ); ?>">
+											<?php echo $i <= $article['rating'] ? '&#9733;' : '&#9734;'; ?>
+										</button>
+									<?php endfor; ?>
+								</div>
+							</div>
+
+							<div class="ereader-notes-wrapper">
+								<textarea
+									class="ereader-notes"
+									placeholder="<?php esc_attr_e( 'Add your notes...', 'send-to-e-reader' ); ?>"
+									rows="2"><?php echo esc_textarea( $article['notes'] ); ?></textarea>
+							</div>
+
+							<div class="ereader-save-status"></div>
+						</li>
+					<?php endforeach; ?>
+				</ul>
+				<?php if ( $has_more_pending ) : ?>
+					<div class="ereader-load-more-section">
+						<button type="button" class="button ereader-load-more-btn" data-type="pending" data-offset="<?php echo count( $pending_articles ); ?>">
+							<?php esc_html_e( 'Load more', 'send-to-e-reader' ); ?>
+						</button>
+					</div>
+				<?php endif; ?>
+			<?php endif; ?>
+		</div>
+
+		<div class="ereader-tab-content" data-tab="unread">
+			<?php if ( empty( $unread_articles ) ) : ?>
+				<p class="ereader-no-articles">
+					<?php esc_html_e( 'No unread articles.', 'send-to-e-reader' ); ?>
+				</p>
+			<?php else : ?>
+				<p class="ereader-tab-hint">
+				<?php esc_html_e( 'Articles marked as "Not read yet". Mark as Read or Skipped to move to Reviewed.', 'send-to-e-reader' ); ?>
+			</p>
+			<ul class="ereader-article-list ereader-unread-list">
+					<?php foreach ( $unread_articles as $article ) : ?>
+						<li class="ereader-article-item" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
+							<div class="ereader-article-header">
+								<a href="<?php echo esc_url( $article['permalink'] ); ?>" class="ereader-article-title" target="_blank">
+									<?php echo esc_html( $article['title'] ); ?>
+								</a>
+								<span class="ereader-article-meta">
+									<?php echo esc_html( $article['author'] ); ?>
+									<?php if ( $article['sent_date'] ) : ?>
+										&bull; <?php echo esc_html( $article['sent_date'] ); ?>
+									<?php endif; ?>
+								</span>
+							</div>
+
+							<div class="ereader-article-controls">
+								<div class="ereader-status-buttons">
+									<?php foreach ( $statuses as $status_key => $status_label ) : ?>
+										<button type="button"
+											class="ereader-status-btn <?php echo $article['status'] === $status_key ? 'active' : ''; ?>"
+											data-status="<?php echo esc_attr( $status_key ); ?>"
+											title="<?php echo esc_attr( $status_label ); ?>">
+											<?php echo esc_html( $status_label ); ?>
+										</button>
+									<?php endforeach; ?>
+								</div>
+
+								<div class="ereader-rating" data-rating="<?php echo esc_attr( $article['rating'] ); ?>">
+									<?php for ( $i = 1; $i <= 5; $i++ ) : ?>
+										<button type="button"
+											class="ereader-star <?php echo $i <= $article['rating'] ? 'active' : ''; ?>"
+											data-rating="<?php echo esc_attr( $i ); ?>"
+											title="<?php echo esc_attr( sprintf( __( '%d stars', 'send-to-e-reader' ), $i ) ); ?>">
+											<?php echo $i <= $article['rating'] ? '&#9733;' : '&#9734;'; ?>
+										</button>
+									<?php endfor; ?>
+								</div>
+							</div>
+
+							<div class="ereader-notes-wrapper">
+								<textarea
+									class="ereader-notes"
+									placeholder="<?php esc_attr_e( 'Add your notes...', 'send-to-e-reader' ); ?>"
+									rows="2"><?php echo esc_textarea( $article['notes'] ); ?></textarea>
+							</div>
+
+							<div class="ereader-save-status"></div>
+						</li>
+					<?php endforeach; ?>
+				</ul>
+				<?php if ( $has_more_unread ) : ?>
+					<div class="ereader-load-more-section">
+						<button type="button" class="button ereader-load-more-btn" data-type="unread" data-offset="<?php echo count( $unread_articles ); ?>">
+							<?php esc_html_e( 'Load more', 'send-to-e-reader' ); ?>
+						</button>
+					</div>
+				<?php endif; ?>
+			<?php endif; ?>
+		</div>
+
+		<div class="ereader-tab-content" data-tab="reviewed">
+			<?php if ( empty( $reviewed_articles ) ) : ?>
+				<p class="ereader-no-articles">
+					<?php esc_html_e( 'No reviewed articles yet.', 'send-to-e-reader' ); ?>
+				</p>
+			<?php else : ?>
+				<p class="ereader-tab-hint">
+				<?php esc_html_e( 'Select articles to create a post, or Archive to hide from this list.', 'send-to-e-reader' ); ?>
+			</p>
+			<ul class="ereader-article-list ereader-reviewed-list">
+					<?php foreach ( $reviewed_articles as $article ) : ?>
+						<li class="ereader-article-item" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
+							<div class="ereader-article-header">
+								<label class="ereader-select-article">
+									<input type="checkbox" name="selected_articles[]" value="<?php echo esc_attr( $article['id'] ); ?>">
+									<a href="<?php echo esc_url( $article['permalink'] ); ?>" class="ereader-article-title" target="_blank">
+										<?php echo esc_html( $article['title'] ); ?>
+									</a>
+								</label>
+								<span class="ereader-article-meta">
+									<?php echo esc_html( $article['author'] ); ?>
+									<?php if ( $article['rating'] > 0 ) : ?>
+										&bull; <?php echo str_repeat( '&#9733;', $article['rating'] ); ?>
+									<?php endif; ?>
+								</span>
+							</div>
+
+							<div class="ereader-article-controls">
+								<div class="ereader-status-buttons">
+									<?php foreach ( $statuses as $status_key => $status_label ) : ?>
+										<button type="button"
+											class="ereader-status-btn <?php echo $article['status'] === $status_key ? 'active' : ''; ?>"
+											data-status="<?php echo esc_attr( $status_key ); ?>"
+											title="<?php echo esc_attr( $status_label ); ?>">
+											<?php echo esc_html( $status_label ); ?>
+										</button>
+									<?php endforeach; ?>
+								</div>
+
+								<div class="ereader-rating" data-rating="<?php echo esc_attr( $article['rating'] ); ?>">
+									<?php for ( $i = 1; $i <= 5; $i++ ) : ?>
+										<button type="button"
+											class="ereader-star <?php echo $i <= $article['rating'] ? 'active' : ''; ?>"
+											data-rating="<?php echo esc_attr( $i ); ?>"
+											title="<?php echo esc_attr( sprintf( __( '%d stars', 'send-to-e-reader' ), $i ) ); ?>">
+											<?php echo $i <= $article['rating'] ? '&#9733;' : '&#9734;'; ?>
+										</button>
+									<?php endfor; ?>
+								</div>
+
+								<button type="button" class="ereader-archive-btn" title="<?php esc_attr_e( 'Archive - hide from this list', 'send-to-e-reader' ); ?>">
+									<?php esc_html_e( 'Archive', 'send-to-e-reader' ); ?>
+								</button>
+							</div>
+
+							<?php if ( ! empty( $article['notes'] ) ) : ?>
+								<div class="ereader-notes-preview">
+									<?php echo esc_html( wp_trim_words( $article['notes'], 20 ) ); ?>
+								</div>
+							<?php endif; ?>
+
+							<div class="ereader-notes-wrapper" style="display: none;">
+								<textarea
+									class="ereader-notes"
+									placeholder="<?php esc_attr_e( 'Add your notes...', 'send-to-e-reader' ); ?>"
+									rows="2"><?php echo esc_textarea( $article['notes'] ); ?></textarea>
+							</div>
+
+							<div class="ereader-save-status"></div>
+						</li>
+					<?php endforeach; ?>
+				</ul>
+
+				<div class="ereader-create-post-section">
+					<input type="text"
+						id="ereader-post-title"
+						class="ereader-post-title-input"
+						placeholder="<?php esc_attr_e( 'Post title (optional)', 'send-to-e-reader' ); ?>">
+					<button type="button" class="button button-primary ereader-create-post-btn">
+						<?php esc_html_e( 'Create Post from Selected', 'send-to-e-reader' ); ?>
+					</button>
+				</div>
+			<?php endif; ?>
+		</div>
+	<?php endif; ?>
+</div>

--- a/templates/frontend/article-notes.php
+++ b/templates/frontend/article-notes.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Article Notes Frontend Template
+ *
+ * Displayed below a single post on the Friends frontend.
+ *
+ * @package Post_Collection
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$article  = isset( $args['article'] ) ? $args['article'] : array();
+$statuses = isset( $args['statuses'] ) ? $args['statuses'] : array();
+$nonce    = isset( $args['nonce'] ) ? $args['nonce'] : '';
+
+if ( empty( $article ) ) {
+	return;
+}
+?>
+<div class="post-collection-frontend-notes post-collection-article-item" data-article-id="<?php echo esc_attr( $article['id'] ); ?>" data-nonce="<?php echo esc_attr( $nonce ); ?>">
+	<div class="post-collection-article-controls">
+		<div class="post-collection-status-buttons">
+			<?php foreach ( $statuses as $status_key => $status_label ) : ?>
+				<button type="button"
+					class="post-collection-status-btn <?php echo ( $article['note_id'] && $article['status'] === $status_key ) ? 'active' : ''; ?>"
+					data-status="<?php echo esc_attr( $status_key ); ?>"
+					title="<?php echo esc_attr( $status_label ); ?>">
+					<?php echo esc_html( $status_label ); ?>
+				</button>
+			<?php endforeach; ?>
+		</div>
+
+		<div class="post-collection-rating" data-rating="<?php echo esc_attr( $article['rating'] ); ?>">
+			<?php for ( $i = 1; $i <= 5; $i++ ) : ?>
+				<button type="button"
+					class="post-collection-star <?php echo $i <= $article['rating'] ? 'active' : ''; ?>"
+					data-rating="<?php echo esc_attr( $i ); ?>"
+					title="<?php echo esc_attr( sprintf( __( '%d stars', 'post-collection' ), $i ) ); ?>">
+					<?php echo $i <= $article['rating'] ? '&#9733;' : '&#9734;'; ?>
+				</button>
+			<?php endfor; ?>
+		</div>
+	</div>
+
+	<div class="post-collection-notes-wrapper">
+		<textarea
+			class="post-collection-notes"
+			placeholder="<?php esc_attr_e( 'Add your notes...', 'post-collection' ); ?>"
+			rows="3"><?php echo esc_textarea( $article['notes'] ); ?></textarea>
+		<div class="post-collection-notes-actions">
+			<button type="button" class="button button-small post-collection-save-notes-btn">
+				<?php esc_html_e( 'Save', 'post-collection' ); ?>
+			</button>
+			<span class="post-collection-save-status"></span>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
## Summary

- Imports `Article_Notes` class with all associated CSS, JS, and templates from the [send-to-e-reader](https://github.com/akirk/send-to-e-reader) plugin
- Wires `Article_Notes` into `Post_Collection` via constructor instantiation and a `get_article_notes()` accessor
- Adds `get_post_author_name()` and `get_template_loader()` helper methods to `Post_Collection`
- Adds `POST_COLLECTION_VERSION` constant and fixes plugin header (Author/Author URI)
- Exposes `post_collection_article_queued_meta_query` and `post_collection_article_queued_orderby_meta_key` filters so send-to-e-reader can mark queued articles by their post meta

## Test plan

- [ ] Verify article notes dashboard widget appears and functions correctly
- [ ] Verify admin menu page for article notes loads
- [ ] Verify sent-to-e-reader articles appear as queued in the widget
- [ ] Verify note saving/loading AJAX actions work