### PR TITLE
Add wp-app frontend collection views

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Contributors:** akirk
 **Requires at least:** 5.0
 **Tested up to:** 6.9
-**Requires PHP:** 7.1
+**Requires PHP:** 7.4
 **License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 **Stable tag:** 2.0.0
@@ -62,4 +62,3 @@ This plugin provides the facilities to store feed items in a separate post type.
 [#5]: https://github.com/akirk/post-collection/pull/5
 [#4]: https://github.com/akirk/post-collection/pull/4
 [#3]: https://github.com/akirk/post-collection/pull/3
-

--- a/assets/css/post-collection-app.css
+++ b/assets/css/post-collection-app.css
@@ -46,6 +46,18 @@ body.post-collection-app {
 	padding: 48px 0 24px;
 }
 
+body.pc-settings-page .pc-detail-header {
+	max-width: none;
+}
+
+body.pc-post-detail-page .pc-detail-header {
+	max-width: none;
+}
+
+body.pc-new-collection-page .pc-detail-header {
+	max-width: none;
+}
+
 .pc-app-header {
 	display: flex;
 	align-items: flex-end;
@@ -130,6 +142,7 @@ body.post-collection-app {
 	border-radius: 8px;
 	background: var(--pc-color-surface);
 	color: var(--pc-color-text);
+	font: inherit;
 	font-weight: 700;
 	text-decoration: none;
 	cursor: pointer;
@@ -190,6 +203,14 @@ body.post-collection-app {
 	overflow: hidden;
 }
 
+.pc-collection-card-bookmarks {
+	border-top: 4px solid #008a20;
+}
+
+.pc-collection-card-posts {
+	border-top: 4px solid var(--pc-color-primary);
+}
+
 .pc-collection-card-main {
 	display: flex;
 	flex: 1;
@@ -210,12 +231,12 @@ body.post-collection-app {
 }
 
 .pc-collection-card-bookmarks .pc-mode-label {
-	background: var(--pc-color-surface-alt);
-	color: var(--pc-color-primary);
+	background: #e6f4ea;
+	color: #0a6f22;
 }
 
 .pc-collection-card-posts .pc-mode-label {
-	background: var(--pc-color-surface-alt);
+	background: #eaf2f8;
 	color: var(--pc-color-primary);
 }
 
@@ -237,21 +258,90 @@ body.post-collection-app {
 	font-size: 0.92rem;
 }
 
+.pc-collection-card-bookmarks .pc-count {
+	color: #0a6f22;
+}
+
+.pc-collection-card-posts .pc-count {
+	color: var(--pc-color-primary);
+}
+
+.pc-hidden-collections {
+	margin-top: 0;
+	padding-bottom: 56px;
+}
+
+.pc-collection-grid + .pc-hidden-collections {
+	margin-top: -28px;
+}
+
+.pc-hidden-collections summary {
+	width: max-content;
+	color: var(--pc-color-muted);
+	font-size: 0.92rem;
+	font-weight: 700;
+	cursor: pointer;
+}
+
+.pc-hidden-collections summary:hover,
+.pc-hidden-collections summary:focus {
+	color: var(--pc-color-primary);
+}
+
+.pc-collection-grid-hidden {
+	margin-top: 16px;
+	padding-bottom: 0;
+}
+
+.pc-muted-note {
+	margin: 0 0 18px;
+	color: var(--pc-color-muted);
+}
+
+.pc-mini-list-wrap {
+	padding: 12px 20px 18px;
+	border-top: 1px solid var(--pc-color-border);
+}
+
+.pc-mini-list-title {
+	margin: 0 0 8px;
+	color: var(--pc-color-muted);
+	font-size: 0.76rem;
+	font-weight: 700;
+	text-transform: uppercase;
+}
+
 .pc-mini-list {
 	display: grid;
 	gap: 8px;
 	margin: 0;
-	padding: 14px 20px 18px;
-	border-top: 1px solid var(--pc-color-border);
+	padding: 0;
 	list-style: none;
 }
 
 .post-collection-app .pc-mini-list a {
-	display: block;
+	display: grid;
+	grid-template-columns: 0.8em minmax(0, 1fr);
+	gap: 7px;
+	align-items: baseline;
 	overflow: hidden;
 	color: var(--pc-color-muted);
+	font-size: 0.92rem;
+	text-decoration: none;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.post-collection-app .pc-mini-list a::before {
+	content: "->";
+	color: currentColor;
+	font-size: 0.78em;
+}
+
+.post-collection-app .pc-mini-list a:hover,
+.post-collection-app .pc-mini-list a:focus {
+	color: var(--pc-color-primary);
+	text-decoration: underline;
 }
 
 .pc-collection-settings,
@@ -275,6 +365,37 @@ body.post-collection-app {
 	align-items: end;
 	padding: 12px;
 	margin-top: 10px;
+}
+
+.pc-settings-page-form.pc-collection-settings {
+	display: grid;
+	grid-template-columns: 1fr;
+	max-width: 680px;
+	gap: 18px;
+	margin-top: 0;
+	padding: 0;
+}
+
+.pc-settings-page-form.pc-collection-settings label {
+	gap: 8px;
+	color: var(--pc-color-text);
+	font-size: 0.95rem;
+}
+
+.pc-settings-page-form.pc-collection-settings label span {
+	color: var(--pc-color-muted);
+	font-size: 0.78rem;
+	text-transform: uppercase;
+}
+
+.pc-settings-page-form.pc-collection-settings select {
+	max-width: 420px;
+	background-color: var(--pc-color-background);
+}
+
+.pc-settings-page-form .pc-form-actions {
+	justify-content: flex-start;
+	padding-top: 2px;
 }
 
 .pc-collection-settings-panel {
@@ -308,6 +429,22 @@ body.post-collection-app {
 	font-weight: 700;
 }
 
+.pc-collection-settings .pc-checkbox-field,
+.pc-create-collection-form .pc-checkbox-field {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	color: var(--pc-color-text);
+	font-size: 0.92rem;
+}
+
+.pc-collection-settings .pc-checkbox-field input,
+.pc-create-collection-form .pc-checkbox-field input {
+	width: auto;
+	min-height: 0;
+	margin: 0;
+}
+
 .pc-collection-settings select,
 .pc-create-collection-form input,
 .pc-create-collection-form select,
@@ -337,10 +474,7 @@ body.post-collection-app {
 	display: grid;
 	max-width: 640px;
 	gap: 14px;
-	padding: 18px;
-	border: 1px solid var(--pc-color-border);
-	border-radius: 8px;
-	background: var(--pc-color-surface);
+	padding: 0;
 }
 
 .pc-form-actions {
@@ -350,6 +484,11 @@ body.post-collection-app {
 	align-items: center;
 	justify-content: flex-end;
 	padding-top: 4px;
+}
+
+.pc-form-actions .pc-button,
+.pc-form-actions button {
+	min-width: 150px;
 }
 
 .pc-clear-link {
@@ -773,6 +912,7 @@ body.post-collection-app {
 .pc-detail-layout {
 	display: grid;
 	grid-template-columns: minmax(0, 820px);
+	justify-content: center;
 	padding-bottom: 72px;
 }
 
@@ -816,6 +956,10 @@ body.post-collection-app {
 	border-radius: 6px;
 	background: var(--pc-color-embed-background);
 	color: var(--pc-color-on-primary);
+}
+
+.pc-detail-footer-actions {
+	margin-top: 18px;
 }
 
 .pc-detail-tags {

--- a/assets/css/post-collection-app.css
+++ b/assets/css/post-collection-app.css
@@ -117,6 +117,8 @@ body.post-collection-app {
 }
 
 .post-collection-app .pc-button,
+.post-collection-app .pc-collection-settings button,
+.post-collection-app .pc-create-collection-form button,
 .post-collection-app .pc-add-form button,
 .post-collection-app .pc-filter-bar button {
 	display: inline-flex;
@@ -134,6 +136,8 @@ body.post-collection-app {
 }
 
 .post-collection-app .pc-button-primary,
+.post-collection-app .pc-collection-settings button,
+.post-collection-app .pc-create-collection-form button,
 .post-collection-app .pc-add-form button,
 .post-collection-app .pc-filter-bar button {
 	border-color: var(--pc-color-primary);
@@ -143,6 +147,10 @@ body.post-collection-app {
 
 .post-collection-app .pc-button:hover,
 .post-collection-app .pc-button:focus,
+.post-collection-app .pc-collection-settings button:hover,
+.post-collection-app .pc-collection-settings button:focus,
+.post-collection-app .pc-create-collection-form button:hover,
+.post-collection-app .pc-create-collection-form button:focus,
 .post-collection-app .pc-add-form button:hover,
 .post-collection-app .pc-add-form button:focus,
 .post-collection-app .pc-filter-bar button:hover,
@@ -153,6 +161,10 @@ body.post-collection-app {
 
 .post-collection-app .pc-button-primary:hover,
 .post-collection-app .pc-button-primary:focus,
+.post-collection-app .pc-collection-settings button:hover,
+.post-collection-app .pc-collection-settings button:focus,
+.post-collection-app .pc-create-collection-form button:hover,
+.post-collection-app .pc-create-collection-form button:focus,
 .post-collection-app .pc-add-form button:hover,
 .post-collection-app .pc-add-form button:focus,
 .post-collection-app .pc-filter-bar button:hover,
@@ -242,6 +254,7 @@ body.post-collection-app {
 	white-space: nowrap;
 }
 
+.pc-collection-settings,
 .pc-add-form,
 .pc-filter-bar {
 	display: grid;
@@ -257,10 +270,47 @@ body.post-collection-app {
 	background: var(--pc-color-surface);
 }
 
+.pc-collection-settings {
+	grid-template-columns: minmax(140px, 180px) minmax(160px, 220px) auto;
+	align-items: end;
+	padding: 12px;
+	margin-top: 10px;
+}
+
+.pc-collection-settings-panel {
+	margin-top: 18px;
+	padding-top: 14px;
+	border-top: 1px solid var(--pc-color-border);
+}
+
+.pc-collection-settings-panel summary {
+	width: max-content;
+	color: var(--pc-color-muted);
+	font-size: 0.86rem;
+	font-weight: 700;
+	cursor: pointer;
+}
+
+.pc-collection-settings-panel[open] summary {
+	color: var(--pc-color-primary);
+}
+
 .pc-filter-bar {
 	grid-template-columns: minmax(0, 1fr) auto auto;
 }
 
+.pc-collection-settings label,
+.pc-create-collection-form label {
+	display: grid;
+	gap: 4px;
+	color: var(--pc-color-muted);
+	font-size: 0.78rem;
+	font-weight: 700;
+}
+
+.pc-collection-settings select,
+.pc-create-collection-form input,
+.pc-create-collection-form select,
 .pc-add-form input,
 .pc-filter-bar input {
 	width: 100%;
@@ -273,11 +323,33 @@ body.post-collection-app {
 	font: inherit;
 }
 
+.pc-collection-settings select:focus,
+.pc-create-collection-form input:focus,
+.pc-create-collection-form select:focus,
 .pc-add-form input:focus,
 .pc-filter-bar input:focus {
 	border-color: var(--pc-color-primary);
 	outline: 2px solid var(--pc-color-focus);
 	outline-offset: 1px;
+}
+
+.pc-create-collection-form {
+	display: grid;
+	max-width: 640px;
+	gap: 14px;
+	padding: 18px;
+	border: 1px solid var(--pc-color-border);
+	border-radius: 8px;
+	background: var(--pc-color-surface);
+}
+
+.pc-form-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+	align-items: center;
+	justify-content: flex-end;
+	padding-top: 4px;
 }
 
 .pc-clear-link {
@@ -430,6 +502,26 @@ body.post-collection-app {
 	padding: 3px 7px;
 	border-radius: 999px;
 	background: var(--pc-color-surface-alt);
+	color: var(--pc-color-accent);
+}
+
+.pc-read-status {
+	display: inline-flex;
+	align-items: center;
+	min-height: 20px;
+	padding: 2px 7px;
+	border-radius: 999px;
+	background: var(--pc-color-surface-alt);
+	color: var(--pc-color-muted);
+	font-size: 0.72rem;
+	font-weight: 700;
+}
+
+.pc-read-status-read {
+	color: var(--pc-color-primary);
+}
+
+.pc-read-status-skipped {
 	color: var(--pc-color-accent);
 }
 
@@ -587,6 +679,7 @@ body.post-collection-app {
 
 .pc-quick-edit-form input[type="text"],
 .pc-quick-edit-form input[type="url"],
+.pc-quick-edit-form select,
 .pc-quick-edit-form textarea {
 	width: 100%;
 	min-height: 30px;
@@ -809,6 +902,7 @@ body.post-collection-app {
 		text-align: left;
 	}
 
+	.pc-collection-settings,
 	.pc-add-form,
 	.pc-filter-bar {
 		grid-template-columns: 1fr;

--- a/assets/css/post-collection-app.css
+++ b/assets/css/post-collection-app.css
@@ -352,6 +352,10 @@ body.post-collection-app {
 	text-decoration: none;
 }
 
+.pc-card-embed {
+	background: #191b1f;
+}
+
 .pc-card-image img {
 	display: block;
 	width: 100%;
@@ -491,6 +495,11 @@ body.post-collection-app {
 	color: #333;
 	font-size: 0.78rem;
 	line-height: 1.35;
+}
+
+.pc-link-embed {
+	width: min(420px, calc(100% - 16px));
+	margin: 6px 0 0 16px;
 }
 
 .pc-link-meta {
@@ -636,6 +645,10 @@ body.post-collection-app {
 	object-fit: cover;
 }
 
+.pc-post-embed {
+	align-self: start;
+}
+
 .pc-detail-header {
 	max-width: 860px;
 }
@@ -663,6 +676,21 @@ body.post-collection-app {
 .pc-detail-content iframe {
 	max-width: 100%;
 	height: auto;
+}
+
+.pc-youtube-embed {
+	aspect-ratio: 16 / 9;
+	width: 100%;
+	overflow: hidden;
+	border-radius: 6px;
+	background: #191b1f;
+}
+
+.pc-youtube-embed iframe {
+	display: block;
+	width: 100%;
+	height: 100%;
+	border: 0;
 }
 
 .pc-detail-content pre {
@@ -718,6 +746,11 @@ body.post-collection-app {
 	text-decoration: none;
 }
 
+.pc-pagination.is-loading .pc-pagination-next {
+	opacity: 0.68;
+	pointer-events: none;
+}
+
 .screen-reader-text {
 	position: absolute;
 	width: 1px;
@@ -770,6 +803,10 @@ body.post-collection-app {
 
 	.pc-post-thumb {
 		display: block;
+		margin-bottom: 14px;
+	}
+
+	.pc-post-embed {
 		margin-bottom: 14px;
 	}
 

--- a/assets/css/post-collection-app.css
+++ b/assets/css/post-collection-app.css
@@ -1,0 +1,779 @@
+* {
+	box-sizing: border-box;
+}
+
+body.post-collection-app {
+	margin: 0;
+	background: #f6f4ef;
+	color: #191b1f;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+	font-size: 16px;
+	line-height: 1.5;
+}
+
+.post-collection-app a {
+	color: #0d5c63;
+	text-decoration-thickness: 1px;
+	text-underline-offset: 3px;
+}
+
+.post-collection-app a:hover {
+	color: #8a3d22;
+}
+
+.pc-shell {
+	width: min(1180px, calc(100% - 32px));
+	margin: 0 auto;
+}
+
+.pc-app-header,
+.pc-collection-header,
+.pc-detail-header {
+	padding: 48px 0 24px;
+}
+
+.pc-app-header {
+	display: flex;
+	align-items: flex-end;
+	justify-content: space-between;
+	gap: 24px;
+}
+
+.pc-kicker,
+.pc-source {
+	margin: 0 0 6px;
+	color: #69645d;
+	font-size: 0.82rem;
+	font-weight: 700;
+	text-transform: uppercase;
+}
+
+.pc-app-header h1,
+.pc-collection-header h1,
+.pc-detail-header h1 {
+	max-width: 840px;
+	margin: 0;
+	color: #111216;
+	font-size: 4rem;
+	line-height: 0.95;
+}
+
+.pc-description {
+	max-width: 720px;
+	margin: 18px 0 0;
+	color: #4a4742;
+	font-size: 1.05rem;
+}
+
+.pc-breadcrumb {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	margin-bottom: 28px;
+	color: #69645d;
+	font-size: 0.92rem;
+}
+
+.pc-collection-title-row {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	gap: 24px;
+	align-items: end;
+}
+
+.pc-collection-stats {
+	min-width: 118px;
+	padding: 14px 16px;
+	border: 1px solid #ddd7cd;
+	border-radius: 8px;
+	background: #fffdf8;
+	text-align: right;
+}
+
+.pc-collection-stats strong {
+	display: block;
+	color: #143f42;
+	font-size: 2rem;
+	line-height: 1;
+}
+
+.pc-collection-stats span {
+	color: #69645d;
+	font-size: 0.82rem;
+}
+
+.pc-button,
+.pc-add-form button,
+.pc-filter-bar button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 40px;
+	padding: 0 14px;
+	border: 1px solid #c9c2b7;
+	border-radius: 8px;
+	background: #fffdf8;
+	color: #191b1f;
+	font-weight: 700;
+	text-decoration: none;
+	cursor: pointer;
+}
+
+.pc-button-primary,
+.pc-add-form button,
+.pc-filter-bar button {
+	border-color: #143f42;
+	background: #143f42;
+	color: #fffdf8;
+}
+
+.pc-button:hover,
+.pc-add-form button:hover,
+.pc-filter-bar button:hover {
+	border-color: #8a3d22;
+	color: #8a3d22;
+}
+
+.pc-button-primary:hover,
+.pc-add-form button:hover,
+.pc-filter-bar button:hover {
+	background: #8a3d22;
+	color: #fffdf8;
+}
+
+.pc-collection-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+	gap: 16px;
+	padding-bottom: 56px;
+}
+
+.pc-collection-card {
+	display: flex;
+	flex-direction: column;
+	min-height: 280px;
+	border: 1px solid #ddd7cd;
+	border-radius: 8px;
+	background: #fffdf8;
+	overflow: hidden;
+}
+
+.pc-collection-card-main {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	padding: 20px;
+	text-decoration: none;
+}
+
+.pc-mode-label {
+	align-self: flex-start;
+	margin-bottom: 28px;
+	padding: 4px 8px;
+	border-radius: 999px;
+	background: #ece7dd;
+	color: #4a4742;
+	font-size: 0.75rem;
+	font-weight: 700;
+}
+
+.pc-collection-card-bookmarks .pc-mode-label {
+	background: #dcebe5;
+	color: #14503d;
+}
+
+.pc-collection-card-posts .pc-mode-label {
+	background: #e5e8f1;
+	color: #2f426c;
+}
+
+.pc-collection-card h2 {
+	margin: 0;
+	color: #111216;
+	font-size: 1.55rem;
+	line-height: 1.1;
+}
+
+.pc-collection-card p {
+	margin: 12px 0 0;
+	color: #4a4742;
+}
+
+.pc-count {
+	margin-top: auto;
+	color: #69645d;
+	font-size: 0.92rem;
+}
+
+.pc-mini-list {
+	display: grid;
+	gap: 8px;
+	margin: 0;
+	padding: 14px 20px 18px;
+	border-top: 1px solid #ebe5dc;
+	list-style: none;
+}
+
+.pc-mini-list a {
+	display: block;
+	overflow: hidden;
+	color: #4a4742;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.pc-add-form,
+.pc-filter-bar {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	gap: 10px;
+	margin-top: 24px;
+}
+
+.pc-add-form {
+	padding: 12px;
+	border: 1px solid #ddd7cd;
+	border-radius: 8px;
+	background: #fffdf8;
+}
+
+.pc-filter-bar {
+	grid-template-columns: minmax(0, 1fr) auto auto;
+}
+
+.pc-add-form input,
+.pc-filter-bar input {
+	width: 100%;
+	min-height: 40px;
+	padding: 0 12px;
+	border: 1px solid #c9c2b7;
+	border-radius: 8px;
+	background: #fffdf8;
+	color: #191b1f;
+	font: inherit;
+}
+
+.pc-add-form input:focus,
+.pc-filter-bar input:focus {
+	border-color: #143f42;
+	outline: 3px solid rgba(20, 63, 66, 0.18);
+}
+
+.pc-clear-link {
+	display: inline-flex;
+	align-items: center;
+	min-height: 40px;
+}
+
+.pc-tag-strip {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-top: 18px;
+}
+
+.pc-view-switch {
+	display: inline-flex;
+	gap: 4px;
+	margin-top: 14px;
+	padding: 4px;
+	border: 1px solid #ddd7cd;
+	border-radius: 8px;
+	background: #fffdf8;
+}
+
+.pc-view-switch a {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 32px;
+	padding: 0 12px;
+	border-radius: 6px;
+	color: #4a4742;
+	font-size: 0.9rem;
+	font-weight: 700;
+	text-decoration: none;
+}
+
+.pc-view-switch a:hover,
+.pc-view-switch a.is-active {
+	background: #143f42;
+	color: #fffdf8;
+}
+
+.pc-tag-strip a {
+	display: inline-flex;
+	gap: 6px;
+	align-items: center;
+	min-height: 32px;
+	padding: 0 10px;
+	border: 1px solid #ddd7cd;
+	border-radius: 999px;
+	background: #fffdf8;
+	color: #4a4742;
+	font-size: 0.9rem;
+	text-decoration: none;
+}
+
+.pc-tag-strip a.is-active,
+.pc-tag-strip a:hover {
+	border-color: #143f42;
+	background: #143f42;
+	color: #fffdf8;
+}
+
+.pc-tag-strip span {
+	color: inherit;
+	opacity: 0.72;
+}
+
+.pc-bookmark-board {
+	columns: 4 240px;
+	column-gap: 16px;
+	padding-bottom: 56px;
+}
+
+.pc-bookmark-card {
+	display: inline-block;
+	width: 100%;
+	margin: 0 0 16px;
+	border: 1px solid #ddd7cd;
+	border-radius: 8px;
+	background: #fffdf8;
+	overflow: hidden;
+	break-inside: avoid;
+}
+
+.pc-card-image,
+.pc-card-host {
+	display: block;
+	width: 100%;
+	background: #dcebe5;
+	text-decoration: none;
+}
+
+.pc-card-image img {
+	display: block;
+	width: 100%;
+	height: auto;
+}
+
+.pc-card-host {
+	display: grid;
+	place-items: center;
+	min-height: 150px;
+	color: #143f42;
+	font-size: 3rem;
+	font-weight: 800;
+	text-transform: uppercase;
+}
+
+.pc-card-body {
+	padding: 14px;
+}
+
+.pc-card-body h2,
+.pc-post-row h2 {
+	margin: 0;
+	font-size: 1.18rem;
+	line-height: 1.2;
+}
+
+.pc-card-body p,
+.pc-post-row p {
+	margin: 10px 0 0;
+	color: #4a4742;
+}
+
+.pc-card-actions,
+.pc-row-meta,
+.pc-detail-meta,
+.pc-detail-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+	align-items: center;
+	margin-top: 14px;
+	color: #69645d;
+	font-size: 0.9rem;
+}
+
+.pc-card-actions span,
+.pc-detail-meta span {
+	padding: 3px 7px;
+	border-radius: 999px;
+	background: #f5dfd2;
+	color: #7d341c;
+}
+
+.pc-post-list {
+	display: grid;
+	gap: 14px;
+	padding-bottom: 56px;
+}
+
+.pc-link-list {
+	display: grid;
+	gap: 0;
+	margin-bottom: 56px;
+	border: 1px solid #ddd7cd;
+	background: #fffdf8;
+	font-family: Verdana, Geneva, sans-serif;
+}
+
+.pc-link-row {
+	display: block;
+	padding: 8px 10px 9px;
+	border-top: 1px solid #ebe5dc;
+}
+
+.pc-link-row:first-child {
+	border-top: 0;
+}
+
+.pc-link-row.is-private {
+	box-shadow: inset 3px 0 0 #8a3d22;
+}
+
+.pc-link-title-line {
+	display: flex;
+	gap: 6px;
+	align-items: baseline;
+}
+
+.pc-link-marker {
+	flex: 0 0 auto;
+	width: 10px;
+	height: 10px;
+	border: 1px solid #69645d;
+	background: #fffdf8;
+	transform: translateY(1px);
+}
+
+.pc-link-row.is-private .pc-link-marker {
+	border-color: #8a3d22;
+	background: #8a3d22;
+}
+
+.pc-link-main h2 {
+	margin: 0;
+	font-family: Verdana, Geneva, sans-serif;
+	font-size: 0.95rem;
+	line-height: 1.25;
+}
+
+.pc-link-main h2 a {
+	color: #0d5c63;
+	text-decoration: underline;
+	text-decoration-thickness: 1px;
+	text-underline-offset: 2px;
+}
+
+.pc-link-main h2 a:visited {
+	color: #0d5c63;
+}
+
+.pc-link-url {
+	display: block;
+	max-width: 100%;
+	margin: 1px 0 0 16px;
+	overflow: hidden;
+	color: #69645d;
+	font-family: Verdana, Geneva, sans-serif;
+	font-size: 0.72rem;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	text-decoration: none;
+}
+
+.pc-link-main p {
+	margin: 4px 0 0 16px;
+	color: #333;
+	font-size: 0.78rem;
+	line-height: 1.35;
+}
+
+.pc-link-meta {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px 8px;
+	margin: 4px 0 0 16px;
+	color: #69645d;
+	font-size: 0.72rem;
+}
+
+.pc-link-tags {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	margin: 4px 0 0 16px;
+}
+
+.pc-link-tags a {
+	display: inline-flex;
+	align-items: center;
+	min-height: 18px;
+	padding: 0 4px;
+	border-radius: 2px;
+	background: #ece7dd;
+	color: #4a4742;
+	font-size: 0.72rem;
+	line-height: 1;
+	text-decoration: underline;
+	text-decoration-thickness: 1px;
+	text-underline-offset: 2px;
+}
+
+.pc-link-tags a:hover {
+	background: #143f42;
+	color: #fffdf8;
+}
+
+.pc-quick-edit-form {
+	display: none;
+	grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+	gap: 8px 10px;
+	margin: 9px 0 0 16px;
+	padding: 10px;
+	border: 1px solid #ddd7cd;
+	border-radius: 4px;
+	background: #fffdf8;
+}
+
+.pc-link-row.is-editing .pc-quick-edit-form {
+	display: grid;
+}
+
+.pc-quick-edit-form label {
+	display: grid;
+	gap: 3px;
+	color: #4a4742;
+	font-size: 0.72rem;
+	font-weight: 700;
+}
+
+.pc-quick-edit-form input[type="text"],
+.pc-quick-edit-form input[type="url"],
+.pc-quick-edit-form textarea {
+	width: 100%;
+	min-height: 30px;
+	padding: 5px 7px;
+	border: 1px solid #c9c2b7;
+	border-radius: 3px;
+	background: #fffdf8;
+	color: #191b1f;
+	font: inherit;
+	font-weight: 400;
+}
+
+.pc-quick-edit-form textarea {
+	resize: vertical;
+}
+
+.pc-quick-edit-actions {
+	display: flex;
+	grid-column: 1 / -1;
+	gap: 10px;
+	align-items: center;
+	justify-content: flex-end;
+}
+
+.pc-quick-edit-form .pc-quick-edit-public {
+	display: inline-flex;
+	gap: 5px;
+	align-items: center;
+	color: #4a4742;
+	font-size: 0.78rem;
+	font-weight: 700;
+}
+
+.pc-quick-edit-actions button {
+	min-height: 30px;
+	padding: 0 10px;
+	border: 1px solid #143f42;
+	border-radius: 4px;
+	background: #143f42;
+	color: #fff;
+	font-weight: 700;
+	cursor: pointer;
+}
+
+.pc-quick-edit-status {
+	color: #69645d;
+	font-size: 0.78rem;
+}
+
+.pc-post-row {
+	display: grid;
+	grid-template-columns: 184px minmax(0, 1fr);
+	gap: 18px;
+	padding: 14px;
+	border: 1px solid #ddd7cd;
+	border-radius: 8px;
+	background: #fffdf8;
+}
+
+.pc-post-row.is-text-only {
+	grid-template-columns: minmax(0, 1fr);
+	padding: 18px 20px;
+}
+
+.pc-post-row.is-text-only h2 {
+	font-size: 1.32rem;
+}
+
+.pc-post-thumb {
+	aspect-ratio: 4 / 3;
+	border-radius: 6px;
+	background: #e5e8f1;
+	overflow: hidden;
+}
+
+.pc-post-thumb img {
+	display: block;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+}
+
+.pc-detail-header {
+	max-width: 860px;
+}
+
+.pc-detail-layout {
+	display: grid;
+	grid-template-columns: minmax(0, 820px);
+	padding-bottom: 72px;
+}
+
+.pc-detail-content {
+	padding: 28px;
+	border: 1px solid #ddd7cd;
+	border-radius: 8px;
+	background: #fffdf8;
+	font-size: 1.08rem;
+}
+
+.pc-detail-content > *:first-child {
+	margin-top: 0;
+}
+
+.pc-detail-content img,
+.pc-detail-content video,
+.pc-detail-content iframe {
+	max-width: 100%;
+	height: auto;
+}
+
+.pc-detail-content pre {
+	overflow: auto;
+	padding: 16px;
+	border-radius: 6px;
+	background: #191b1f;
+	color: #fffdf8;
+}
+
+.pc-detail-tags {
+	margin-top: 20px;
+}
+
+.pc-empty {
+	max-width: 620px;
+	margin: 48px auto;
+	padding: 32px;
+	border: 1px solid #ddd7cd;
+	border-radius: 8px;
+	background: #fffdf8;
+	text-align: center;
+}
+
+.pc-empty h1,
+.pc-empty h2 {
+	margin: 0;
+	font-size: 1.8rem;
+	line-height: 1.1;
+}
+
+.pc-empty p {
+	color: #4a4742;
+}
+
+.pc-pagination {
+	display: flex;
+	gap: 12px;
+	align-items: center;
+	justify-content: center;
+	padding: 8px 0 64px;
+}
+
+.pc-pagination a,
+.pc-pagination span {
+	display: inline-flex;
+	align-items: center;
+	min-height: 38px;
+	padding: 0 12px;
+	border: 1px solid #ddd7cd;
+	border-radius: 8px;
+	background: #fffdf8;
+	text-decoration: none;
+}
+
+.screen-reader-text {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	padding: 0;
+	border: 0;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	word-wrap: normal;
+}
+
+@media (max-width: 760px) {
+	.pc-shell {
+		width: min(100% - 20px, 1180px);
+	}
+
+	.pc-app-header,
+	.pc-collection-title-row,
+	.pc-post-row {
+		display: block;
+	}
+
+	.pc-app-header h1,
+	.pc-collection-header h1,
+	.pc-detail-header h1 {
+		font-size: 2.4rem;
+	}
+
+	.pc-collection-stats {
+		margin-top: 18px;
+		text-align: left;
+	}
+
+	.pc-add-form,
+	.pc-filter-bar {
+		grid-template-columns: 1fr;
+	}
+
+	.pc-view-switch {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		width: 100%;
+	}
+
+	.pc-quick-edit-form {
+		grid-template-columns: 1fr;
+		margin-left: 0;
+	}
+
+	.pc-post-thumb {
+		display: block;
+		margin-bottom: 14px;
+	}
+
+	.pc-detail-content {
+		padding: 18px;
+	}
+}

--- a/assets/css/post-collection-app.css
+++ b/assets/css/post-collection-app.css
@@ -15,7 +15,7 @@ body.post-collection-app {
 	--pc-color-primary-hover: var(--wp-app-color-primary-hover, #00a0d2);
 	--pc-color-accent: var(--wp-app-color-accent, #00a0d2);
 	--pc-color-focus: var(--wp-app-color-focus, #00a0d2);
-	--pc-color-on-primary: var(--wp-app-admin-icon-color-current, #fff);
+	--pc-color-on-primary: var(--wp-app-color-on-primary, #fff);
 	--pc-color-embed-background: var(--wp-app-admin-color-background, #23282d);
 	margin: 0;
 	background: var(--pc-color-background);
@@ -116,9 +116,9 @@ body.post-collection-app {
 	font-size: 0.82rem;
 }
 
-.pc-button,
-.pc-add-form button,
-.pc-filter-bar button {
+.post-collection-app .pc-button,
+.post-collection-app .pc-add-form button,
+.post-collection-app .pc-filter-bar button {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -133,24 +133,30 @@ body.post-collection-app {
 	cursor: pointer;
 }
 
-.pc-button-primary,
-.pc-add-form button,
-.pc-filter-bar button {
+.post-collection-app .pc-button-primary,
+.post-collection-app .pc-add-form button,
+.post-collection-app .pc-filter-bar button {
 	border-color: var(--pc-color-primary);
 	background: var(--pc-color-primary);
 	color: var(--pc-color-on-primary);
 }
 
-.pc-button:hover,
-.pc-add-form button:hover,
-.pc-filter-bar button:hover {
+.post-collection-app .pc-button:hover,
+.post-collection-app .pc-button:focus,
+.post-collection-app .pc-add-form button:hover,
+.post-collection-app .pc-add-form button:focus,
+.post-collection-app .pc-filter-bar button:hover,
+.post-collection-app .pc-filter-bar button:focus {
 	border-color: var(--pc-color-primary-hover);
 	color: var(--pc-color-primary-hover);
 }
 
-.pc-button-primary:hover,
-.pc-add-form button:hover,
-.pc-filter-bar button:hover {
+.post-collection-app .pc-button-primary:hover,
+.post-collection-app .pc-button-primary:focus,
+.post-collection-app .pc-add-form button:hover,
+.post-collection-app .pc-add-form button:focus,
+.post-collection-app .pc-filter-bar button:hover,
+.post-collection-app .pc-filter-bar button:focus {
 	background: var(--pc-color-primary-hover);
 	color: var(--pc-color-on-primary);
 }
@@ -228,7 +234,7 @@ body.post-collection-app {
 	list-style: none;
 }
 
-.pc-mini-list a {
+.post-collection-app .pc-mini-list a {
 	display: block;
 	overflow: hidden;
 	color: var(--pc-color-muted);
@@ -297,7 +303,7 @@ body.post-collection-app {
 	background: var(--pc-color-surface);
 }
 
-.pc-view-switch a {
+.post-collection-app .pc-view-switch a {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
@@ -310,13 +316,14 @@ body.post-collection-app {
 	text-decoration: none;
 }
 
-.pc-view-switch a:hover,
-.pc-view-switch a.is-active {
+.post-collection-app .pc-view-switch a:hover,
+.post-collection-app .pc-view-switch a:focus,
+.post-collection-app .pc-view-switch a.is-active {
 	background: var(--pc-color-primary);
 	color: var(--pc-color-on-primary);
 }
 
-.pc-tag-strip a {
+.post-collection-app .pc-tag-strip a {
 	display: inline-flex;
 	gap: 6px;
 	align-items: center;
@@ -330,8 +337,9 @@ body.post-collection-app {
 	text-decoration: none;
 }
 
-.pc-tag-strip a.is-active,
-.pc-tag-strip a:hover {
+.post-collection-app .pc-tag-strip a.is-active,
+.post-collection-app .pc-tag-strip a:hover,
+.post-collection-app .pc-tag-strip a:focus {
 	border-color: var(--pc-color-primary);
 	background: var(--pc-color-primary);
 	color: var(--pc-color-on-primary);
@@ -481,14 +489,14 @@ body.post-collection-app {
 	line-height: 1.25;
 }
 
-.pc-link-main h2 a {
+.post-collection-app .pc-link-main h2 a {
 	color: var(--pc-color-link);
 	text-decoration: underline;
 	text-decoration-thickness: 1px;
 	text-underline-offset: 2px;
 }
 
-.pc-link-main h2 a:visited {
+.post-collection-app .pc-link-main h2 a:visited {
 	color: var(--pc-color-link);
 }
 
@@ -533,7 +541,7 @@ body.post-collection-app {
 	margin: 4px 0 0 16px;
 }
 
-.pc-link-tags a {
+.post-collection-app .pc-link-tags a {
 	display: inline-flex;
 	align-items: center;
 	min-height: 18px;
@@ -548,7 +556,8 @@ body.post-collection-app {
 	text-underline-offset: 2px;
 }
 
-.pc-link-tags a:hover {
+.post-collection-app .pc-link-tags a:hover,
+.post-collection-app .pc-link-tags a:focus {
 	background: var(--pc-color-primary);
 	color: var(--pc-color-on-primary);
 }
@@ -749,8 +758,8 @@ body.post-collection-app {
 	padding: 8px 0 64px;
 }
 
-.pc-pagination a,
-.pc-pagination span {
+.post-collection-app .pc-pagination a,
+.post-collection-app .pc-pagination span {
 	display: inline-flex;
 	align-items: center;
 	min-height: 38px;

--- a/assets/css/post-collection-app.css
+++ b/assets/css/post-collection-app.css
@@ -3,22 +3,36 @@
 }
 
 body.post-collection-app {
+	--pc-color-background: var(--wp-app-color-background, #f6f7f7);
+	--pc-color-surface: var(--wp-app-color-surface, #fff);
+	--pc-color-surface-alt: var(--wp-app-color-surface-alt, #f0f0f1);
+	--pc-color-text: var(--wp-app-color-text, #1d2327);
+	--pc-color-muted: var(--wp-app-color-muted, #646970);
+	--pc-color-border: var(--wp-app-color-border, #dcdcde);
+	--pc-color-link: var(--wp-app-color-link, #0073aa);
+	--pc-color-link-hover: var(--wp-app-color-link-hover, #00a0d2);
+	--pc-color-primary: var(--wp-app-color-primary, #0073aa);
+	--pc-color-primary-hover: var(--wp-app-color-primary-hover, #00a0d2);
+	--pc-color-accent: var(--wp-app-color-accent, #00a0d2);
+	--pc-color-focus: var(--wp-app-color-focus, #00a0d2);
+	--pc-color-on-primary: var(--wp-app-admin-icon-color-current, #fff);
+	--pc-color-embed-background: var(--wp-app-admin-color-background, #23282d);
 	margin: 0;
-	background: #f6f4ef;
-	color: #191b1f;
+	background: var(--pc-color-background);
+	color: var(--pc-color-text);
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 	font-size: 16px;
 	line-height: 1.5;
 }
 
 .post-collection-app a {
-	color: #0d5c63;
+	color: var(--pc-color-link);
 	text-decoration-thickness: 1px;
 	text-underline-offset: 3px;
 }
 
 .post-collection-app a:hover {
-	color: #8a3d22;
+	color: var(--pc-color-link-hover);
 }
 
 .pc-shell {
@@ -42,7 +56,7 @@ body.post-collection-app {
 .pc-kicker,
 .pc-source {
 	margin: 0 0 6px;
-	color: #69645d;
+	color: var(--pc-color-muted);
 	font-size: 0.82rem;
 	font-weight: 700;
 	text-transform: uppercase;
@@ -53,7 +67,7 @@ body.post-collection-app {
 .pc-detail-header h1 {
 	max-width: 840px;
 	margin: 0;
-	color: #111216;
+	color: var(--pc-color-text);
 	font-size: 4rem;
 	line-height: 0.95;
 }
@@ -61,7 +75,7 @@ body.post-collection-app {
 .pc-description {
 	max-width: 720px;
 	margin: 18px 0 0;
-	color: #4a4742;
+	color: var(--pc-color-muted);
 	font-size: 1.05rem;
 }
 
@@ -70,7 +84,7 @@ body.post-collection-app {
 	gap: 8px;
 	align-items: center;
 	margin-bottom: 28px;
-	color: #69645d;
+	color: var(--pc-color-muted);
 	font-size: 0.92rem;
 }
 
@@ -84,21 +98,21 @@ body.post-collection-app {
 .pc-collection-stats {
 	min-width: 118px;
 	padding: 14px 16px;
-	border: 1px solid #ddd7cd;
+	border: 1px solid var(--pc-color-border);
 	border-radius: 8px;
-	background: #fffdf8;
+	background: var(--pc-color-surface);
 	text-align: right;
 }
 
 .pc-collection-stats strong {
 	display: block;
-	color: #143f42;
+	color: var(--pc-color-primary);
 	font-size: 2rem;
 	line-height: 1;
 }
 
 .pc-collection-stats span {
-	color: #69645d;
+	color: var(--pc-color-muted);
 	font-size: 0.82rem;
 }
 
@@ -110,10 +124,10 @@ body.post-collection-app {
 	justify-content: center;
 	min-height: 40px;
 	padding: 0 14px;
-	border: 1px solid #c9c2b7;
+	border: 1px solid var(--pc-color-border);
 	border-radius: 8px;
-	background: #fffdf8;
-	color: #191b1f;
+	background: var(--pc-color-surface);
+	color: var(--pc-color-text);
 	font-weight: 700;
 	text-decoration: none;
 	cursor: pointer;
@@ -122,23 +136,23 @@ body.post-collection-app {
 .pc-button-primary,
 .pc-add-form button,
 .pc-filter-bar button {
-	border-color: #143f42;
-	background: #143f42;
-	color: #fffdf8;
+	border-color: var(--pc-color-primary);
+	background: var(--pc-color-primary);
+	color: var(--pc-color-on-primary);
 }
 
 .pc-button:hover,
 .pc-add-form button:hover,
 .pc-filter-bar button:hover {
-	border-color: #8a3d22;
-	color: #8a3d22;
+	border-color: var(--pc-color-primary-hover);
+	color: var(--pc-color-primary-hover);
 }
 
 .pc-button-primary:hover,
 .pc-add-form button:hover,
 .pc-filter-bar button:hover {
-	background: #8a3d22;
-	color: #fffdf8;
+	background: var(--pc-color-primary-hover);
+	color: var(--pc-color-on-primary);
 }
 
 .pc-collection-grid {
@@ -152,9 +166,9 @@ body.post-collection-app {
 	display: flex;
 	flex-direction: column;
 	min-height: 280px;
-	border: 1px solid #ddd7cd;
+	border: 1px solid var(--pc-color-border);
 	border-radius: 8px;
-	background: #fffdf8;
+	background: var(--pc-color-surface);
 	overflow: hidden;
 }
 
@@ -171,37 +185,37 @@ body.post-collection-app {
 	margin-bottom: 28px;
 	padding: 4px 8px;
 	border-radius: 999px;
-	background: #ece7dd;
-	color: #4a4742;
+	background: var(--pc-color-surface-alt);
+	color: var(--pc-color-muted);
 	font-size: 0.75rem;
 	font-weight: 700;
 }
 
 .pc-collection-card-bookmarks .pc-mode-label {
-	background: #dcebe5;
-	color: #14503d;
+	background: var(--pc-color-surface-alt);
+	color: var(--pc-color-primary);
 }
 
 .pc-collection-card-posts .pc-mode-label {
-	background: #e5e8f1;
-	color: #2f426c;
+	background: var(--pc-color-surface-alt);
+	color: var(--pc-color-primary);
 }
 
 .pc-collection-card h2 {
 	margin: 0;
-	color: #111216;
+	color: var(--pc-color-text);
 	font-size: 1.55rem;
 	line-height: 1.1;
 }
 
 .pc-collection-card p {
 	margin: 12px 0 0;
-	color: #4a4742;
+	color: var(--pc-color-muted);
 }
 
 .pc-count {
 	margin-top: auto;
-	color: #69645d;
+	color: var(--pc-color-muted);
 	font-size: 0.92rem;
 }
 
@@ -210,14 +224,14 @@ body.post-collection-app {
 	gap: 8px;
 	margin: 0;
 	padding: 14px 20px 18px;
-	border-top: 1px solid #ebe5dc;
+	border-top: 1px solid var(--pc-color-border);
 	list-style: none;
 }
 
 .pc-mini-list a {
 	display: block;
 	overflow: hidden;
-	color: #4a4742;
+	color: var(--pc-color-muted);
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
@@ -232,9 +246,9 @@ body.post-collection-app {
 
 .pc-add-form {
 	padding: 12px;
-	border: 1px solid #ddd7cd;
+	border: 1px solid var(--pc-color-border);
 	border-radius: 8px;
-	background: #fffdf8;
+	background: var(--pc-color-surface);
 }
 
 .pc-filter-bar {
@@ -246,17 +260,18 @@ body.post-collection-app {
 	width: 100%;
 	min-height: 40px;
 	padding: 0 12px;
-	border: 1px solid #c9c2b7;
+	border: 1px solid var(--pc-color-border);
 	border-radius: 8px;
-	background: #fffdf8;
-	color: #191b1f;
+	background: var(--pc-color-surface);
+	color: var(--pc-color-text);
 	font: inherit;
 }
 
 .pc-add-form input:focus,
 .pc-filter-bar input:focus {
-	border-color: #143f42;
-	outline: 3px solid rgba(20, 63, 66, 0.18);
+	border-color: var(--pc-color-primary);
+	outline: 2px solid var(--pc-color-focus);
+	outline-offset: 1px;
 }
 
 .pc-clear-link {
@@ -277,9 +292,9 @@ body.post-collection-app {
 	gap: 4px;
 	margin-top: 14px;
 	padding: 4px;
-	border: 1px solid #ddd7cd;
+	border: 1px solid var(--pc-color-border);
 	border-radius: 8px;
-	background: #fffdf8;
+	background: var(--pc-color-surface);
 }
 
 .pc-view-switch a {
@@ -289,7 +304,7 @@ body.post-collection-app {
 	min-height: 32px;
 	padding: 0 12px;
 	border-radius: 6px;
-	color: #4a4742;
+	color: var(--pc-color-muted);
 	font-size: 0.9rem;
 	font-weight: 700;
 	text-decoration: none;
@@ -297,8 +312,8 @@ body.post-collection-app {
 
 .pc-view-switch a:hover,
 .pc-view-switch a.is-active {
-	background: #143f42;
-	color: #fffdf8;
+	background: var(--pc-color-primary);
+	color: var(--pc-color-on-primary);
 }
 
 .pc-tag-strip a {
@@ -307,19 +322,19 @@ body.post-collection-app {
 	align-items: center;
 	min-height: 32px;
 	padding: 0 10px;
-	border: 1px solid #ddd7cd;
+	border: 1px solid var(--pc-color-border);
 	border-radius: 999px;
-	background: #fffdf8;
-	color: #4a4742;
+	background: var(--pc-color-surface);
+	color: var(--pc-color-muted);
 	font-size: 0.9rem;
 	text-decoration: none;
 }
 
 .pc-tag-strip a.is-active,
 .pc-tag-strip a:hover {
-	border-color: #143f42;
-	background: #143f42;
-	color: #fffdf8;
+	border-color: var(--pc-color-primary);
+	background: var(--pc-color-primary);
+	color: var(--pc-color-on-primary);
 }
 
 .pc-tag-strip span {
@@ -337,9 +352,9 @@ body.post-collection-app {
 	display: inline-block;
 	width: 100%;
 	margin: 0 0 16px;
-	border: 1px solid #ddd7cd;
+	border: 1px solid var(--pc-color-border);
 	border-radius: 8px;
-	background: #fffdf8;
+	background: var(--pc-color-surface);
 	overflow: hidden;
 	break-inside: avoid;
 }
@@ -348,12 +363,12 @@ body.post-collection-app {
 .pc-card-host {
 	display: block;
 	width: 100%;
-	background: #dcebe5;
+	background: var(--pc-color-surface-alt);
 	text-decoration: none;
 }
 
 .pc-card-embed {
-	background: #191b1f;
+	background: var(--pc-color-embed-background);
 }
 
 .pc-card-image img {
@@ -366,7 +381,7 @@ body.post-collection-app {
 	display: grid;
 	place-items: center;
 	min-height: 150px;
-	color: #143f42;
+	color: var(--pc-color-primary);
 	font-size: 3rem;
 	font-weight: 800;
 	text-transform: uppercase;
@@ -386,7 +401,7 @@ body.post-collection-app {
 .pc-card-body p,
 .pc-post-row p {
 	margin: 10px 0 0;
-	color: #4a4742;
+	color: var(--pc-color-muted);
 }
 
 .pc-card-actions,
@@ -398,7 +413,7 @@ body.post-collection-app {
 	gap: 10px;
 	align-items: center;
 	margin-top: 14px;
-	color: #69645d;
+	color: var(--pc-color-muted);
 	font-size: 0.9rem;
 }
 
@@ -406,8 +421,8 @@ body.post-collection-app {
 .pc-detail-meta span {
 	padding: 3px 7px;
 	border-radius: 999px;
-	background: #f5dfd2;
-	color: #7d341c;
+	background: var(--pc-color-surface-alt);
+	color: var(--pc-color-accent);
 }
 
 .pc-post-list {
@@ -420,15 +435,15 @@ body.post-collection-app {
 	display: grid;
 	gap: 0;
 	margin-bottom: 56px;
-	border: 1px solid #ddd7cd;
-	background: #fffdf8;
+	border: 1px solid var(--pc-color-border);
+	background: var(--pc-color-surface);
 	font-family: Verdana, Geneva, sans-serif;
 }
 
 .pc-link-row {
 	display: block;
 	padding: 8px 10px 9px;
-	border-top: 1px solid #ebe5dc;
+	border-top: 1px solid var(--pc-color-border);
 }
 
 .pc-link-row:first-child {
@@ -436,7 +451,7 @@ body.post-collection-app {
 }
 
 .pc-link-row.is-private {
-	box-shadow: inset 3px 0 0 #8a3d22;
+	box-shadow: inset 3px 0 0 var(--pc-color-accent);
 }
 
 .pc-link-title-line {
@@ -449,14 +464,14 @@ body.post-collection-app {
 	flex: 0 0 auto;
 	width: 10px;
 	height: 10px;
-	border: 1px solid #69645d;
-	background: #fffdf8;
+	border: 1px solid var(--pc-color-muted);
+	background: var(--pc-color-surface);
 	transform: translateY(1px);
 }
 
 .pc-link-row.is-private .pc-link-marker {
-	border-color: #8a3d22;
-	background: #8a3d22;
+	border-color: var(--pc-color-accent);
+	background: var(--pc-color-accent);
 }
 
 .pc-link-main h2 {
@@ -467,14 +482,14 @@ body.post-collection-app {
 }
 
 .pc-link-main h2 a {
-	color: #0d5c63;
+	color: var(--pc-color-link);
 	text-decoration: underline;
 	text-decoration-thickness: 1px;
 	text-underline-offset: 2px;
 }
 
 .pc-link-main h2 a:visited {
-	color: #0d5c63;
+	color: var(--pc-color-link);
 }
 
 .pc-link-url {
@@ -482,7 +497,7 @@ body.post-collection-app {
 	max-width: 100%;
 	margin: 1px 0 0 16px;
 	overflow: hidden;
-	color: #69645d;
+	color: var(--pc-color-muted);
 	font-family: Verdana, Geneva, sans-serif;
 	font-size: 0.72rem;
 	text-overflow: ellipsis;
@@ -492,7 +507,7 @@ body.post-collection-app {
 
 .pc-link-main p {
 	margin: 4px 0 0 16px;
-	color: #333;
+	color: var(--pc-color-text);
 	font-size: 0.78rem;
 	line-height: 1.35;
 }
@@ -507,7 +522,7 @@ body.post-collection-app {
 	flex-wrap: wrap;
 	gap: 4px 8px;
 	margin: 4px 0 0 16px;
-	color: #69645d;
+	color: var(--pc-color-muted);
 	font-size: 0.72rem;
 }
 
@@ -524,8 +539,8 @@ body.post-collection-app {
 	min-height: 18px;
 	padding: 0 4px;
 	border-radius: 2px;
-	background: #ece7dd;
-	color: #4a4742;
+	background: var(--pc-color-surface-alt);
+	color: var(--pc-color-muted);
 	font-size: 0.72rem;
 	line-height: 1;
 	text-decoration: underline;
@@ -534,8 +549,8 @@ body.post-collection-app {
 }
 
 .pc-link-tags a:hover {
-	background: #143f42;
-	color: #fffdf8;
+	background: var(--pc-color-primary);
+	color: var(--pc-color-on-primary);
 }
 
 .pc-quick-edit-form {
@@ -544,9 +559,9 @@ body.post-collection-app {
 	gap: 8px 10px;
 	margin: 9px 0 0 16px;
 	padding: 10px;
-	border: 1px solid #ddd7cd;
+	border: 1px solid var(--pc-color-border);
 	border-radius: 4px;
-	background: #fffdf8;
+	background: var(--pc-color-surface);
 }
 
 .pc-link-row.is-editing .pc-quick-edit-form {
@@ -556,7 +571,7 @@ body.post-collection-app {
 .pc-quick-edit-form label {
 	display: grid;
 	gap: 3px;
-	color: #4a4742;
+	color: var(--pc-color-muted);
 	font-size: 0.72rem;
 	font-weight: 700;
 }
@@ -567,10 +582,10 @@ body.post-collection-app {
 	width: 100%;
 	min-height: 30px;
 	padding: 5px 7px;
-	border: 1px solid #c9c2b7;
+	border: 1px solid var(--pc-color-border);
 	border-radius: 3px;
-	background: #fffdf8;
-	color: #191b1f;
+	background: var(--pc-color-surface);
+	color: var(--pc-color-text);
 	font: inherit;
 	font-weight: 400;
 }
@@ -591,7 +606,7 @@ body.post-collection-app {
 	display: inline-flex;
 	gap: 5px;
 	align-items: center;
-	color: #4a4742;
+	color: var(--pc-color-muted);
 	font-size: 0.78rem;
 	font-weight: 700;
 }
@@ -599,16 +614,16 @@ body.post-collection-app {
 .pc-quick-edit-actions button {
 	min-height: 30px;
 	padding: 0 10px;
-	border: 1px solid #143f42;
+	border: 1px solid var(--pc-color-primary);
 	border-radius: 4px;
-	background: #143f42;
-	color: #fff;
+	background: var(--pc-color-primary);
+	color: var(--pc-color-on-primary);
 	font-weight: 700;
 	cursor: pointer;
 }
 
 .pc-quick-edit-status {
-	color: #69645d;
+	color: var(--pc-color-muted);
 	font-size: 0.78rem;
 }
 
@@ -617,9 +632,9 @@ body.post-collection-app {
 	grid-template-columns: 184px minmax(0, 1fr);
 	gap: 18px;
 	padding: 14px;
-	border: 1px solid #ddd7cd;
+	border: 1px solid var(--pc-color-border);
 	border-radius: 8px;
-	background: #fffdf8;
+	background: var(--pc-color-surface);
 }
 
 .pc-post-row.is-text-only {
@@ -634,7 +649,7 @@ body.post-collection-app {
 .pc-post-thumb {
 	aspect-ratio: 4 / 3;
 	border-radius: 6px;
-	background: #e5e8f1;
+	background: var(--pc-color-surface-alt);
 	overflow: hidden;
 }
 
@@ -661,9 +676,9 @@ body.post-collection-app {
 
 .pc-detail-content {
 	padding: 28px;
-	border: 1px solid #ddd7cd;
+	border: 1px solid var(--pc-color-border);
 	border-radius: 8px;
-	background: #fffdf8;
+	background: var(--pc-color-surface);
 	font-size: 1.08rem;
 }
 
@@ -683,7 +698,7 @@ body.post-collection-app {
 	width: 100%;
 	overflow: hidden;
 	border-radius: 6px;
-	background: #191b1f;
+	background: var(--pc-color-embed-background);
 }
 
 .pc-youtube-embed iframe {
@@ -697,8 +712,8 @@ body.post-collection-app {
 	overflow: auto;
 	padding: 16px;
 	border-radius: 6px;
-	background: #191b1f;
-	color: #fffdf8;
+	background: var(--pc-color-embed-background);
+	color: var(--pc-color-on-primary);
 }
 
 .pc-detail-tags {
@@ -709,9 +724,9 @@ body.post-collection-app {
 	max-width: 620px;
 	margin: 48px auto;
 	padding: 32px;
-	border: 1px solid #ddd7cd;
+	border: 1px solid var(--pc-color-border);
 	border-radius: 8px;
-	background: #fffdf8;
+	background: var(--pc-color-surface);
 	text-align: center;
 }
 
@@ -723,7 +738,7 @@ body.post-collection-app {
 }
 
 .pc-empty p {
-	color: #4a4742;
+	color: var(--pc-color-muted);
 }
 
 .pc-pagination {
@@ -740,9 +755,9 @@ body.post-collection-app {
 	align-items: center;
 	min-height: 38px;
 	padding: 0 12px;
-	border: 1px solid #ddd7cd;
+	border: 1px solid var(--pc-color-border);
 	border-radius: 8px;
-	background: #fffdf8;
+	background: var(--pc-color-surface);
 	text-decoration: none;
 }
 

--- a/assets/js/post-collection-app.js
+++ b/assets/js/post-collection-app.js
@@ -1,0 +1,207 @@
+( function () {
+	function closest( element, selector ) {
+		while ( element && element !== document ) {
+			if ( element.matches( selector ) ) {
+				return element;
+			}
+			element = element.parentNode;
+		}
+
+		return null;
+	}
+
+	function closeEditors( exceptRow ) {
+		document.querySelectorAll( '.pc-link-row.is-editing' ).forEach( function ( row ) {
+			if ( row !== exceptRow ) {
+				row.classList.remove( 'is-editing' );
+				var cancel = row.querySelector( '.pc-quick-edit-cancel' );
+				if ( cancel ) {
+					setToggle( cancel, false );
+				}
+			}
+		} );
+	}
+
+	function setToggle( toggle, isEditing ) {
+		toggle.classList.toggle( 'pc-quick-edit-open', ! isEditing );
+		toggle.classList.toggle( 'pc-quick-edit-cancel', isEditing );
+		toggle.textContent = isEditing ? toggle.dataset.cancelLabel || 'Cancel edit' : toggle.dataset.editLabel || 'Edit';
+		if ( isEditing && toggle.dataset.cancelUrl ) {
+			toggle.href = toggle.dataset.cancelUrl;
+		} else if ( ! isEditing && toggle.dataset.editUrl ) {
+			toggle.href = toggle.dataset.editUrl;
+		}
+	}
+
+	function replaceLocation( href ) {
+		if ( href && window.history && window.history.replaceState ) {
+			window.history.replaceState( null, '', href );
+		}
+	}
+
+	function openEditor( row ) {
+		closeEditors( row );
+		row.classList.add( 'is-editing' );
+		var toggle = row.querySelector( '.pc-quick-edit-open' );
+		if ( toggle ) {
+			setToggle( toggle, true );
+			replaceLocation( toggle.dataset.editUrl || toggle.href );
+		}
+		var firstInput = row.querySelector( '.pc-quick-edit-form input[type="text"]' );
+		if ( firstInput ) {
+			firstInput.focus();
+			firstInput.select();
+		}
+	}
+
+	function closeEditor( row ) {
+		row.classList.remove( 'is-editing' );
+		var toggle = row.querySelector( '.pc-quick-edit-cancel' );
+		if ( toggle ) {
+			replaceLocation( toggle.dataset.cancelUrl || toggle.href );
+			setToggle( toggle, false );
+		}
+	}
+
+	function updateTags( row, terms ) {
+		var tagContainer = row.querySelector( '.pc-link-tags' );
+		if ( ! tagContainer ) {
+			return;
+		}
+
+		tagContainer.textContent = '';
+		terms.forEach( function ( term ) {
+			var link = document.createElement( 'a' );
+			link.href = term.url;
+			link.textContent = term.name;
+			tagContainer.appendChild( link );
+		} );
+	}
+
+	function updateRow( row, item ) {
+		row.classList.toggle( 'is-private', !! item.is_private );
+
+		var marker = row.querySelector( '.pc-link-marker' );
+		if ( marker ) {
+			marker.setAttribute( 'aria-hidden', 'true' );
+		}
+
+		var title = row.querySelector( '.pc-link-title' );
+		if ( title ) {
+			title.href = item.source_url;
+			title.textContent = item.title;
+		}
+
+		var urlLink = row.querySelector( '.pc-link-url' );
+		if ( urlLink ) {
+			urlLink.href = item.source_url;
+			urlLink.textContent = item.display_url;
+		}
+
+		var excerpt = row.querySelector( '.pc-link-excerpt' );
+		if ( ! excerpt && item.excerpt ) {
+			excerpt = document.createElement( 'p' );
+			excerpt.className = 'pc-link-excerpt';
+			if ( urlLink ) {
+				urlLink.after( excerpt );
+			}
+		}
+		if ( excerpt ) {
+			excerpt.textContent = item.excerpt || '';
+			excerpt.hidden = ! item.excerpt;
+		}
+
+		var host = row.querySelector( '.pc-link-host' );
+		if ( host ) {
+			host.textContent = item.host || '';
+		}
+
+		var privateLabel = row.querySelector( '.pc-link-private' );
+		if ( item.is_private && ! privateLabel ) {
+			privateLabel = document.createElement( 'span' );
+			privateLabel.className = 'pc-link-private';
+			privateLabel.textContent = 'private';
+			var details = row.querySelector( '.pc-link-meta a' );
+			if ( details ) {
+				details.before( privateLabel );
+			}
+		} else if ( ! item.is_private && privateLabel ) {
+			privateLabel.remove();
+		}
+
+		updateTags( row, item.terms || [] );
+		closeEditor( row );
+	}
+
+	document.addEventListener( 'click', function ( event ) {
+		var editLink = closest( event.target, '.pc-quick-edit-open' );
+		if ( editLink ) {
+			var row = closest( editLink, '.pc-link-row' );
+			if ( row ) {
+				event.preventDefault();
+				openEditor( row );
+			}
+			return;
+		}
+
+		var cancelLink = closest( event.target, '.pc-quick-edit-cancel' );
+		if ( cancelLink ) {
+			var cancelRow = closest( cancelLink, '.pc-link-row' );
+			if ( cancelRow ) {
+				event.preventDefault();
+				closeEditor( cancelRow );
+			}
+		}
+	} );
+
+	document.addEventListener( 'submit', function ( event ) {
+		var form = closest( event.target, '.pc-quick-edit-form' );
+		if ( ! form ) {
+			return;
+		}
+
+		event.preventDefault();
+		var row = closest( form, '.pc-link-row' );
+		var button = form.querySelector( 'button[type="submit"]' );
+		var status = form.querySelector( '.pc-quick-edit-status' );
+		if ( ! row ) {
+			return;
+		}
+
+		if ( button ) {
+			button.disabled = true;
+		}
+		if ( status ) {
+			status.textContent = 'Saving...';
+		}
+
+		fetch( form.dataset.ajaxAction || form.action, {
+			method: 'POST',
+			credentials: 'same-origin',
+			body: new FormData( form ),
+		} )
+			.then( function ( response ) {
+				return response.json();
+			} )
+			.then( function ( result ) {
+				if ( ! result || ! result.success ) {
+					throw new Error( result && result.data && result.data.message ? result.data.message : 'Could not save changes.' );
+				}
+
+				updateRow( row, result.data );
+				if ( status ) {
+					status.textContent = '';
+				}
+			} )
+			.catch( function ( error ) {
+				if ( status ) {
+					status.textContent = error.message;
+				}
+			} )
+			.finally( function () {
+				if ( button ) {
+					button.disabled = false;
+				}
+			} );
+	} );
+}() );

--- a/assets/js/post-collection-app.js
+++ b/assets/js/post-collection-app.js
@@ -78,6 +78,27 @@
 		} );
 	}
 
+	function getCollectionList() {
+		return document.querySelector( '.pc-bookmark-board, .pc-link-list, .pc-post-list' );
+	}
+
+	function getCollectionListSelector( list ) {
+		if ( ! list ) {
+			return '';
+		}
+		if ( list.classList.contains( 'pc-bookmark-board' ) ) {
+			return '.pc-bookmark-board';
+		}
+		if ( list.classList.contains( 'pc-link-list' ) ) {
+			return '.pc-link-list';
+		}
+		if ( list.classList.contains( 'pc-post-list' ) ) {
+			return '.pc-post-list';
+		}
+
+		return '';
+	}
+
 	function updateRow( row, item ) {
 		row.classList.toggle( 'is-private', !! item.is_private );
 
@@ -98,17 +119,35 @@
 			urlLink.textContent = item.display_url;
 		}
 
+		var embed = row.querySelector( '.pc-link-embed' );
+		if ( item.embed_html ) {
+			if ( ! embed ) {
+				embed = document.createElement( 'div' );
+				embed.className = 'pc-link-embed';
+				if ( urlLink ) {
+					urlLink.after( embed );
+				}
+			}
+			embed.innerHTML = item.embed_html;
+			embed.hidden = false;
+		} else if ( embed ) {
+			embed.remove();
+			embed = null;
+		}
+
 		var excerpt = row.querySelector( '.pc-link-excerpt' );
 		if ( ! excerpt && item.excerpt ) {
 			excerpt = document.createElement( 'p' );
 			excerpt.className = 'pc-link-excerpt';
-			if ( urlLink ) {
+			if ( embed ) {
+				embed.after( excerpt );
+			} else if ( urlLink ) {
 				urlLink.after( excerpt );
 			}
 		}
 		if ( excerpt ) {
 			excerpt.textContent = item.excerpt || '';
-			excerpt.hidden = ! item.excerpt;
+			excerpt.hidden = ! item.excerpt || !! item.embed_html;
 		}
 
 		var host = row.querySelector( '.pc-link-host' );
@@ -131,6 +170,105 @@
 
 		updateTags( row, item.terms || [] );
 		closeEditor( row );
+	}
+
+	var infiniteObserver = null;
+	var infiniteLoading = false;
+
+	function setPaginationLoading( pagination, nextLink, isLoading ) {
+		if ( pagination ) {
+			pagination.classList.toggle( 'is-loading', isLoading );
+			if ( isLoading ) {
+				pagination.setAttribute( 'aria-busy', 'true' );
+			} else {
+				pagination.removeAttribute( 'aria-busy' );
+			}
+		}
+		if ( nextLink ) {
+			if ( ! nextLink.dataset.label ) {
+				nextLink.dataset.label = nextLink.textContent;
+			}
+			nextLink.textContent = isLoading ? 'Loading...' : nextLink.dataset.label;
+		}
+	}
+
+	function setupInfiniteScroll() {
+		if ( infiniteObserver ) {
+			infiniteObserver.disconnect();
+			infiniteObserver = null;
+		}
+
+		if ( ! ( 'IntersectionObserver' in window ) || ! window.fetch || ! window.DOMParser ) {
+			return;
+		}
+
+		var nextLink = document.querySelector( '.pc-pagination-next' );
+		if ( ! nextLink ) {
+			return;
+		}
+
+		infiniteObserver = new IntersectionObserver( function ( entries ) {
+			entries.forEach( function ( entry ) {
+				if ( entry.isIntersecting ) {
+					loadNextPage();
+				}
+			} );
+		}, { rootMargin: '360px 0px' } );
+		infiniteObserver.observe( nextLink );
+	}
+
+	function loadNextPage() {
+		var currentList = getCollectionList();
+		var selector = getCollectionListSelector( currentList );
+		var pagination = document.querySelector( '.pc-pagination' );
+		var nextLink = document.querySelector( '.pc-pagination-next' );
+
+		if ( infiniteLoading || ! currentList || ! selector || ! nextLink ) {
+			return;
+		}
+
+		infiniteLoading = true;
+		if ( infiniteObserver ) {
+			infiniteObserver.disconnect();
+		}
+		setPaginationLoading( pagination, nextLink, true );
+
+		fetch( nextLink.href, {
+			credentials: 'same-origin',
+		} )
+			.then( function ( response ) {
+				if ( ! response.ok ) {
+					throw new Error( 'Could not load more items.' );
+				}
+
+				return response.text();
+			} )
+			.then( function ( html ) {
+				var doc = new DOMParser().parseFromString( html, 'text/html' );
+				var nextList = doc.querySelector( selector );
+				if ( ! nextList ) {
+					throw new Error( 'Could not load more items.' );
+				}
+
+				Array.prototype.forEach.call( nextList.children, function ( child ) {
+					currentList.appendChild( document.importNode( child, true ) );
+				} );
+
+				var nextPagination = doc.querySelector( '.pc-pagination' );
+				pagination = document.querySelector( '.pc-pagination' );
+				if ( pagination && nextPagination ) {
+					pagination.replaceWith( document.importNode( nextPagination, true ) );
+				} else if ( pagination ) {
+					pagination.remove();
+				}
+
+				infiniteLoading = false;
+				setupInfiniteScroll();
+			} )
+			.catch( function () {
+				infiniteLoading = false;
+				setPaginationLoading( pagination, nextLink, false );
+			} );
 	}
 
 	document.addEventListener( 'click', function ( event ) {
@@ -204,4 +342,10 @@
 				}
 			} );
 	} );
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', setupInfiniteScroll );
+	} else {
+		setupInfiniteScroll();
+	}
 }() );

--- a/assets/js/post-collection-app.js
+++ b/assets/js/post-collection-app.js
@@ -78,6 +78,16 @@
 		} );
 	}
 
+	function updateReadStatus( row, item ) {
+		var readStatus = row.querySelector( '.pc-read-status' );
+		if ( ! readStatus || ! item.read_status ) {
+			return;
+		}
+
+		readStatus.className = 'pc-read-status pc-read-status-' + item.read_status;
+		readStatus.textContent = item.read_label || item.read_status;
+	}
+
 	function getCollectionList() {
 		return document.querySelector( '.pc-bookmark-board, .pc-link-list, .pc-post-list' );
 	}
@@ -169,6 +179,7 @@
 		}
 
 		updateTags( row, item.terms || [] );
+		updateReadStatus( row, item );
 		closeEditor( row );
 	}
 

--- a/class-post-collection-app.php
+++ b/class-post-collection-app.php
@@ -1,0 +1,702 @@
+<?php
+/**
+ * Frontend app for post collections.
+ *
+ * @package Post_Collection
+ */
+
+namespace PostCollection;
+
+defined( 'ABSPATH' ) || exit;
+
+use WpApp\WpApp;
+
+/**
+ * WpApp-powered frontend for browsing collected posts.
+ */
+class Post_Collection_App {
+	const PATH = 'post-collection';
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var Post_Collection_App|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Post Collection plugin instance.
+	 *
+	 * @var Post_Collection
+	 */
+	private $post_collection;
+
+	/**
+	 * WpApp instance.
+	 *
+	 * @var WpApp
+	 */
+	private $app;
+
+	/**
+	 * Initialize the frontend app.
+	 *
+	 * @param Post_Collection $post_collection The plugin instance.
+	 * @return Post_Collection_App
+	 */
+	public static function boot( Post_Collection $post_collection ) {
+		if ( null === self::$instance ) {
+			self::$instance = new self( $post_collection );
+			self::$instance->init();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @return Post_Collection_App|null
+	 */
+	public static function instance() {
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Post_Collection $post_collection The plugin instance.
+	 */
+	private function __construct( Post_Collection $post_collection ) {
+		$this->post_collection = $post_collection;
+		$this->app = new WpApp(
+			POST_COLLECTION_PLUGIN_DIR . 'templates/app',
+			self::PATH,
+			array(
+				'app_name'                      => __( 'Post Collection', 'post-collection' ),
+				'my_apps'                       => __( 'Post Collection', 'post-collection' ),
+				'show_wp_logo'                  => false,
+				'show_site_name'                => true,
+				'show_dark_mode_toggle'         => true,
+				'show_masterbar_for_anonymous' => true,
+			)
+		);
+	}
+
+	/**
+	 * Set up routes and assets.
+	 */
+	private function init() {
+		add_action( 'wp_loaded', array( $this, 'handle_quick_edit' ) );
+		add_action( 'wp_ajax_post_collection_quick_edit', array( $this, 'wp_ajax_quick_edit' ) );
+
+		$this->app->route( '' );
+		$this->app->route( '{username}', 'collection.php' );
+		$this->app->route( '{username}/{post_id}', 'post.php' );
+
+		$this->app->add_menu_item(
+			'collections',
+			__( 'Collections', 'post-collection' ),
+			$this->get_home_url()
+		);
+
+		if ( current_user_can( $this->post_collection->get_required_role() ) ) {
+			$this->app->add_menu_item(
+				'new-collection',
+				__( 'New Collection', 'post-collection' ),
+				self_admin_url( 'admin.php?page=create-post-collection' )
+			);
+		}
+
+		if ( function_exists( 'wp_app_enqueue_style' ) ) {
+			wp_app_enqueue_style(
+				'post-collection-app',
+				plugins_url( 'assets/css/post-collection-app.css', POST_COLLECTION_PLUGIN_FILE ),
+				array(),
+				POST_COLLECTION_VERSION
+			);
+			wp_app_enqueue_script(
+				'post-collection-app',
+				plugins_url( 'assets/js/post-collection-app.js', POST_COLLECTION_PLUGIN_FILE ),
+				array(),
+				POST_COLLECTION_VERSION,
+				true
+			);
+		}
+
+		$this->app->init();
+	}
+
+	/**
+	 * Get the backing plugin instance.
+	 *
+	 * @return Post_Collection
+	 */
+	public function get_post_collection() {
+		return $this->post_collection;
+	}
+
+	/**
+	 * Get the app home URL.
+	 *
+	 * @return string
+	 */
+	public function get_home_url() {
+		return home_url( '/' . self::PATH . '/' );
+	}
+
+	/**
+	 * Get the URL for a collection or a collected post.
+	 *
+	 * @param \WP_User|User $user    The collection user.
+	 * @param int|null      $post_id Optional post ID.
+	 * @return string
+	 */
+	public function get_collection_url( $user, $post_id = null ) {
+		$path = '/' . self::PATH . '/' . rawurlencode( $user->user_login ) . '/';
+
+		if ( $post_id ) {
+			$path .= absint( $post_id ) . '/';
+		}
+
+		return home_url( $path );
+	}
+
+	/**
+	 * Get collection users.
+	 *
+	 * @return array
+	 */
+	public function get_collections() {
+		return $this->post_collection->get_post_collection_users()->get_results();
+	}
+
+	/**
+	 * Find a collection by URL username.
+	 *
+	 * @param string $username The route username.
+	 * @return User|null
+	 */
+	public function get_collection_by_username( $username ) {
+		$username = sanitize_user( rawurldecode( $username ), true );
+
+		foreach ( $this->get_collections() as $user ) {
+			if (
+				$user->user_login === $username ||
+				sanitize_title( $user->user_login ) === sanitize_title( $username ) ||
+				sanitize_title( $user->display_name ) === sanitize_title( $username )
+			) {
+				return $user;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Whether the current visitor can manage all collections.
+	 *
+	 * @return bool
+	 */
+	public function can_manage_collections() {
+		return current_user_can( $this->post_collection->get_required_role() );
+	}
+
+	/**
+	 * Whether the current visitor can view a collection.
+	 *
+	 * @param User|\WP_User $user The collection user.
+	 * @return bool
+	 */
+	public function can_view_collection( $user ) {
+		if ( $this->can_manage_collections() ) {
+			return true;
+		}
+
+		return (bool) get_user_option( 'friends_publish_post_collection', $user->ID );
+	}
+
+	/**
+	 * Whether private posts should be included for this visitor.
+	 *
+	 * @param User|\WP_User $user The collection user.
+	 * @return bool
+	 */
+	public function can_view_private_posts( $user ) {
+		return $this->can_manage_collections();
+	}
+
+	/**
+	 * Get the frontend mode for a collection.
+	 *
+	 * @param User|\WP_User $user The collection user.
+	 * @return string
+	 */
+	public function get_collection_mode( $user ) {
+		$mode = get_user_option( 'post_collection_frontend_mode', $user->ID );
+		if ( in_array( $mode, array( 'bookmarks', 'posts' ), true ) ) {
+			return $mode;
+		}
+
+		if ( $this->is_bookmark_collection( $user ) ) {
+			return 'bookmarks';
+		}
+
+		return 'posts';
+	}
+
+	/**
+	 * Get the default frontend view for a collection.
+	 *
+	 * @param User|\WP_User $user The collection user.
+	 * @return string
+	 */
+	public function get_collection_default_view( $user ) {
+		$view = get_user_option( 'post_collection_frontend_view', $user->ID );
+		if ( in_array( $view, array( 'board', 'links', 'reader' ), true ) ) {
+			return $view;
+		}
+
+		if ( 'bookmarks' === $this->get_collection_mode( $user ) ) {
+			return 'links';
+		}
+
+		return 'reader';
+	}
+
+	/**
+	 * Get the active frontend view for a collection.
+	 *
+	 * @param User|\WP_User $user The collection user.
+	 * @return string
+	 */
+	public function get_collection_view( $user ) {
+		if ( isset( $_GET['pc-view'] ) ) {
+			$view = sanitize_key( wp_unslash( $_GET['pc-view'] ) );
+			if ( in_array( $view, array( 'board', 'links', 'reader' ), true ) ) {
+				return $view;
+			}
+		}
+
+		return $this->get_collection_default_view( $user );
+	}
+
+	/**
+	 * Whether quick edit mode is active for the current request.
+	 *
+	 * @return bool
+	 */
+	public function is_quick_edit_mode() {
+		return $this->can_manage_collections() && $this->get_quick_edit_post_id() > 0;
+	}
+
+	/**
+	 * Get the post currently targeted by quick edit.
+	 *
+	 * @return int
+	 */
+	public function get_quick_edit_post_id() {
+		if ( ! isset( $_GET['pc-edit'] ) ) {
+			return 0;
+		}
+
+		return absint( wp_unslash( $_GET['pc-edit'] ) );
+	}
+
+	/**
+	 * Handle quick edit submissions from the links view.
+	 */
+	public function handle_quick_edit() {
+		if ( wp_doing_ajax() ) {
+			return;
+		}
+
+		if ( ! isset( $_POST['post_collection_action'] ) || 'quick-edit' !== $_POST['post_collection_action'] ) {
+			return;
+		}
+
+		$post_id = isset( $_POST['post_id'] ) ? absint( wp_unslash( $_POST['post_id'] ) ) : 0;
+		$result = $this->update_quick_edit_post( $_POST );
+		if ( is_wp_error( $result ) ) {
+			wp_die( esc_html( $result->get_error_message() ), '', array( 'response' => $result->get_error_data( 'status' ) ? $result->get_error_data( 'status' ) : 400 ) );
+		}
+
+		$redirect = wp_get_referer();
+		if ( ! $redirect ) {
+			$post = get_post( $post_id );
+			$redirect = $post ? $this->get_collection_url( new User( $post->post_author ) ) : $this->get_home_url();
+		}
+
+		wp_safe_redirect( add_query_arg( array( 'pc-view' => 'links', 'pc-edit' => $post_id ), remove_query_arg( array( '_wpnonce' ), $redirect ) ) . '#pc-link-' . $post_id );
+		exit;
+	}
+
+	/**
+	 * Handle quick edit AJAX submissions from the links view.
+	 */
+	public function wp_ajax_quick_edit() {
+		$result = $this->update_quick_edit_post( $_POST );
+		if ( is_wp_error( $result ) ) {
+			wp_send_json_error(
+				array(
+					'message' => $result->get_error_message(),
+				),
+				$result->get_error_data( 'status' ) ? $result->get_error_data( 'status' ) : 400
+			);
+		}
+
+		wp_send_json_success( $result );
+	}
+
+	/**
+	 * Update a post from quick edit request data.
+	 *
+	 * @param array $data Request data.
+	 * @return array|\WP_Error
+	 */
+	private function update_quick_edit_post( array $data ) {
+		if ( ! $this->can_manage_collections() ) {
+			return new \WP_Error( 'forbidden', __( 'Sorry, you are not allowed to edit this collection.', 'post-collection' ), array( 'status' => 403 ) );
+		}
+
+		$post_id = isset( $data['post_id'] ) ? absint( wp_unslash( $data['post_id'] ) ) : 0;
+		if ( ! $post_id || ! isset( $data['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $data['_wpnonce'] ) ), 'post-collection-quick-edit-' . $post_id ) ) {
+			return new \WP_Error( 'invalid_nonce', __( 'The quick edit request could not be verified.', 'post-collection' ), array( 'status' => 403 ) );
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post || Post_Collection::CPT !== $post->post_type ) {
+			return new \WP_Error( 'not_found', __( 'That post does not exist.', 'post-collection' ), array( 'status' => 404 ) );
+		}
+
+		$title       = isset( $data['post_title'] ) ? sanitize_text_field( wp_unslash( $data['post_title'] ) ) : $post->post_title;
+		$url         = isset( $data['source_url'] ) ? esc_url_raw( wp_unslash( $data['source_url'] ) ) : $post->guid;
+		$description = isset( $data['post_excerpt'] ) ? sanitize_textarea_field( wp_unslash( $data['post_excerpt'] ) ) : $post->post_excerpt;
+		$status      = isset( $data['post_status'] ) && 'publish' === wp_unslash( $data['post_status'] ) ? 'publish' : 'private';
+
+		$update = array(
+			'ID'           => $post_id,
+			'post_title'   => $title ? $title : $post->post_title,
+			'post_excerpt' => $description,
+			'post_status'  => $status,
+		);
+
+		if ( $this->post_collection->check_url( $url ) ) {
+			$update['guid'] = $url;
+		}
+
+		$updated = wp_update_post( $update, true );
+		if ( is_wp_error( $updated ) ) {
+			return $updated;
+		}
+
+		$taxonomy = $this->post_collection->get_tag_taxonomy();
+		if ( taxonomy_exists( $taxonomy ) ) {
+			$tags = isset( $data['post_tags'] ) ? sanitize_text_field( wp_unslash( $data['post_tags'] ) ) : '';
+			$tags = array_filter( array_map( 'trim', explode( ',', $tags ) ) );
+			$terms_updated = wp_set_object_terms( $post_id, $tags, $taxonomy, false );
+			if ( is_wp_error( $terms_updated ) ) {
+				return $terms_updated;
+			}
+		}
+
+		$post = get_post( $post_id );
+		$user = new User( $post->post_author );
+		$terms = $this->get_post_terms( $post );
+		$base_url = $this->get_collection_url( $user );
+		$term_data = array();
+		foreach ( $terms as $term ) {
+			$term_data[] = array(
+				'name' => $term->name,
+				'slug' => $term->slug,
+				'url'  => add_query_arg(
+					array(
+						'pc-tag'  => $term->slug,
+						'pc-view' => 'links',
+					),
+					$base_url
+				),
+			);
+		}
+
+		$source_url = $this->get_source_url( $post );
+
+		return array(
+			'id'          => $post->ID,
+			'title'       => get_the_title( $post ),
+			'source_url'  => $source_url,
+			'display_url' => preg_replace( '#^https?://#', '', $source_url ),
+			'excerpt'     => $this->get_post_excerpt( $post, 24 ),
+			'host'        => $this->get_source_host( $post ),
+			'is_private'  => 'private' === $post->post_status,
+			'status'      => $post->post_status,
+			'terms'       => $term_data,
+		);
+	}
+
+	/**
+	 * Get available frontend views.
+	 *
+	 * @return array
+	 */
+	public function get_available_views() {
+		return array(
+			'board'  => __( 'Board', 'post-collection' ),
+			'links'  => __( 'Links', 'post-collection' ),
+			'reader' => __( 'Reader', 'post-collection' ),
+		);
+	}
+
+	/**
+	 * Detect whether a collection should use the bookmark UI.
+	 *
+	 * @param User|\WP_User $user The collection user.
+	 * @return bool
+	 */
+	public function is_bookmark_collection( $user ) {
+		$bookmark_slugs = apply_filters(
+			'post_collection_bookmark_collection_slugs',
+			array( 'bookmark', 'bookmarks' )
+		);
+		$collection_slugs = array(
+			sanitize_title( $user->user_login ),
+			sanitize_title( $user->display_name ),
+		);
+
+		foreach ( $collection_slugs as $collection_slug ) {
+			foreach ( $bookmark_slugs as $bookmark_slug ) {
+				$bookmark_slug = sanitize_title( $bookmark_slug );
+				if ( $collection_slug === $bookmark_slug || false !== strpos( $collection_slug, $bookmark_slug ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Query posts for a collection.
+	 *
+	 * @param User|\WP_User $user The collection user.
+	 * @param array         $args Optional query args.
+	 * @return \WP_Query
+	 */
+	public function query_collection_posts( $user, array $args = array() ) {
+		$apply_filters = ! isset( $args['post_collection_apply_filters'] ) || $args['post_collection_apply_filters'];
+		unset( $args['post_collection_apply_filters'] );
+
+		$defaults = array(
+			'post_type'           => Post_Collection::CPT,
+			'post_status'         => $this->can_view_private_posts( $user ) ? array( 'publish', 'private' ) : array( 'publish' ),
+			'author'              => $user->ID,
+			'posts_per_page'      => 24,
+			'paged'               => isset( $_GET['pc-page'] ) ? max( 1, absint( wp_unslash( $_GET['pc-page'] ) ) ) : 1,
+			'ignore_sticky_posts' => true,
+		);
+
+		$query_args = wp_parse_args( $args, $defaults );
+
+		if ( $apply_filters && isset( $_GET['pc-search'] ) && '' !== trim( wp_unslash( $_GET['pc-search'] ) ) ) {
+			$query_args['s'] = sanitize_text_field( wp_unslash( $_GET['pc-search'] ) );
+		}
+
+		if ( $apply_filters && isset( $_GET['pc-tag'] ) && taxonomy_exists( $this->post_collection->get_tag_taxonomy() ) ) {
+			$query_args['tax_query'] = array(
+				array(
+					'taxonomy' => $this->post_collection->get_tag_taxonomy(),
+					'field'    => 'slug',
+					'terms'    => sanitize_title( wp_unslash( $_GET['pc-tag'] ) ),
+				),
+			);
+		}
+
+		return new \WP_Query( $query_args );
+	}
+
+	/**
+	 * Get a visible post from a collection.
+	 *
+	 * @param int           $post_id The post ID.
+	 * @param User|\WP_User $user    The collection user.
+	 * @return \WP_Post|null
+	 */
+	public function get_visible_post( $post_id, $user ) {
+		$post = get_post( $post_id );
+
+		if ( ! $post || Post_Collection::CPT !== $post->post_type || intval( $post->post_author ) !== intval( $user->ID ) ) {
+			return null;
+		}
+
+		if ( 'publish' !== $post->post_status && ! $this->can_view_private_posts( $user ) ) {
+			return null;
+		}
+
+		return $post;
+	}
+
+	/**
+	 * Count visible posts in a collection.
+	 *
+	 * @param User|\WP_User $user The collection user.
+	 * @return int
+	 */
+	public function count_collection_posts( $user ) {
+		$query = $this->query_collection_posts(
+			$user,
+			array(
+				'posts_per_page'                 => 1,
+				'fields'                         => 'ids',
+				'post_collection_apply_filters' => false,
+			)
+		);
+
+		return intval( $query->found_posts );
+	}
+
+	/**
+	 * Get the source URL for a collected post.
+	 *
+	 * @param \WP_Post $post The post.
+	 * @return string
+	 */
+	public function get_source_url( \WP_Post $post ) {
+		if ( $this->post_collection->check_url( $post->guid ) ) {
+			return $post->guid;
+		}
+
+		return get_permalink( $post );
+	}
+
+	/**
+	 * Get a compact source host.
+	 *
+	 * @param \WP_Post $post The post.
+	 * @return string
+	 */
+	public function get_source_host( \WP_Post $post ) {
+		$host = wp_parse_url( $this->get_source_url( $post ), PHP_URL_HOST );
+		if ( ! $host ) {
+			return '';
+		}
+
+		return preg_replace( '#^www\.#', '', strtolower( $host ) );
+	}
+
+	/**
+	 * Get the best image URL for a post card.
+	 *
+	 * @param \WP_Post $post The post.
+	 * @return string
+	 */
+	public function get_post_image_url( \WP_Post $post ) {
+		$thumbnail = get_the_post_thumbnail_url( $post, 'large' );
+		if ( $thumbnail ) {
+			return $thumbnail;
+		}
+
+		if ( class_exists( '\WP_HTML_Tag_Processor' ) ) {
+			$processor = new \WP_HTML_Tag_Processor( $post->post_content );
+			while ( $processor->next_tag( 'img' ) ) {
+				$src = $processor->get_attribute( 'src' );
+				if ( $src ) {
+					return esc_url_raw( $src );
+				}
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Get a trimmed excerpt for a card.
+	 *
+	 * @param \WP_Post $post   The post.
+	 * @param int      $length Word length.
+	 * @return string
+	 */
+	public function get_post_excerpt( \WP_Post $post, $length = 28 ) {
+		$text = $post->post_excerpt ? $post->post_excerpt : $post->post_content;
+		$text = wp_strip_all_tags( strip_shortcodes( $text ) );
+
+		return wp_trim_words( $text, $length );
+	}
+
+	/**
+	 * Get terms attached to a post.
+	 *
+	 * @param \WP_Post $post The post.
+	 * @return array
+	 */
+	public function get_post_terms( \WP_Post $post ) {
+		$taxonomy = $this->post_collection->get_tag_taxonomy();
+		if ( ! taxonomy_exists( $taxonomy ) ) {
+			return array();
+		}
+
+		$terms = get_the_terms( $post, $taxonomy );
+		if ( is_wp_error( $terms ) || ! $terms ) {
+			return array();
+		}
+
+		return $terms;
+	}
+
+	/**
+	 * Get popular terms for the visible collection posts.
+	 *
+	 * @param User|\WP_User $user The collection user.
+	 * @return array
+	 */
+	public function get_collection_terms( $user ) {
+		$taxonomy = $this->post_collection->get_tag_taxonomy();
+		if ( ! taxonomy_exists( $taxonomy ) ) {
+			return array();
+		}
+
+		$query = $this->query_collection_posts(
+			$user,
+			array(
+				'posts_per_page'                 => 100,
+				'fields'                         => 'ids',
+				'post_collection_apply_filters' => false,
+			)
+		);
+
+		if ( empty( $query->posts ) ) {
+			return array();
+		}
+
+		$terms = get_terms(
+			array(
+				'taxonomy'   => $taxonomy,
+				'object_ids' => $query->posts,
+				'hide_empty' => true,
+				'number'     => 18,
+				'orderby'    => 'count',
+				'order'      => 'DESC',
+			)
+		);
+
+		if ( is_wp_error( $terms ) || ! $terms ) {
+			return array();
+		}
+
+		return $terms;
+	}
+
+	/**
+	 * Get an external save URL for the collection.
+	 *
+	 * @param User|\WP_User $user The collection user.
+	 * @return string
+	 */
+	public function get_save_url( $user ) {
+		return add_query_arg(
+			array(
+				'user' => $user->ID,
+			),
+			home_url( '/' )
+		);
+	}
+}

--- a/class-post-collection-app.php
+++ b/class-post-collection-app.php
@@ -88,12 +88,16 @@ class Post_Collection_App {
 	 */
 	private function init() {
 		add_action( 'wp_loaded', array( $this, 'handle_quick_edit' ) );
+		add_action( 'wp_loaded', array( $this, 'handle_collection_settings' ) );
+		add_action( 'wp_loaded', array( $this, 'handle_create_collection' ) );
 		add_action( 'wp_ajax_post_collection_quick_edit', array( $this, 'wp_ajax_quick_edit' ) );
 		add_filter( 'private_title_format', array( $this, 'filter_private_title_format' ), 10, 2 );
 
 		$this->app->route( '' );
-		$this->app->route( '{username}', 'collection.php' );
-		$this->app->route( '{username}/{post_id}', 'post.php' );
+		$this->app->route( 'new', 'new.php' );
+		$this->app->route( '{collection}/settings', 'settings.php' );
+		$this->app->route( '{collection}', 'collection.php' );
+		$this->app->route( '{collection}/{post_id}', 'post.php' );
 
 		$this->app->add_menu_item(
 			'collections',
@@ -105,7 +109,7 @@ class Post_Collection_App {
 			$this->app->add_menu_item(
 				'new-collection',
 				__( 'New Collection', 'post-collection' ),
-				self_admin_url( 'admin.php?page=create-post-collection' )
+				$this->get_new_collection_url()
 			);
 		}
 
@@ -147,14 +151,23 @@ class Post_Collection_App {
 	}
 
 	/**
+	 * Get the app URL for creating a collection.
+	 *
+	 * @return string
+	 */
+	public function get_new_collection_url() {
+		return home_url( '/' . self::PATH . '/new/' );
+	}
+
+	/**
 	 * Get the URL for a collection or a collected post.
 	 *
-	 * @param \WP_User|User $user    The collection user.
+	 * @param \WP_Term $collection The collection term.
 	 * @param int|null      $post_id Optional post ID.
 	 * @return string
 	 */
-	public function get_collection_url( $user, $post_id = null ) {
-		$path = '/' . self::PATH . '/' . rawurlencode( $user->user_login ) . '/';
+	public function get_collection_url( $collection, $post_id = null ) {
+		$path = '/' . self::PATH . '/' . rawurlencode( $collection->slug ) . '/';
 
 		if ( $post_id ) {
 			$path .= absint( $post_id ) . '/';
@@ -164,31 +177,43 @@ class Post_Collection_App {
 	}
 
 	/**
-	 * Get collection users.
+	 * Get the settings URL for a collection.
+	 *
+	 * @param \WP_Term $collection The collection term.
+	 * @return string
+	 */
+	public function get_collection_settings_url( $collection ) {
+		return trailingslashit( $this->get_collection_url( $collection ) . 'settings' );
+	}
+
+	/**
+	 * Get collection terms.
 	 *
 	 * @return array
 	 */
 	public function get_collections() {
-		return $this->post_collection->get_post_collection_users()->get_results();
+		$terms = get_terms(
+			array(
+				'taxonomy'   => Post_Collection::COLLECTION_TAXONOMY,
+				'hide_empty' => false,
+			)
+		);
+
+		return is_wp_error( $terms ) ? array() : $terms;
 	}
 
 	/**
-	 * Find a collection by URL username.
+	 * Find a collection by URL slug.
 	 *
-	 * @param string $username The route username.
-	 * @return User|null
+	 * @param string $collection_slug The route collection slug.
+	 * @return \WP_Term|null
 	 */
-	public function get_collection_by_username( $username ) {
-		$username = sanitize_user( rawurldecode( $username ), true );
+	public function get_collection_by_username( $collection_slug ) {
+		$collection_slug = sanitize_title( rawurldecode( $collection_slug ) );
 
-		foreach ( $this->get_collections() as $user ) {
-			if (
-				$user->user_login === $username ||
-				sanitize_title( $user->user_login ) === sanitize_title( $username ) ||
-				sanitize_title( $user->display_name ) === sanitize_title( $username )
-			) {
-				return $user;
-			}
+		$term = get_term_by( 'slug', $collection_slug, Post_Collection::COLLECTION_TAXONOMY );
+		if ( $term && ! is_wp_error( $term ) ) {
+			return $term;
 		}
 
 		return null;
@@ -206,24 +231,24 @@ class Post_Collection_App {
 	/**
 	 * Whether the current visitor can view a collection.
 	 *
-	 * @param User|\WP_User $user The collection user.
+	 * @param \WP_Term $collection The collection term.
 	 * @return bool
 	 */
-	public function can_view_collection( $user ) {
+	public function can_view_collection( $collection ) {
 		if ( $this->can_manage_collections() ) {
 			return true;
 		}
 
-		return (bool) get_user_option( 'friends_publish_post_collection', $user->ID );
+		return (bool) get_term_meta( $collection->term_id, 'friends_publish_post_collection', true );
 	}
 
 	/**
 	 * Whether private posts should be included for this visitor.
 	 *
-	 * @param User|\WP_User $user The collection user.
+	 * @param \WP_Term $collection The collection term.
 	 * @return bool
 	 */
-	public function can_view_private_posts( $user ) {
+	public function can_view_private_posts( $collection ) {
 		return $this->can_manage_collections();
 	}
 
@@ -268,16 +293,16 @@ class Post_Collection_App {
 	/**
 	 * Get the frontend mode for a collection.
 	 *
-	 * @param User|\WP_User $user The collection user.
+	 * @param \WP_Term $collection The collection term.
 	 * @return string
 	 */
-	public function get_collection_mode( $user ) {
-		$mode = get_user_option( 'post_collection_frontend_mode', $user->ID );
+	public function get_collection_mode( $collection ) {
+		$mode = get_term_meta( $collection->term_id, 'post_collection_frontend_mode', true );
 		if ( in_array( $mode, array( 'bookmarks', 'posts' ), true ) ) {
 			return $mode;
 		}
 
-		if ( $this->is_bookmark_collection( $user ) ) {
+		if ( $this->is_bookmark_collection( $collection ) ) {
 			return 'bookmarks';
 		}
 
@@ -287,16 +312,16 @@ class Post_Collection_App {
 	/**
 	 * Get the default frontend view for a collection.
 	 *
-	 * @param User|\WP_User $user The collection user.
+	 * @param \WP_Term $collection The collection term.
 	 * @return string
 	 */
-	public function get_collection_default_view( $user ) {
-		$view = get_user_option( 'post_collection_frontend_view', $user->ID );
+	public function get_collection_default_view( $collection ) {
+		$view = get_term_meta( $collection->term_id, 'post_collection_frontend_view', true );
 		if ( in_array( $view, array( 'board', 'links', 'reader' ), true ) ) {
 			return $view;
 		}
 
-		if ( 'bookmarks' === $this->get_collection_mode( $user ) ) {
+		if ( 'bookmarks' === $this->get_collection_mode( $collection ) ) {
 			return 'links';
 		}
 
@@ -306,10 +331,10 @@ class Post_Collection_App {
 	/**
 	 * Get the active frontend view for a collection.
 	 *
-	 * @param User|\WP_User $user The collection user.
+	 * @param \WP_Term $collection The collection term.
 	 * @return string
 	 */
-	public function get_collection_view( $user ) {
+	public function get_collection_view( $collection ) {
 		if ( isset( $_GET['pc-view'] ) ) {
 			$view = sanitize_key( wp_unslash( $_GET['pc-view'] ) );
 			if ( in_array( $view, array( 'board', 'links', 'reader' ), true ) ) {
@@ -317,7 +342,141 @@ class Post_Collection_App {
 			}
 		}
 
-		return $this->get_collection_default_view( $user );
+		return $this->get_collection_default_view( $collection );
+	}
+
+	/**
+	 * Handle collection frontend settings submissions.
+	 */
+	public function handle_collection_settings() {
+		if ( wp_doing_ajax() ) {
+			return;
+		}
+
+		if ( ! isset( $_POST['post_collection_action'] ) || 'collection-settings' !== $_POST['post_collection_action'] ) {
+			return;
+		}
+
+		if ( ! $this->can_manage_collections() ) {
+			wp_die( esc_html__( 'Sorry, you are not allowed to edit this collection.', 'post-collection' ), '', array( 'response' => 403 ) );
+		}
+
+		$term_id = isset( $_POST['collection_term_id'] ) ? absint( wp_unslash( $_POST['collection_term_id'] ) ) : 0;
+		if ( ! $term_id || ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'post-collection-settings-' . $term_id ) ) {
+			wp_die( esc_html__( 'The collection settings request could not be verified.', 'post-collection' ), '', array( 'response' => 403 ) );
+		}
+
+		$collection = get_term( $term_id, Post_Collection::COLLECTION_TAXONOMY );
+		if ( ! $collection || is_wp_error( $collection ) ) {
+			wp_die( esc_html__( 'Invalid post collection.', 'post-collection' ), '', array( 'response' => 404 ) );
+		}
+
+		$frontend_mode = isset( $_POST['frontend_mode'] ) ? sanitize_key( wp_unslash( $_POST['frontend_mode'] ) ) : 'auto';
+		if ( in_array( $frontend_mode, array( 'auto', 'bookmarks', 'posts' ), true ) ) {
+			if ( 'auto' === $frontend_mode ) {
+				delete_term_meta( $collection->term_id, 'post_collection_frontend_mode' );
+			} else {
+				update_term_meta( $collection->term_id, 'post_collection_frontend_mode', $frontend_mode );
+			}
+		}
+
+		$frontend_view = isset( $_POST['frontend_view'] ) ? sanitize_key( wp_unslash( $_POST['frontend_view'] ) ) : 'auto';
+		if ( in_array( $frontend_view, array( 'auto', 'board', 'links', 'reader' ), true ) ) {
+			if ( 'auto' === $frontend_view ) {
+				delete_term_meta( $collection->term_id, 'post_collection_frontend_view' );
+			} else {
+				update_term_meta( $collection->term_id, 'post_collection_frontend_view', $frontend_view );
+			}
+		}
+
+		wp_safe_redirect( add_query_arg( 'pc-settings-updated', '1', $this->get_collection_settings_url( $collection ) ) );
+		exit;
+	}
+
+	/**
+	 * Handle frontend collection creation submissions.
+	 */
+	public function handle_create_collection() {
+		if ( wp_doing_ajax() ) {
+			return;
+		}
+
+		if ( ! isset( $_POST['post_collection_action'] ) || 'create-collection' !== $_POST['post_collection_action'] ) {
+			return;
+		}
+
+		$result = $this->create_collection_from_request( $_POST );
+		if ( is_wp_error( $result ) ) {
+			wp_die( wp_kses_post( $result->get_error_message() ), '', array( 'response' => $result->get_error_data( 'status' ) ? $result->get_error_data( 'status' ) : 400 ) );
+		}
+
+		wp_safe_redirect( $this->get_collection_url( $result ) );
+		exit;
+	}
+
+	/**
+	 * Create a post collection term from request data.
+	 *
+	 * @param array $data Request data.
+	 * @return \WP_Term|\WP_Error
+	 */
+	public function create_collection_from_request( array $data ) {
+		if ( ! $this->can_manage_collections() ) {
+			return new \WP_Error( 'forbidden', __( 'Sorry, you are not allowed to create collections.', 'post-collection' ), array( 'status' => 403 ) );
+		}
+
+		if ( ! isset( $data['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $data['_wpnonce'] ) ), 'post-collection-create' ) ) {
+			return new \WP_Error( 'invalid_nonce', __( 'The create collection request could not be verified.', 'post-collection' ), array( 'status' => 403 ) );
+		}
+
+		$display_name = isset( $data['display_name'] ) ? sanitize_text_field( wp_unslash( $data['display_name'] ) ) : '';
+		$user_login   = isset( $data['user_login'] ) ? sanitize_user( wp_unslash( $data['user_login'] ) ) : '';
+		if ( ! $user_login && $display_name ) {
+			$user_login = User::sanitize_username( $display_name );
+		}
+
+		if ( ! $user_login ) {
+			return new \WP_Error( 'invalid_collection_slug', __( 'Please enter a valid collection slug.', 'post-collection' ), array( 'status' => 400 ) );
+		}
+
+		if ( term_exists( $user_login, Post_Collection::COLLECTION_TAXONOMY ) ) {
+			return new \WP_Error( 'existing_collection_slug', __( 'That collection slug already exists. Please choose another one.', 'post-collection' ), array( 'status' => 400 ) );
+		}
+
+		if ( ! $display_name ) {
+			return new \WP_Error( 'invalid_display_name', __( 'Please enter a display name.', 'post-collection' ), array( 'status' => 400 ) );
+		}
+
+		$created = wp_insert_term(
+			$display_name,
+			Post_Collection::COLLECTION_TAXONOMY,
+			array(
+				'slug' => $user_login,
+			)
+		);
+
+		if ( is_wp_error( $created ) ) {
+			return $created;
+		}
+
+		$collection = get_term( $created['term_id'], Post_Collection::COLLECTION_TAXONOMY );
+		if ( ! $collection || is_wp_error( $collection ) ) {
+			return new \WP_Error( 'collection_not_found', __( 'The collection was created but could not be loaded.', 'post-collection' ), array( 'status' => 500 ) );
+		}
+
+		$frontend_mode = isset( $data['frontend_mode'] ) ? sanitize_key( wp_unslash( $data['frontend_mode'] ) ) : 'auto';
+		if ( in_array( $frontend_mode, array( 'bookmarks', 'posts' ), true ) ) {
+			update_term_meta( $collection->term_id, 'post_collection_frontend_mode', $frontend_mode );
+		}
+
+		$frontend_view = isset( $data['frontend_view'] ) ? sanitize_key( wp_unslash( $data['frontend_view'] ) ) : 'auto';
+		if ( in_array( $frontend_view, array( 'board', 'links', 'reader' ), true ) ) {
+			update_term_meta( $collection->term_id, 'post_collection_frontend_view', $frontend_view );
+		}
+
+		update_term_meta( $collection->term_id, 'friends_publish_post_collection', true );
+
+		return $collection;
 	}
 
 	/**
@@ -363,7 +522,8 @@ class Post_Collection_App {
 		$redirect = wp_get_referer();
 		if ( ! $redirect ) {
 			$post = get_post( $post_id );
-			$redirect = $post ? $this->get_collection_url( new User( $post->post_author ) ) : $this->get_home_url();
+			$collection = $post ? $this->get_post_collection_term( $post ) : null;
+			$redirect = $collection ? $this->get_collection_url( $collection ) : $this->get_home_url();
 		}
 
 		wp_safe_redirect( add_query_arg( array( 'pc-view' => 'links', 'pc-edit' => $post_id ), remove_query_arg( array( '_wpnonce' ), $redirect ) ) . '#pc-link-' . $post_id );
@@ -408,10 +568,11 @@ class Post_Collection_App {
 			return new \WP_Error( 'not_found', __( 'That post does not exist.', 'post-collection' ), array( 'status' => 404 ) );
 		}
 
-		$title       = isset( $data['post_title'] ) ? sanitize_text_field( wp_unslash( $data['post_title'] ) ) : $post->post_title;
-		$url         = isset( $data['source_url'] ) ? esc_url_raw( wp_unslash( $data['source_url'] ) ) : $post->guid;
-		$description = isset( $data['post_excerpt'] ) ? sanitize_textarea_field( wp_unslash( $data['post_excerpt'] ) ) : $post->post_excerpt;
-		$status      = isset( $data['post_status'] ) && 'publish' === wp_unslash( $data['post_status'] ) ? 'publish' : 'private';
+		$title          = isset( $data['post_title'] ) ? sanitize_text_field( wp_unslash( $data['post_title'] ) ) : $post->post_title;
+		$url            = isset( $data['source_url'] ) ? esc_url_raw( wp_unslash( $data['source_url'] ) ) : $post->guid;
+		$description    = isset( $data['post_excerpt'] ) ? sanitize_textarea_field( wp_unslash( $data['post_excerpt'] ) ) : $post->post_excerpt;
+		$status         = isset( $data['post_status'] ) && 'publish' === wp_unslash( $data['post_status'] ) ? 'publish' : 'private';
+		$article_status = isset( $data['article_status'] ) ? sanitize_key( wp_unslash( $data['article_status'] ) ) : '';
 
 		$update = array(
 			'ID'           => $post_id,
@@ -429,6 +590,13 @@ class Post_Collection_App {
 			return $updated;
 		}
 
+		if ( $article_status && in_array( $article_status, array_keys( $this->get_article_statuses() ), true ) ) {
+			$note_id = $this->post_collection->get_article_notes()->save_note( $post_id, $article_status );
+			if ( ! $note_id ) {
+				return new \WP_Error( 'note_save_failed', __( 'The reading status could not be saved.', 'post-collection' ), array( 'status' => 500 ) );
+			}
+		}
+
 		$taxonomy = $this->post_collection->get_tag_taxonomy();
 		if ( taxonomy_exists( $taxonomy ) ) {
 			$tags = isset( $data['post_tags'] ) ? sanitize_text_field( wp_unslash( $data['post_tags'] ) ) : '';
@@ -440,9 +608,9 @@ class Post_Collection_App {
 		}
 
 		$post = get_post( $post_id );
-		$user = new User( $post->post_author );
+		$collection = $this->get_post_collection_term( $post );
 		$terms = $this->get_post_terms( $post );
-		$base_url = $this->get_collection_url( $user );
+		$base_url = $collection ? $this->get_collection_url( $collection ) : $this->get_home_url();
 		$term_data = array();
 		foreach ( $terms as $term ) {
 			$term_data[] = array(
@@ -458,7 +626,8 @@ class Post_Collection_App {
 			);
 		}
 
-		$source_url = $this->get_source_url( $post );
+		$source_url   = $this->get_source_url( $post );
+		$read_status = $this->get_article_note_status( $post );
 
 		return array(
 			'id'          => $post->ID,
@@ -470,8 +639,45 @@ class Post_Collection_App {
 			'host'        => $this->get_source_host( $post ),
 			'is_private'  => 'private' === $post->post_status,
 			'status'      => $post->post_status,
+			'read_status' => $read_status,
+			'read_label'  => $this->get_article_note_status_label( $read_status ),
 			'terms'       => $term_data,
 		);
+	}
+
+	/**
+	 * Get available reading statuses.
+	 *
+	 * @return array
+	 */
+	public function get_article_statuses() {
+		return Article_Notes::get_statuses();
+	}
+
+	/**
+	 * Get the current reading status for a collected post.
+	 *
+	 * @param \WP_Post $post The post.
+	 * @return string
+	 */
+	public function get_article_note_status( \WP_Post $post ) {
+		$note = $this->post_collection->get_article_notes()->get_note( $post->ID );
+		if ( $note && ! empty( $note['status'] ) && in_array( $note['status'], array_keys( $this->get_article_statuses() ), true ) ) {
+			return $note['status'];
+		}
+
+		return Article_Notes::STATUS_UNREAD;
+	}
+
+	/**
+	 * Get a label for a reading status.
+	 *
+	 * @param string $status Reading status.
+	 * @return string
+	 */
+	public function get_article_note_status_label( $status ) {
+		$statuses = $this->get_article_statuses();
+		return isset( $statuses[ $status ] ) ? $statuses[ $status ] : $statuses[ Article_Notes::STATUS_UNREAD ];
 	}
 
 	/**
@@ -490,17 +696,17 @@ class Post_Collection_App {
 	/**
 	 * Detect whether a collection should use the bookmark UI.
 	 *
-	 * @param User|\WP_User $user The collection user.
+	 * @param \WP_Term $collection The collection term.
 	 * @return bool
 	 */
-	public function is_bookmark_collection( $user ) {
+	public function is_bookmark_collection( $collection ) {
 		$bookmark_slugs = apply_filters(
 			'post_collection_bookmark_collection_slugs',
 			array( 'bookmark', 'bookmarks' )
 		);
 		$collection_slugs = array(
-			sanitize_title( $user->user_login ),
-			sanitize_title( $user->display_name ),
+			sanitize_title( $collection->slug ),
+			sanitize_title( $collection->name ),
 		);
 
 		foreach ( $collection_slugs as $collection_slug ) {
@@ -518,21 +724,27 @@ class Post_Collection_App {
 	/**
 	 * Query posts for a collection.
 	 *
-	 * @param User|\WP_User $user The collection user.
+	 * @param \WP_Term $collection The collection term.
 	 * @param array         $args Optional query args.
 	 * @return \WP_Query
 	 */
-	public function query_collection_posts( $user, array $args = array() ) {
+	public function query_collection_posts( $collection, array $args = array() ) {
 		$apply_filters = ! isset( $args['post_collection_apply_filters'] ) || $args['post_collection_apply_filters'];
 		unset( $args['post_collection_apply_filters'] );
 
 		$defaults = array(
 			'post_type'           => Post_Collection::CPT,
-			'post_status'         => $this->can_view_private_posts( $user ) ? array( 'publish', 'private' ) : array( 'publish' ),
-			'author'              => $user->ID,
+			'post_status'         => $this->can_view_private_posts( $collection ) ? array( 'publish', 'private' ) : array( 'publish' ),
 			'posts_per_page'      => 24,
 			'paged'               => isset( $_GET['pc-page'] ) ? max( 1, absint( wp_unslash( $_GET['pc-page'] ) ) ) : 1,
 			'ignore_sticky_posts' => true,
+			'tax_query'           => array(
+				array(
+					'taxonomy' => Post_Collection::COLLECTION_TAXONOMY,
+					'field'    => 'term_id',
+					'terms'    => $collection->term_id,
+				),
+			),
 		);
 
 		$query_args = wp_parse_args( $args, $defaults );
@@ -542,12 +754,10 @@ class Post_Collection_App {
 		}
 
 		if ( $apply_filters && isset( $_GET['pc-tag'] ) && taxonomy_exists( $this->post_collection->get_tag_taxonomy() ) ) {
-			$query_args['tax_query'] = array(
-				array(
-					'taxonomy' => $this->post_collection->get_tag_taxonomy(),
-					'field'    => 'slug',
-					'terms'    => sanitize_title( wp_unslash( $_GET['pc-tag'] ) ),
-				),
+			$query_args['tax_query'][] = array(
+				'taxonomy' => $this->post_collection->get_tag_taxonomy(),
+				'field'    => 'slug',
+				'terms'    => sanitize_title( wp_unslash( $_GET['pc-tag'] ) ),
 			);
 		}
 
@@ -558,17 +768,17 @@ class Post_Collection_App {
 	 * Get a visible post from a collection.
 	 *
 	 * @param int           $post_id The post ID.
-	 * @param User|\WP_User $user    The collection user.
+	 * @param \WP_Term      $collection The collection term.
 	 * @return \WP_Post|null
 	 */
-	public function get_visible_post( $post_id, $user ) {
+	public function get_visible_post( $post_id, $collection ) {
 		$post = get_post( $post_id );
 
-		if ( ! $post || Post_Collection::CPT !== $post->post_type || intval( $post->post_author ) !== intval( $user->ID ) ) {
+		if ( ! $post || Post_Collection::CPT !== $post->post_type || ! has_term( $collection->term_id, Post_Collection::COLLECTION_TAXONOMY, $post ) ) {
 			return null;
 		}
 
-		if ( 'publish' !== $post->post_status && ! $this->can_view_private_posts( $user ) ) {
+		if ( 'publish' !== $post->post_status && ! $this->can_view_private_posts( $collection ) ) {
 			return null;
 		}
 
@@ -578,12 +788,12 @@ class Post_Collection_App {
 	/**
 	 * Count visible posts in a collection.
 	 *
-	 * @param User|\WP_User $user The collection user.
+	 * @param \WP_Term $collection The collection term.
 	 * @return int
 	 */
-	public function count_collection_posts( $user ) {
+	public function count_collection_posts( $collection ) {
 		$query = $this->query_collection_posts(
-			$user,
+			$collection,
 			array(
 				'posts_per_page'                 => 1,
 				'fields'                         => 'ids',
@@ -592,6 +802,21 @@ class Post_Collection_App {
 		);
 
 		return intval( $query->found_posts );
+	}
+
+	/**
+	 * Get the collection assigned to a post.
+	 *
+	 * @param \WP_Post $post The post.
+	 * @return \WP_Term|null
+	 */
+	public function get_post_collection_term( \WP_Post $post ) {
+		$terms = get_the_terms( $post, Post_Collection::COLLECTION_TAXONOMY );
+		if ( is_wp_error( $terms ) || empty( $terms ) ) {
+			return null;
+		}
+
+		return reset( $terms );
 	}
 
 	/**
@@ -827,19 +1052,19 @@ class Post_Collection_App {
 	/**
 	 * Get popular terms for the visible collection posts.
 	 *
-	 * @param User|\WP_User $user The collection user.
+	 * @param \WP_Term $collection The collection term.
 	 * @return array
 	 */
-	public function get_collection_terms( $user ) {
+	public function get_collection_terms( $collection ) {
 		$taxonomy = $this->post_collection->get_tag_taxonomy();
 		if ( ! taxonomy_exists( $taxonomy ) ) {
 			return array();
 		}
 
 		$query = $this->query_collection_posts(
-			$user,
+			$collection,
 			array(
-				'posts_per_page'                 => 100,
+				'posts_per_page'                 => -1,
 				'fields'                         => 'ids',
 				'post_collection_apply_filters' => false,
 			)
@@ -849,34 +1074,75 @@ class Post_Collection_App {
 			return array();
 		}
 
-		$terms = get_terms(
-			array(
-				'taxonomy'   => $taxonomy,
-				'object_ids' => $query->posts,
-				'hide_empty' => true,
-				'number'     => 18,
-				'orderby'    => 'count',
-				'order'      => 'DESC',
-			)
-		);
+		global $wpdb;
 
-		if ( is_wp_error( $terms ) || ! $terms ) {
+		$post_ids = array_map( 'absint', $query->posts );
+		$placeholders = implode( ',', array_fill( 0, count( $post_ids ), '%d' ) );
+		$sql = $wpdb->prepare(
+			"SELECT t.term_id, COUNT(*) AS collection_count
+			FROM {$wpdb->terms} t
+			INNER JOIN {$wpdb->term_taxonomy} tt ON t.term_id = tt.term_id
+			INNER JOIN {$wpdb->term_relationships} tr ON tt.term_taxonomy_id = tr.term_taxonomy_id
+			WHERE tt.taxonomy = %s
+				AND tr.object_id IN ($placeholders)
+			GROUP BY t.term_id
+			ORDER BY collection_count DESC, t.name ASC
+			LIMIT 100",
+			array_merge( array( $taxonomy ), $post_ids )
+		);
+		$rows = $wpdb->get_results( $sql );
+
+		if ( ! $rows ) {
 			return array();
+		}
+
+		$terms = array();
+		foreach ( $rows as $row ) {
+			$term = get_term( (int) $row->term_id, $taxonomy );
+			if ( ! $term || is_wp_error( $term ) ) {
+				continue;
+			}
+			if ( $this->is_noisy_tag_term( $term ) ) {
+				continue;
+			}
+			$term->count = (int) $row->collection_count;
+			$terms[] = $term;
+			if ( count( $terms ) >= 18 ) {
+				break;
+			}
 		}
 
 		return $terms;
 	}
 
 	/**
+	 * Determine whether a tag term is likely generated noise.
+	 *
+	 * @param \WP_Term $term The term.
+	 * @return bool Whether to hide it from app tag navigation.
+	 */
+	private function is_noisy_tag_term( \WP_Term $term ) {
+		$name = trim( (string) $term->name );
+		$slug = trim( (string) $term->slug );
+
+		if ( '' === $name || is_numeric( $name ) || is_numeric( $slug ) ) {
+			return true;
+		}
+
+		return (bool) preg_match( '/^(?:[a-f0-9]{3}|[a-f0-9]{6})$/i', $name )
+			|| (bool) preg_match( '/^(?:[a-f0-9]{3}|[a-f0-9]{6})$/i', $slug );
+	}
+
+	/**
 	 * Get an external save URL for the collection.
 	 *
-	 * @param User|\WP_User $user The collection user.
+	 * @param \WP_Term $collection The collection term.
 	 * @return string
 	 */
-	public function get_save_url( $user ) {
+	public function get_save_url( $collection ) {
 		return add_query_arg(
 			array(
-				'user' => $user->ID,
+				'collection' => $collection->term_id,
 			),
 			home_url( '/' )
 		);

--- a/class-post-collection-app.php
+++ b/class-post-collection-app.php
@@ -243,6 +243,16 @@ class Post_Collection_App {
 	}
 
 	/**
+	 * Whether a collection should be tucked away on the app home page.
+	 *
+	 * @param \WP_Term $collection The collection term.
+	 * @return bool
+	 */
+	public function is_collection_hidden_from_home( $collection ) {
+		return (bool) get_term_meta( $collection->term_id, 'post_collection_hide_from_home', true );
+	}
+
+	/**
 	 * Whether private posts should be included for this visitor.
 	 *
 	 * @param \WP_Term $collection The collection term.
@@ -298,11 +308,7 @@ class Post_Collection_App {
 	 */
 	public function get_collection_mode( $collection ) {
 		$mode = get_term_meta( $collection->term_id, 'post_collection_frontend_mode', true );
-		if ( in_array( $mode, array( 'bookmarks', 'posts' ), true ) ) {
-			return $mode;
-		}
-
-		if ( $this->is_bookmark_collection( $collection ) ) {
+		if ( 'bookmarks' === $mode ) {
 			return 'bookmarks';
 		}
 
@@ -319,10 +325,6 @@ class Post_Collection_App {
 		$view = get_term_meta( $collection->term_id, 'post_collection_frontend_view', true );
 		if ( in_array( $view, array( 'board', 'links', 'reader' ), true ) ) {
 			return $view;
-		}
-
-		if ( 'bookmarks' === $this->get_collection_mode( $collection ) ) {
-			return 'links';
 		}
 
 		return 'reader';
@@ -371,22 +373,20 @@ class Post_Collection_App {
 			wp_die( esc_html__( 'Invalid post collection.', 'post-collection' ), '', array( 'response' => 404 ) );
 		}
 
-		$frontend_mode = isset( $_POST['frontend_mode'] ) ? sanitize_key( wp_unslash( $_POST['frontend_mode'] ) ) : 'auto';
-		if ( in_array( $frontend_mode, array( 'auto', 'bookmarks', 'posts' ), true ) ) {
-			if ( 'auto' === $frontend_mode ) {
-				delete_term_meta( $collection->term_id, 'post_collection_frontend_mode' );
-			} else {
-				update_term_meta( $collection->term_id, 'post_collection_frontend_mode', $frontend_mode );
-			}
+		$frontend_mode = isset( $_POST['frontend_mode'] ) ? sanitize_key( wp_unslash( $_POST['frontend_mode'] ) ) : 'posts';
+		if ( in_array( $frontend_mode, array( 'bookmarks', 'posts' ), true ) ) {
+			update_term_meta( $collection->term_id, 'post_collection_frontend_mode', $frontend_mode );
 		}
 
-		$frontend_view = isset( $_POST['frontend_view'] ) ? sanitize_key( wp_unslash( $_POST['frontend_view'] ) ) : 'auto';
-		if ( in_array( $frontend_view, array( 'auto', 'board', 'links', 'reader' ), true ) ) {
-			if ( 'auto' === $frontend_view ) {
-				delete_term_meta( $collection->term_id, 'post_collection_frontend_view' );
-			} else {
-				update_term_meta( $collection->term_id, 'post_collection_frontend_view', $frontend_view );
-			}
+		$frontend_view = isset( $_POST['frontend_view'] ) ? sanitize_key( wp_unslash( $_POST['frontend_view'] ) ) : 'reader';
+		if ( in_array( $frontend_view, array( 'board', 'links', 'reader' ), true ) ) {
+			update_term_meta( $collection->term_id, 'post_collection_frontend_view', $frontend_view );
+		}
+
+		if ( isset( $_POST['hide_from_home'] ) && $_POST['hide_from_home'] ) {
+			update_term_meta( $collection->term_id, 'post_collection_hide_from_home', true );
+		} else {
+			delete_term_meta( $collection->term_id, 'post_collection_hide_from_home' );
 		}
 
 		wp_safe_redirect( add_query_arg( 'pc-settings-updated', '1', $this->get_collection_settings_url( $collection ) ) );
@@ -464,14 +464,18 @@ class Post_Collection_App {
 			return new \WP_Error( 'collection_not_found', __( 'The collection was created but could not be loaded.', 'post-collection' ), array( 'status' => 500 ) );
 		}
 
-		$frontend_mode = isset( $data['frontend_mode'] ) ? sanitize_key( wp_unslash( $data['frontend_mode'] ) ) : 'auto';
+		$frontend_mode = isset( $data['frontend_mode'] ) ? sanitize_key( wp_unslash( $data['frontend_mode'] ) ) : 'posts';
 		if ( in_array( $frontend_mode, array( 'bookmarks', 'posts' ), true ) ) {
 			update_term_meta( $collection->term_id, 'post_collection_frontend_mode', $frontend_mode );
 		}
 
-		$frontend_view = isset( $data['frontend_view'] ) ? sanitize_key( wp_unslash( $data['frontend_view'] ) ) : 'auto';
+		$frontend_view = isset( $data['frontend_view'] ) ? sanitize_key( wp_unslash( $data['frontend_view'] ) ) : 'reader';
 		if ( in_array( $frontend_view, array( 'board', 'links', 'reader' ), true ) ) {
 			update_term_meta( $collection->term_id, 'post_collection_frontend_view', $frontend_view );
+		}
+
+		if ( ! empty( $data['hide_from_home'] ) ) {
+			update_term_meta( $collection->term_id, 'post_collection_hide_from_home', true );
 		}
 
 		update_term_meta( $collection->term_id, 'friends_publish_post_collection', true );
@@ -691,34 +695,6 @@ class Post_Collection_App {
 			'links'  => __( 'Links', 'post-collection' ),
 			'reader' => __( 'Reader', 'post-collection' ),
 		);
-	}
-
-	/**
-	 * Detect whether a collection should use the bookmark UI.
-	 *
-	 * @param \WP_Term $collection The collection term.
-	 * @return bool
-	 */
-	public function is_bookmark_collection( $collection ) {
-		$bookmark_slugs = apply_filters(
-			'post_collection_bookmark_collection_slugs',
-			array( 'bookmark', 'bookmarks' )
-		);
-		$collection_slugs = array(
-			sanitize_title( $collection->slug ),
-			sanitize_title( $collection->name ),
-		);
-
-		foreach ( $collection_slugs as $collection_slug ) {
-			foreach ( $bookmark_slugs as $bookmark_slug ) {
-				$bookmark_slug = sanitize_title( $bookmark_slug );
-				if ( $collection_slug === $bookmark_slug || false !== strpos( $collection_slug, $bookmark_slug ) ) {
-					return true;
-				}
-			}
-		}
-
-		return false;
 	}
 
 	/**

--- a/class-post-collection-app.php
+++ b/class-post-collection-app.php
@@ -89,6 +89,7 @@ class Post_Collection_App {
 	private function init() {
 		add_action( 'wp_loaded', array( $this, 'handle_quick_edit' ) );
 		add_action( 'wp_ajax_post_collection_quick_edit', array( $this, 'wp_ajax_quick_edit' ) );
+		add_filter( 'private_title_format', array( $this, 'filter_private_title_format' ), 10, 2 );
 
 		$this->app->route( '' );
 		$this->app->route( '{username}', 'collection.php' );
@@ -224,6 +225,44 @@ class Post_Collection_App {
 	 */
 	public function can_view_private_posts( $user ) {
 		return $this->can_manage_collections();
+	}
+
+	/**
+	 * Remove WordPress' private title prefix inside the frontend app.
+	 *
+	 * @param string   $format The title format.
+	 * @param \WP_Post $post   The post object.
+	 * @return string
+	 */
+	public function filter_private_title_format( $format, $post = null ) {
+		if ( $this->is_app_request() ) {
+			return '%s';
+		}
+
+		return $format;
+	}
+
+	/**
+	 * Whether the current request is handled by this frontend app.
+	 *
+	 * @return bool
+	 */
+	private function is_app_request() {
+		if ( wp_doing_ajax() ) {
+			$action = isset( $_REQUEST['action'] ) ? wp_unslash( $_REQUEST['action'] ) : '';
+			return is_string( $action ) && 'post_collection_quick_edit' === sanitize_key( $action );
+		}
+
+		if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+			return false;
+		}
+
+		$path = wp_parse_url( wp_unslash( $_SERVER['REQUEST_URI'] ), PHP_URL_PATH );
+		if ( ! $path ) {
+			return false;
+		}
+
+		return (bool) preg_match( '#/(?:index\.php/)?' . preg_quote( self::PATH, '#' ) . '(?:/|$)#', $path );
 	}
 
 	/**
@@ -427,6 +466,7 @@ class Post_Collection_App {
 			'source_url'  => $source_url,
 			'display_url' => preg_replace( '#^https?://#', '', $source_url ),
 			'excerpt'     => $this->get_post_excerpt( $post, 24 ),
+			'embed_html'  => $this->get_post_embed_html( $post, 'links' ),
 			'host'        => $this->get_source_host( $post ),
 			'is_private'  => 'private' === $post->post_status,
 			'status'      => $post->post_status,
@@ -584,6 +624,144 @@ class Post_Collection_App {
 	}
 
 	/**
+	 * Get embeddable media HTML for a post preview.
+	 *
+	 * @param \WP_Post $post    The post.
+	 * @param string   $context Display context for CSS classes.
+	 * @return string
+	 */
+	public function get_post_embed_html( \WP_Post $post, $context = 'collection' ) {
+		$video_id = $this->get_post_youtube_video_id( $post );
+		if ( ! $video_id ) {
+			return '';
+		}
+
+		return $this->render_youtube_embed( $video_id, get_the_title( $post ), $context );
+	}
+
+	/**
+	 * Get embeddable media HTML from the explicit post description.
+	 *
+	 * @param \WP_Post $post    The post.
+	 * @param string   $context Display context for CSS classes.
+	 * @return string
+	 */
+	public function get_post_description_embed_html( \WP_Post $post, $context = 'collection' ) {
+		$video_id = $this->get_youtube_video_id_from_text( $post->post_excerpt );
+		if ( ! $video_id ) {
+			return '';
+		}
+
+		return $this->render_youtube_embed( $video_id, get_the_title( $post ), $context );
+	}
+
+	/**
+	 * Get a YouTube video ID from a post's standalone media URL.
+	 *
+	 * @param \WP_Post $post The post.
+	 * @return string
+	 */
+	private function get_post_youtube_video_id( \WP_Post $post ) {
+		$video_id = $this->get_youtube_video_id_from_text( $post->post_excerpt );
+		if ( $video_id ) {
+			return $video_id;
+		}
+
+		return $this->get_youtube_video_id_from_text( $post->post_content );
+	}
+
+	/**
+	 * Get a YouTube video ID from text that only contains a YouTube URL.
+	 *
+	 * @param string $text Text to inspect.
+	 * @return string
+	 */
+	private function get_youtube_video_id_from_text( $text ) {
+		$url = $this->get_standalone_url_from_text( $text );
+		if ( ! $url ) {
+			return '';
+		}
+
+		return $this->get_youtube_video_id_from_url( $url );
+	}
+
+	/**
+	 * Get a URL from text when it is the only meaningful content.
+	 *
+	 * @param string $text Text to inspect.
+	 * @return string
+	 */
+	private function get_standalone_url_from_text( $text ) {
+		$text = preg_replace( '#<!--.*?-->#s', '', (string) $text );
+		$text = trim( html_entity_decode( wp_strip_all_tags( strip_shortcodes( $text ) ), ENT_QUOTES, 'UTF-8' ) );
+
+		if ( '' === $text || preg_match( '#\s#', $text ) || ! preg_match( '#^https?://#i', $text ) ) {
+			return '';
+		}
+
+		return $text;
+	}
+
+	/**
+	 * Extract a YouTube video ID from a supported URL.
+	 *
+	 * @param string $url The URL.
+	 * @return string
+	 */
+	private function get_youtube_video_id_from_url( $url ) {
+		$url   = html_entity_decode( trim( $url ), ENT_QUOTES, 'UTF-8' );
+		$parts = wp_parse_url( $url );
+
+		if ( ! is_array( $parts ) || empty( $parts['host'] ) ) {
+			return '';
+		}
+
+		$host = preg_replace( '#^www\.#', '', strtolower( $parts['host'] ) );
+		$path = isset( $parts['path'] ) ? $parts['path'] : '';
+		$id   = '';
+
+		if ( 'youtu.be' === $host ) {
+			$path_parts = explode( '/', trim( $path, '/' ) );
+			$id         = reset( $path_parts );
+		} elseif ( in_array( $host, array( 'youtube.com', 'm.youtube.com', 'music.youtube.com', 'youtube-nocookie.com' ), true ) ) {
+			if ( '/watch' === $path && ! empty( $parts['query'] ) ) {
+				$query = array();
+				parse_str( $parts['query'], $query );
+				$id = isset( $query['v'] ) && is_string( $query['v'] ) ? $query['v'] : '';
+			} elseif ( preg_match( '#^/(?:embed|shorts|live)/([^/?#]+)#', $path, $matches ) ) {
+				$id = $matches[1];
+			}
+		}
+
+		$id = is_string( $id ) ? trim( $id ) : '';
+
+		return preg_match( '#^[A-Za-z0-9_-]{11}$#', $id ) ? $id : '';
+	}
+
+	/**
+	 * Render a safe YouTube iframe.
+	 *
+	 * @param string $video_id YouTube video ID.
+	 * @param string $title    Video title.
+	 * @param string $context  Display context for CSS classes.
+	 * @return string
+	 */
+	private function render_youtube_embed( $video_id, $title, $context ) {
+		$context   = sanitize_html_class( $context );
+		$title     = $title ? $title : __( 'YouTube video', 'post-collection' );
+		$embed_url = add_query_arg( 'rel', '0', 'https://www.youtube-nocookie.com/embed/' . rawurlencode( $video_id ) );
+
+		return sprintf(
+			'<div class="pc-youtube-embed pc-youtube-embed-%1$s">' .
+				'<iframe src="%2$s" title="%3$s" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>' .
+			'</div>',
+			esc_attr( $context ),
+			esc_url( $embed_url ),
+			esc_attr( sprintf( __( 'YouTube video: %s', 'post-collection' ), $title ) )
+		);
+	}
+
+	/**
 	 * Get the best image URL for a post card.
 	 *
 	 * @param \WP_Post $post The post.
@@ -616,6 +794,10 @@ class Post_Collection_App {
 	 * @return string
 	 */
 	public function get_post_excerpt( \WP_Post $post, $length = 28 ) {
+		if ( $this->get_post_youtube_video_id( $post ) ) {
+			return '';
+		}
+
 		$text = $post->post_excerpt ? $post->post_excerpt : $post->post_content;
 		$text = wp_strip_all_tags( strip_shortcodes( $text ) );
 

--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -23,7 +23,8 @@ use WP_HTML_Tag_Processor;
  * @author Alex Kirk
  */
 class Post_Collection {
-	const CPT = 'post_collection';
+	const CPT = 'collected_post';
+	const COLLECTION_TAXONOMY = 'post_collection';
 	/**
 	 * Whether to cache the retrieved users
 	 *
@@ -234,6 +235,7 @@ class Post_Collection {
 		}
 		add_filter( 'friends_author_post_type', array( $this, 'filter_author_post_type' ), 10, 2 );
 		add_filter( 'friends_frontend_post_types', array( $this, 'add_frontend_post_types' ) );
+		add_action( 'pre_get_posts', array( $this, 'filter_collection_friend_posts_query' ), 20 );
 		add_action( 'tool_box', array( $this, 'toolbox_bookmarklet' ) );
 		add_filter( 'user_row_actions', array( $this, 'user_row_actions' ), 10, 2 );
 		add_action( 'admin_menu', array( $this, 'admin_menu' ), 50 );
@@ -245,6 +247,7 @@ class Post_Collection {
 		add_action( 'friends_show_author_edit', array( $this, 'friends_show_author_edit' ), 10, 2 );
 		add_action( 'friends_entry_dropdown_menu', array( $this, 'entry_dropdown_menu' ) );
 		add_action( 'friends_friend_feed_viewable', array( $this, 'friends_friend_feed_viewable' ), 10, 2 );
+		add_filter( 'friends_friend_posts_query_viewable', array( $this, 'collection_friend_posts_query_viewable' ), 10, 2 );
 		add_action( 'friend_user_role_name', array( $this, 'friend_user_role_name' ), 10, 2 );
 		add_filter( 'friends_plugin_roles', array( $this, 'associate_friend_user_role' ) );
 		add_action( 'friends_override_author_name', array( $this, 'friends_override_author_name' ), 15, 3 );
@@ -279,6 +282,8 @@ class Post_Collection {
 	 * Register the custom post type for collected posts.
 	 */
 	public function register_custom_post_type() {
+		$this->register_collection_taxonomy();
+
 		$labels = array(
 			'name'               => __( 'Collected Posts', 'post-collection' ),
 			'singular_name'      => __( 'Collected Post', 'post-collection' ),
@@ -310,12 +315,43 @@ class Post_Collection {
 			'menu_position'       => 5,
 			'menu_icon'           => 'dashicons-book',
 			'supports'            => array( 'title', 'editor', 'author', 'revisions', 'thumbnail', 'excerpt', 'comments', 'post-formats' ),
-			'taxonomies'          => array( $this->get_tag_taxonomy(), 'post_format' ),
+			'taxonomies'          => array( self::COLLECTION_TAXONOMY, $this->get_tag_taxonomy(), 'post_format' ),
 			'has_archive'         => true,
 			'rewrite'             => false,
 		);
 
 		register_post_type( self::CPT, $args );
+	}
+
+	/**
+	 * Register collections as a taxonomy for collected posts.
+	 */
+	public function register_collection_taxonomy() {
+		$labels = array(
+			'name'          => __( 'Post Collections', 'post-collection' ),
+			'singular_name' => __( 'Post Collection', 'post-collection' ),
+			'search_items'  => __( 'Search Post Collections', 'post-collection' ),
+			'all_items'     => __( 'All Post Collections', 'post-collection' ),
+			'edit_item'     => __( 'Edit Post Collection', 'post-collection' ),
+			'update_item'   => __( 'Update Post Collection', 'post-collection' ),
+			'add_new_item'  => __( 'Add New Post Collection', 'post-collection' ),
+			'new_item_name' => __( 'New Post Collection Name', 'post-collection' ),
+			'menu_name'     => __( 'Post Collections', 'post-collection' ),
+		);
+
+		register_taxonomy(
+			self::COLLECTION_TAXONOMY,
+			self::CPT,
+			array(
+				'labels'            => $labels,
+				'public'            => false,
+				'show_ui'           => true,
+				'show_admin_column' => true,
+				'show_in_rest'      => is_user_logged_in(),
+				'hierarchical'      => false,
+				'rewrite'           => false,
+			)
+		);
 	}
 
 	public function add_revision_support() {
@@ -334,6 +370,81 @@ class Post_Collection {
 			return self::CPT;
 		}
 		return $post_type;
+	}
+
+	/**
+	 * Get the collection term addressed by a /friends/{collection}/ query.
+	 *
+	 * @param \WP_Query|null $query Optional query object.
+	 * @return \WP_Term|null Collection term, if the query targets one.
+	 */
+	private function get_collection_term_from_friends_query( $query = null ) {
+		if ( $query instanceof \WP_Query ) {
+			$pagename = isset( $query->query['pagename'] ) ? $query->query['pagename'] : $query->get( 'pagename' );
+			if ( ! $pagename ) {
+				$pagename = isset( $query->query['category_name'] ) ? $query->query['category_name'] : $query->get( 'category_name' );
+			}
+			if ( ! $pagename ) {
+				$pagename = isset( $query->query['name'] ) ? $query->query['name'] : $query->get( 'name' );
+			}
+		} else {
+			$pagename = get_query_var( 'pagename' );
+			if ( ! $pagename ) {
+				$pagename = get_query_var( 'category_name' );
+			}
+			if ( ! $pagename ) {
+				$pagename = get_query_var( 'name' );
+			}
+		}
+
+		$pagename_parts = explode( '/', trim( (string) $pagename, '/' ) );
+		if ( 'friends' !== array_shift( $pagename_parts ) || empty( $pagename_parts[0] ) ) {
+			return null;
+		}
+
+		$collection = get_term_by( 'slug', sanitize_title( $pagename_parts[0] ), self::COLLECTION_TAXONOMY );
+		if ( ! $collection || is_wp_error( $collection ) ) {
+			return null;
+		}
+
+		return $collection;
+	}
+
+	/**
+	 * Query migrated collection URLs by collection term instead of old author users.
+	 *
+	 * @param \WP_Query $query The main query.
+	 */
+	public function filter_collection_friend_posts_query( \WP_Query $query ) {
+		global $wp_query;
+
+		if ( $wp_query !== $query || $query->is_admin() || $query->is_home() ) {
+			return;
+		}
+
+		$collection = $this->get_collection_term_from_friends_query( $query );
+		if ( ! $collection ) {
+			return;
+		}
+
+		$tax_query = $query->get( 'tax_query' );
+		if ( ! is_array( $tax_query ) ) {
+			$tax_query = array();
+		}
+		if ( $tax_query ) {
+			$tax_query['relation'] = 'AND';
+		}
+		$tax_query[] = array(
+			'taxonomy' => self::COLLECTION_TAXONOMY,
+			'field'    => 'term_id',
+			'terms'    => array( (int) $collection->term_id ),
+		);
+
+		$query->set( 'author', '' );
+		$query->set( 'author_name', '' );
+		$query->set( 'post_type', self::CPT );
+		$query->set( 'tax_query', $tax_query );
+		$query->is_author = true;
 	}
 
 	/**
@@ -986,6 +1097,24 @@ class Post_Collection {
 		return $users;
 	}
 
+	/**
+	 * Get taxonomy-backed post collections.
+	 *
+	 * @return \WP_Term[] Collection terms.
+	 */
+	private function get_post_collection_terms() {
+		$terms = get_terms(
+			array(
+				'taxonomy'   => self::COLLECTION_TAXONOMY,
+				'hide_empty' => false,
+				'orderby'    => 'name',
+				'order'      => 'ASC',
+			)
+		);
+
+		return is_wp_error( $terms ) ? array() : $terms;
+	}
+
 	private function get_bookmarklet_js() {
 		$js = file_get_contents( __DIR__ . '/post-collection-injector.js' );
 		$js = str_replace( 'text.sending_article_to_your_blog', '"' . addslashes( __( 'Sending the article to your WordPress...', 'post-collection' ) ) . '"', $js );
@@ -999,10 +1128,10 @@ class Post_Collection {
 	 */
 	public function toolbox_bookmarklet() {
 		$post_collections = array();
-		foreach ( $this->get_post_collection_users()->get_results() as $user ) {
+		foreach ( $this->get_post_collection_terms() as $collection ) {
 			$post_collections[] = array(
-				'user_id'      => $user->ID,
-				'display_name' => $user->display_name,
+				'term_id'      => $collection->term_id,
+				'display_name' => $collection->name,
 			);
 		}
 
@@ -1019,6 +1148,14 @@ class Post_Collection {
 	public function save_url_endpoint() {
 		$delimiter = '===BODY===';
 		$url = false;
+		$collection = null;
+		if ( isset( $_REQUEST['collect-post'], $_REQUEST['collection'] ) ) {
+			$collection = get_term( absint( wp_unslash( $_REQUEST['collection'] ) ), self::COLLECTION_TAXONOMY );
+			if ( ! $collection || is_wp_error( $collection ) ) {
+				return;
+			}
+			$url = wp_unslash( $_REQUEST['collect-post'] );
+		}
 		if ( isset( $_REQUEST['collect-post'] ) && isset( $_REQUEST['user'] ) ) {
 			if ( ! intval( $_REQUEST['user'] ) ) {
 				return;
@@ -1064,6 +1201,18 @@ class Post_Collection {
 			auth_redirect();
 		}
 
+		if ( $collection ) {
+			$post_id = $this->save_url_to_collection_term( $url, $collection, $body );
+			if ( is_wp_error( $post_id ) ) {
+				echo '<pre>';
+				print_r( $post_id );
+				exit;
+			}
+
+			wp_safe_redirect( home_url( '/post-collection/' . $collection->slug . '/' . $post_id . '/' ) );
+			exit;
+		}
+
 		$friend_user = new User( intval( $_REQUEST['user'] ) );
 		if ( ! is_wp_error( $friend_user ) || ! $friend_user->has_cap( 'post_collection' ) ) {
 			$error = $this->save_url( $url, $friend_user, $body );
@@ -1073,6 +1222,180 @@ class Post_Collection {
 				exit;
 			}
 		}
+	}
+
+	/**
+	 * Find a collected post in a collection term by source URL.
+	 *
+	 * @param string   $url        Source URL.
+	 * @param \WP_Term $collection Collection term.
+	 * @return int|null Post ID if found.
+	 */
+	private function url_to_collection_term_postid( $url, \WP_Term $collection ) {
+		global $wpdb;
+
+		$post_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT p.ID
+				FROM {$wpdb->posts} p
+				INNER JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id
+				INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+				WHERE p.guid = %s
+					AND p.post_type = %s
+					AND tt.taxonomy = %s
+					AND tt.term_id = %d
+				LIMIT 1",
+				$url,
+				self::CPT,
+				self::COLLECTION_TAXONOMY,
+				$collection->term_id
+			)
+		);
+
+		return $post_id ? (int) $post_id : null;
+	}
+
+	/**
+	 * Save a URL to a taxonomy-backed collection.
+	 *
+	 * @param string   $url        Source URL.
+	 * @param \WP_Term $collection Collection term.
+	 * @param string   $content    Optional HTML content.
+	 * @return int|\WP_Error Post ID or error.
+	 */
+	private function save_url_to_collection_term( $url, \WP_Term $collection, $content = null, $args = array() ) {
+		if ( ! is_string( $url ) || ! $this->check_url( $url ) ) {
+			return new \WP_Error( 'invalid-url', __( 'You entered an invalid URL.', 'post-collection' ) );
+		}
+
+		$return_details = ! empty( $args['return_details'] );
+		$title_override = '';
+		if ( isset( $args['title'] ) ) {
+			$title_override = wp_strip_all_tags( trim( sanitize_text_field( $args['title'] ) ) );
+		}
+
+		$tags = array();
+		if ( isset( $args['tags'] ) && is_array( $args['tags'] ) ) {
+			$tags = array_values(
+				array_filter(
+					array_map(
+						function ( $tag ) {
+							return sanitize_text_field( wp_strip_all_tags( trim( $tag ) ) );
+						},
+						$args['tags']
+					)
+				)
+			);
+		}
+
+		$post_id = $this->url_to_collection_term_postid( $url, $collection );
+		if ( $post_id ) {
+			wp_untrash_post( $post_id );
+			if ( $title_override ) {
+				$updated_post = wp_update_post(
+					array(
+						'ID'         => $post_id,
+						'post_title' => $title_override,
+					),
+					true
+				);
+				if ( is_wp_error( $updated_post ) ) {
+					return $updated_post;
+				}
+			}
+
+			if ( $tags ) {
+				$terms = wp_set_post_terms( $post_id, $tags, $this->get_tag_taxonomy(), true );
+				if ( is_wp_error( $terms ) ) {
+					return $terms;
+				}
+			}
+
+			if ( $return_details ) {
+				return array(
+					'post_id'           => (int) $post_id,
+					'created'           => false,
+					'content_extracted' => false,
+				);
+			}
+
+			return (int) $post_id;
+		}
+
+		$item = $this->download( $url, $content );
+		if ( is_wp_error( $item ) ) {
+			return $item;
+		}
+
+		if ( ! $item->content ) {
+			return new \WP_Error(
+				'invalid-content',
+				__( 'No content was extracted.', 'post-collection' ),
+				array(
+					'status' => 422,
+					'url'    => $url,
+				)
+			);
+		}
+
+		$title = $item->title ? wp_strip_all_tags( trim( $item->title ) ) : '';
+		if ( ! $title ) {
+			$path = trim( (string) wp_parse_url( $url, PHP_URL_PATH ), '/' );
+			$parts = explode( '/', $path );
+			$title = ucwords( strtr( end( $parts ), '-', ' ' ) );
+		}
+		if ( $title_override ) {
+			$title = $title_override;
+		}
+
+		$post_id = wp_insert_post(
+			array(
+				'post_status'  => 'private',
+				'post_author'  => get_current_user_id(),
+				'guid'         => $url,
+				'post_type'    => self::CPT,
+				'post_title'   => $title,
+				'post_content' => ! empty( $item->raw_html ) ? $item->raw_html : '',
+			),
+			true
+		);
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+
+		wp_set_object_terms( $post_id, array( (int) $collection->term_id ), self::COLLECTION_TAXONOMY, false );
+
+		$content_extracted = false;
+		if ( $item->content ) {
+			wp_update_post(
+				array(
+					'ID'           => $post_id,
+					'post_content' => force_balance_tags( trim( wp_kses_post( $item->content ) ) ),
+				)
+			);
+			$content_extracted = true;
+		}
+
+		if ( $item->author ) {
+			update_post_meta( $post_id, 'author', $item->author );
+		}
+
+		if ( $tags ) {
+			$terms = wp_set_post_terms( $post_id, $tags, $this->get_tag_taxonomy(), true );
+			if ( is_wp_error( $terms ) ) {
+				return $terms;
+			}
+		}
+
+		if ( $return_details ) {
+			return array(
+				'post_id'           => (int) $post_id,
+				'created'           => true,
+				'content_extracted' => $content_extracted,
+			);
+		}
+
+		return (int) $post_id;
 	}
 
 	/**
@@ -1261,8 +1584,8 @@ class Post_Collection {
 		}
 
 		$collection_id = absint( $request->get_param( 'collection_id' ) );
-		$friend_user   = User::get_user_by_id( $collection_id );
-		if ( ! $friend_user || ! $friend_user->has_cap( 'post_collection' ) ) {
+		$collection    = get_term( $collection_id, self::COLLECTION_TAXONOMY );
+		if ( ! $collection || is_wp_error( $collection ) ) {
 			return new \WP_Error(
 				'invalid-collection',
 				__( 'Invalid post collection.', 'post-collection' ),
@@ -1270,7 +1593,7 @@ class Post_Collection {
 			);
 		}
 
-		if ( get_user_option( 'friends_post_collection_inactive', $friend_user->ID ) ) {
+		if ( get_term_meta( $collection->term_id, 'friends_post_collection_inactive', true ) ) {
 			return new \WP_Error(
 				'inactive-collection',
 				__( 'This post collection is inactive.', 'post-collection' ),
@@ -1302,9 +1625,9 @@ class Post_Collection {
 
 		$tags = $this->parse_extension_action_tags( $request->get_param( 'tags' ) );
 
-		$post_id = $this->save_url_to_collection(
+		$post_id = $this->save_url_to_collection_term(
 			$url,
-			$friend_user,
+			$collection,
 			$html,
 			array(
 				'title'          => $title,
@@ -1320,18 +1643,18 @@ class Post_Collection {
 		$save_details = $post_id;
 		$post_id      = $save_details['post_id'];
 		$edit_url = get_edit_post_link( $post_id, 'raw' );
-		$item_url = $friend_user->get_local_friends_page_url( $post_id );
+		$item_url = home_url( '/post-collection/' . $collection->slug . '/' . $post_id . '/' );
 		if ( ! empty( $save_details['content_extracted'] ) ) {
 			$message = sprintf(
 				// translators: %s is the name of a post collection.
 				__( 'Saved extracted content to %s.', 'post-collection' ),
-				$friend_user->display_name
+				$collection->name
 			);
 		} else {
 			$message = sprintf(
 				// translators: %s is the name of a post collection.
 				__( 'Saved to %s. This URL was already in the collection.', 'post-collection' ),
-				$friend_user->display_name
+				$collection->name
 			);
 		}
 
@@ -1919,18 +2242,18 @@ class Post_Collection {
 		$browser_key       = $this->get_browser_extension_key( $context );
 		$use_inline        = method_exists( '\Friends\REST', 'rest_extension_action' ) && $browser_key && ( ! $extension_version || version_compare( $extension_version, '1.6.0', '>=' ) );
 
-		foreach ( $this->get_post_collection_users()->get_results() as $user ) {
-			if ( get_user_option( 'friends_post_collection_inactive', $user->ID ) ) {
+		foreach ( $this->get_post_collection_terms() as $collection ) {
+			if ( get_term_meta( $collection->term_id, 'friends_post_collection_inactive', true ) ) {
 				continue;
 			}
 
 			if ( $use_inline ) {
 				$actions[] = array(
-					'id'               => 'save-to-post-collection-' . $user->ID,
+					'id'               => 'save-to-post-collection-' . $collection->term_id,
 					'name'             => sprintf(
 						// translators: %s is the name of a post collection.
 						__( 'Save to %s', 'post-collection' ),
-						$user->display_name
+						$collection->name
 					),
 					'category'         => __( 'Save', 'post-collection' ),
 					'url'              => rest_url( 'friends/v1/extension/action' ),
@@ -1942,7 +2265,7 @@ class Post_Collection {
 					'fields'           => array(
 						'action'        => 'post_collection_save',
 						'key'           => $browser_key,
-						'collection_id' => (string) $user->ID,
+						'collection_id' => (string) $collection->term_id,
 						'url'           => '{current_url}',
 						'html'          => '{page_html}',
 					),
@@ -1965,7 +2288,7 @@ class Post_Collection {
 				continue;
 			}
 
-			$actions[] = $this->get_legacy_browser_extension_action( $user );
+			$actions[] = $this->get_legacy_browser_extension_action( $collection );
 		}
 
 		return $actions;
@@ -1974,13 +2297,13 @@ class Post_Collection {
 	/**
 	 * Get the legacy browser extension action.
 	 *
-	 * @param User $user The post collection user.
+	 * @param \WP_Term $collection The post collection term.
 	 * @return array The action definition.
 	 */
-	private function get_legacy_browser_extension_action( User $user ) {
+	private function get_legacy_browser_extension_action( \WP_Term $collection ) {
 		return array(
-			'name'     => $user->display_name,
-			'url'      => home_url( '/?user=' . $user->ID . '&post-only=1&collect-post={current_url}' ),
+			'name'     => $collection->name,
+			'url'      => home_url( '/?collection=' . $collection->term_id . '&post-only=1&collect-post={current_url}' ),
 			'method'   => 'POST',
 			'fields'   => array( 'body' => '{page_html}' ),
 			'category' => __( 'Collect Post', 'post-collection' ),
@@ -2110,11 +2433,27 @@ class Post_Collection {
 	 * @return     bool    Whether it's viewable.
 	 */
 	function friends_friend_feed_viewable( $viewable, $author_login ) {
-		$author = get_user_by( 'login', $author_login );
-		if ( $author && ! is_wp_error( $author ) && get_user_option( 'friends_publish_post_collection', $author->ID ) && $author->has_cap( 'post_collection' ) ) {
+		$collection = get_term_by( 'slug', sanitize_title( $author_login ), self::COLLECTION_TAXONOMY );
+		if ( $collection && ! is_wp_error( $collection ) && get_term_meta( $collection->term_id, 'friends_publish_post_collection', true ) ) {
 			add_filter( 'pre_option_rss_use_excerpt', '__return_true', 30 );
 			return true;
 		}
+		return $viewable;
+	}
+
+	/**
+	 * Expose public collection front pages by collection term.
+	 *
+	 * @param bool   $viewable     Whether the Friends page is viewable.
+	 * @param string $author_login The first path segment after /friends/.
+	 * @return bool Whether it is viewable.
+	 */
+	public function collection_friend_posts_query_viewable( $viewable, $author_login ) {
+		$collection = get_term_by( 'slug', sanitize_title( $author_login ), self::COLLECTION_TAXONOMY );
+		if ( $collection && ! is_wp_error( $collection ) && get_term_meta( $collection->term_id, 'friends_publish_post_collection', true ) ) {
+			return true;
+		}
+
 		return $viewable;
 	}
 

--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -78,6 +78,17 @@ class Post_Collection {
 			$this->abilities = new Post_Collection_Abilities( $this );
 		}
 		$this->register_hooks();
+		if ( did_action( 'init' ) ) {
+			$this->boot_app();
+		} else {
+			add_action( 'init', array( $this, 'boot_app' ), 0 );
+		}
+	}
+
+	/**
+	 * Initialize the standalone frontend app.
+	 */
+	public function boot_app() {
 		if ( class_exists( __NAMESPACE__ . '\Post_Collection_App' ) ) {
 			Post_Collection_App::boot( $this );
 		}

--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -78,6 +78,9 @@ class Post_Collection {
 			$this->abilities = new Post_Collection_Abilities( $this );
 		}
 		$this->register_hooks();
+		if ( class_exists( __NAMESPACE__ . '\Post_Collection_App' ) ) {
+			Post_Collection_App::boot( $this );
+		}
 	}
 
 	/**
@@ -550,6 +553,22 @@ class Post_Collection {
 			} else {
 				delete_user_option( $user->ID, 'friends_publish_post_collection' );
 			}
+			$frontend_mode = isset( $_POST['frontend_mode'] ) ? sanitize_key( wp_unslash( $_POST['frontend_mode'] ) ) : 'auto';
+			if ( in_array( $frontend_mode, array( 'auto', 'bookmarks', 'posts' ), true ) ) {
+				if ( 'auto' === $frontend_mode ) {
+					delete_user_option( $user->ID, 'post_collection_frontend_mode' );
+				} else {
+					update_user_option( $user->ID, 'post_collection_frontend_mode', $frontend_mode );
+				}
+			}
+			$frontend_view = isset( $_POST['frontend_view'] ) ? sanitize_key( wp_unslash( $_POST['frontend_view'] ) ) : 'auto';
+			if ( in_array( $frontend_view, array( 'auto', 'board', 'links', 'reader' ), true ) ) {
+				if ( 'auto' === $frontend_view ) {
+					delete_user_option( $user->ID, 'post_collection_frontend_view' );
+				} else {
+					update_user_option( $user->ID, 'post_collection_frontend_view', $frontend_view );
+				}
+			}
 			if ( isset( $_POST['dropdown'] ) ) {
 				switch ( $_POST['dropdown'] ) {
 					case 'inactive':
@@ -592,7 +611,9 @@ class Post_Collection {
 			),
 			'post_collection_url' => home_url( '/?user=' . $user->ID ),
 			'bookmarklet_js'      => $this->get_bookmarklet_js(),
-
+			'frontend_mode'       => get_user_option( 'post_collection_frontend_mode', $user->ID ),
+			'frontend_view'       => get_user_option( 'post_collection_frontend_view', $user->ID ),
+			'frontend_url'        => class_exists( __NAMESPACE__ . '\Post_Collection_App' ) && Post_Collection_App::instance() ? Post_Collection_App::instance()->get_collection_url( $user ) : '',
 		);
 
 		?>

--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -675,21 +675,18 @@ class Post_Collection {
 			} else {
 				delete_user_option( $user->ID, 'friends_publish_post_collection' );
 			}
-			$frontend_mode = isset( $_POST['frontend_mode'] ) ? sanitize_key( wp_unslash( $_POST['frontend_mode'] ) ) : 'auto';
-			if ( in_array( $frontend_mode, array( 'auto', 'bookmarks', 'posts' ), true ) ) {
-				if ( 'auto' === $frontend_mode ) {
-					delete_user_option( $user->ID, 'post_collection_frontend_mode' );
-				} else {
-					update_user_option( $user->ID, 'post_collection_frontend_mode', $frontend_mode );
-				}
+			$frontend_mode = isset( $_POST['frontend_mode'] ) ? sanitize_key( wp_unslash( $_POST['frontend_mode'] ) ) : 'posts';
+			if ( in_array( $frontend_mode, array( 'bookmarks', 'posts' ), true ) ) {
+				update_user_option( $user->ID, 'post_collection_frontend_mode', $frontend_mode );
 			}
-			$frontend_view = isset( $_POST['frontend_view'] ) ? sanitize_key( wp_unslash( $_POST['frontend_view'] ) ) : 'auto';
-			if ( in_array( $frontend_view, array( 'auto', 'board', 'links', 'reader' ), true ) ) {
-				if ( 'auto' === $frontend_view ) {
-					delete_user_option( $user->ID, 'post_collection_frontend_view' );
-				} else {
-					update_user_option( $user->ID, 'post_collection_frontend_view', $frontend_view );
-				}
+			$frontend_view = isset( $_POST['frontend_view'] ) ? sanitize_key( wp_unslash( $_POST['frontend_view'] ) ) : 'reader';
+			if ( in_array( $frontend_view, array( 'board', 'links', 'reader' ), true ) ) {
+				update_user_option( $user->ID, 'post_collection_frontend_view', $frontend_view );
+			}
+			if ( isset( $_POST['hide_from_home'] ) && $_POST['hide_from_home'] ) {
+				update_user_option( $user->ID, 'post_collection_hide_from_home', true );
+			} else {
+				delete_user_option( $user->ID, 'post_collection_hide_from_home' );
 			}
 			if ( isset( $_POST['dropdown'] ) ) {
 				switch ( $_POST['dropdown'] ) {
@@ -735,6 +732,7 @@ class Post_Collection {
 			'bookmarklet_js'      => $this->get_bookmarklet_js(),
 			'frontend_mode'       => get_user_option( 'post_collection_frontend_mode', $user->ID ),
 			'frontend_view'       => get_user_option( 'post_collection_frontend_view', $user->ID ),
+			'hide_from_home'      => get_user_option( 'post_collection_hide_from_home', $user->ID ),
 			'frontend_url'        => class_exists( __NAMESPACE__ . '\Post_Collection_App' ) && Post_Collection_App::instance() ? Post_Collection_App::instance()->get_collection_url( $user ) : '',
 		);
 

--- a/class-user.php
+++ b/class-user.php
@@ -79,6 +79,9 @@ class User extends \WP_User {
 	 */
 	public function get_local_friends_page_url( $post_id = null ) {
 		if ( ! class_exists( 'Friends\Friends' ) ) {
+			if ( class_exists( __NAMESPACE__ . '\Post_Collection_App' ) && Post_Collection_App::instance() ) {
+				return Post_Collection_App::instance()->get_collection_url( $this, $post_id );
+			}
 			if ( $post_id && ! is_wp_error( $post_id ) ) {
 				return get_permalink( $post_id );
 			}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "akirk/wp-app": "^1.1",
+        "akirk/wp-app": "^1.2",
         "andreskrey/readability.php": "^2.1",
         "php": ">=7.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,8 @@
 {
     "require": {
-        "andreskrey/readability.php": "^2.1"
+        "akirk/wp-app": "^1.1",
+        "andreskrey/readability.php": "^2.1",
+        "php": ">=7.4"
     },
     "require-dev": {
         "ozh/log": "^1.0",

--- a/post-collection.php
+++ b/post-collection.php
@@ -7,6 +7,7 @@
  * Author URI: https://alex.kirk.at/
  *
  * Description: Collect posts from around the web.
+ * Requires PHP: 7.4
  *
  * License: GPL2
  * Text Domain: post-collection
@@ -31,6 +32,7 @@ require_once __DIR__ . '/class-user.php';
 require_once __DIR__ . '/class-user-query.php';
 require_once __DIR__ . '/class-post-collection.php';
 require_once __DIR__ . '/class-post-collection-abilities.php';
+require_once __DIR__ . '/class-post-collection-app.php';
 require_once __DIR__ . '/class-extracted-page.php';
 require_once __DIR__ . '/site-configs/class-site-config.php';
 require_once __DIR__ . '/site-configs/class-youtube.php';

--- a/templates/admin/edit-post-collection.php
+++ b/templates/admin/edit-post-collection.php
@@ -52,13 +52,41 @@ defined( 'ABSPATH' ) || exit;
 				<th><label><?php /* phpcs:ignore WordPress.WP.I18n.MissingArgDomain */ esc_html_e( 'Posts' ); ?></label></th>
 				<td>
 					<fieldset>
-					<a href="<?php echo esc_url( $args['user']->get_local_friends_page_url() ); ?>">
+					<a href="<?php echo esc_url( $args['frontend_url'] ? $args['frontend_url'] : $args['user']->get_local_friends_page_url() ); ?>">
 						<?php
 						// translators: %d is the number of posts.
 						echo esc_html( sprintf( _n( 'View %d post', 'View %d posts', $args['posts']->found_posts, 'post-collection' ), $args['posts']->found_posts ) );
 						?>
 					</a>
 					</fieldset>
+				</td>
+			</tr>
+			<tr>
+				<th><label for="frontend_mode"><?php esc_html_e( 'Frontend View', 'post-collection' ); ?></label></th>
+				<td>
+					<select name="frontend_mode" id="frontend_mode">
+						<option value="auto"<?php selected( ! $args['frontend_mode'] ); ?>><?php esc_html_e( 'Auto-detect', 'post-collection' ); ?></option>
+						<option value="bookmarks"<?php selected( 'bookmarks', $args['frontend_mode'] ); ?>><?php esc_html_e( 'Bookmarks', 'post-collection' ); ?></option>
+						<option value="posts"<?php selected( 'posts', $args['frontend_mode'] ); ?>><?php esc_html_e( 'Posts', 'post-collection' ); ?></option>
+					</select>
+					<p class="description"><?php esc_html_e( 'Choose whether this collection behaves like saved links or collected articles.', 'post-collection' ); ?></p>
+				</td>
+			</tr>
+			<tr>
+				<th><label for="frontend_view"><?php esc_html_e( 'Default Layout', 'post-collection' ); ?></label></th>
+				<td>
+					<select name="frontend_view" id="frontend_view">
+						<option value="auto"<?php selected( ! $args['frontend_view'] ); ?>><?php esc_html_e( 'Auto', 'post-collection' ); ?></option>
+						<option value="board"<?php selected( 'board', $args['frontend_view'] ); ?>><?php esc_html_e( 'Board', 'post-collection' ); ?></option>
+						<option value="links"<?php selected( 'links', $args['frontend_view'] ); ?>><?php esc_html_e( 'Compact links', 'post-collection' ); ?></option>
+						<option value="reader"<?php selected( 'reader', $args['frontend_view'] ); ?>><?php esc_html_e( 'Reader list', 'post-collection' ); ?></option>
+					</select>
+					<p class="description"><?php esc_html_e( 'Bookmark collections default to the compact links layout, inspired by Pinboard and Delicious.', 'post-collection' ); ?></p>
+					<?php if ( $args['frontend_url'] ) : ?>
+						<p class="description">
+							<a href="<?php echo esc_url( $args['frontend_url'] ); ?>"><?php echo esc_html( $args['frontend_url'] ); ?></a>
+						</p>
+					<?php endif; ?>
 				</td>
 			</tr>
 			<tr>
@@ -144,5 +172,3 @@ defined( 'ABSPATH' ) || exit;
 		<a href="<?php echo esc_url( self_admin_url( 'admin.php?page=post-collection' ) ); ?>"><?php esc_html_e( 'Back to the Post Collection overview', 'post-collection' ); ?></a></p>
 
 </form>
-
-

--- a/templates/admin/edit-post-collection.php
+++ b/templates/admin/edit-post-collection.php
@@ -62,12 +62,11 @@ defined( 'ABSPATH' ) || exit;
 				</td>
 			</tr>
 			<tr>
-				<th><label for="frontend_mode"><?php esc_html_e( 'Frontend View', 'post-collection' ); ?></label></th>
+				<th><label for="frontend_mode"><?php esc_html_e( 'Frontend Type', 'post-collection' ); ?></label></th>
 				<td>
 					<select name="frontend_mode" id="frontend_mode">
-						<option value="auto"<?php selected( ! $args['frontend_mode'] ); ?>><?php esc_html_e( 'Auto-detect', 'post-collection' ); ?></option>
+						<option value="posts"<?php selected( 'posts', $args['frontend_mode'] ?: 'posts' ); ?>><?php esc_html_e( 'Posts', 'post-collection' ); ?></option>
 						<option value="bookmarks"<?php selected( 'bookmarks', $args['frontend_mode'] ); ?>><?php esc_html_e( 'Bookmarks', 'post-collection' ); ?></option>
-						<option value="posts"<?php selected( 'posts', $args['frontend_mode'] ); ?>><?php esc_html_e( 'Posts', 'post-collection' ); ?></option>
 					</select>
 					<p class="description"><?php esc_html_e( 'Choose whether this collection behaves like saved links or collected articles.', 'post-collection' ); ?></p>
 				</td>
@@ -76,17 +75,26 @@ defined( 'ABSPATH' ) || exit;
 				<th><label for="frontend_view"><?php esc_html_e( 'Default Layout', 'post-collection' ); ?></label></th>
 				<td>
 					<select name="frontend_view" id="frontend_view">
-						<option value="auto"<?php selected( ! $args['frontend_view'] ); ?>><?php esc_html_e( 'Auto', 'post-collection' ); ?></option>
+						<option value="reader"<?php selected( 'reader', $args['frontend_view'] ?: 'reader' ); ?>><?php esc_html_e( 'Reader list', 'post-collection' ); ?></option>
 						<option value="board"<?php selected( 'board', $args['frontend_view'] ); ?>><?php esc_html_e( 'Board', 'post-collection' ); ?></option>
 						<option value="links"<?php selected( 'links', $args['frontend_view'] ); ?>><?php esc_html_e( 'Compact links', 'post-collection' ); ?></option>
-						<option value="reader"<?php selected( 'reader', $args['frontend_view'] ); ?>><?php esc_html_e( 'Reader list', 'post-collection' ); ?></option>
 					</select>
-					<p class="description"><?php esc_html_e( 'Bookmark collections default to the compact links layout, inspired by Pinboard and Delicious.', 'post-collection' ); ?></p>
+					<p class="description"><?php esc_html_e( 'Choose the layout used when the collection URL has no view parameter.', 'post-collection' ); ?></p>
 					<?php if ( $args['frontend_url'] ) : ?>
 						<p class="description">
 							<a href="<?php echo esc_url( $args['frontend_url'] ); ?>"><?php echo esc_html( $args['frontend_url'] ); ?></a>
 						</p>
 					<?php endif; ?>
+				</td>
+			</tr>
+			<tr>
+				<th><label><?php esc_html_e( 'Home Page', 'post-collection' ); ?></label></th>
+				<td>
+					<label>
+						<input type="checkbox" name="hide_from_home" value="1" <?php checked( $args['hide_from_home'] ); ?> />
+						<?php esc_html_e( 'Hide from the default collections view', 'post-collection' ); ?>
+					</label>
+					<p class="description"><?php esc_html_e( 'Hidden collections are still available from a collapsed section on the app home page.', 'post-collection' ); ?></p>
 				</td>
 			</tr>
 			<tr>

--- a/templates/admin/tools-post-collection.php
+++ b/templates/admin/tools-post-collection.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
 	<p><?php esc_html_e( "Drag one of these bookmarklets to your bookmarks bar and click it when you're on an article you want to save from the web.", 'post-collection' ); ?></p>
 	<p>
 		<?php foreach ( $args['post_collections'] as $collection ) : ?>
-		<a href="javascript:<?php echo rawurlencode( trim( str_replace( "window.document.getElementById( 'post-collection-script' ).getAttribute( 'data-post-url' )", "'" . esc_url( home_url() ) . "/?user=" . $collection['user_id'] . "'", $args['bookmarklet_js'] ), ';' ) ); ?>" style="display: inline-block; padding: .5em; border: 1px solid #999; border-radius: 4px; background-color: #ddd;text-decoration: none; margin-right: 3em">
+		<a href="javascript:<?php echo rawurlencode( trim( str_replace( "window.document.getElementById( 'post-collection-script' ).getAttribute( 'data-post-url' )", "'" . esc_url( home_url() ) . "/?collection=" . $collection['term_id'] . "'", $args['bookmarklet_js'] ), ';' ) ); ?>" style="display: inline-block; padding: .5em; border: 1px solid #999; border-radius: 4px; background-color: #ddd;text-decoration: none; margin-right: 3em">
 			<?php
 			echo esc_html(
 				sprintf(

--- a/templates/app/403.php
+++ b/templates/app/403.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Frontend app 403 view.
+ *
+ * @package Post_Collection
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$app = \PostCollection\Post_Collection_App::instance();
+?>
+<!DOCTYPE html>
+<html <?php echo wp_app_language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title><?php echo wp_app_title( __( 'Access Denied', 'post-collection' ) ); ?></title>
+	<?php wp_app_head(); ?>
+</head>
+<body <?php body_class( 'post-collection-app' ); ?>>
+	<?php wp_app_body_open(); ?>
+	<main class="pc-shell">
+		<section class="pc-empty">
+			<h1><?php esc_html_e( 'Access denied', 'post-collection' ); ?></h1>
+			<p><?php esc_html_e( 'You do not have access to this collection.', 'post-collection' ); ?></p>
+			<?php if ( $app ) : ?>
+				<a class="pc-button pc-button-primary" href="<?php echo esc_url( $app->get_home_url() ); ?>"><?php esc_html_e( 'View Collections', 'post-collection' ); ?></a>
+			<?php endif; ?>
+		</section>
+	</main>
+	<?php wp_app_body_close(); ?>
+</body>
+</html>

--- a/templates/app/403.php
+++ b/templates/app/403.php
@@ -17,7 +17,7 @@ $app = \PostCollection\Post_Collection_App::instance();
 	<title><?php echo wp_app_title( __( 'Access Denied', 'post-collection' ) ); ?></title>
 	<?php wp_app_head(); ?>
 </head>
-<body <?php body_class( 'post-collection-app' ); ?>>
+<body <?php body_class( 'wp-app-body post-collection-app' ); ?>>
 	<?php wp_app_body_open(); ?>
 	<main class="pc-shell">
 		<section class="pc-empty">

--- a/templates/app/404.php
+++ b/templates/app/404.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Frontend app 404 view.
+ *
+ * @package Post_Collection
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$app = \PostCollection\Post_Collection_App::instance();
+?>
+<!DOCTYPE html>
+<html <?php echo wp_app_language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title><?php echo wp_app_title( __( 'Not Found', 'post-collection' ) ); ?></title>
+	<?php wp_app_head(); ?>
+</head>
+<body <?php body_class( 'post-collection-app' ); ?>>
+	<?php wp_app_body_open(); ?>
+	<main class="pc-shell">
+		<section class="pc-empty">
+			<h1><?php esc_html_e( 'Collection item not found', 'post-collection' ); ?></h1>
+			<p><?php esc_html_e( 'It may be private, unpublished, or no longer available.', 'post-collection' ); ?></p>
+			<?php if ( $app ) : ?>
+				<a class="pc-button pc-button-primary" href="<?php echo esc_url( $app->get_home_url() ); ?>"><?php esc_html_e( 'View Collections', 'post-collection' ); ?></a>
+			<?php endif; ?>
+		</section>
+	</main>
+	<?php wp_app_body_close(); ?>
+</body>
+</html>

--- a/templates/app/404.php
+++ b/templates/app/404.php
@@ -17,7 +17,7 @@ $app = \PostCollection\Post_Collection_App::instance();
 	<title><?php echo wp_app_title( __( 'Not Found', 'post-collection' ) ); ?></title>
 	<?php wp_app_head(); ?>
 </head>
-<body <?php body_class( 'post-collection-app' ); ?>>
+<body <?php body_class( 'wp-app-body post-collection-app' ); ?>>
 	<?php wp_app_body_open(); ?>
 	<main class="pc-shell">
 		<section class="pc-empty">

--- a/templates/app/collection.php
+++ b/templates/app/collection.php
@@ -13,25 +13,26 @@ if ( ! $app ) {
 	return;
 }
 
-$username = wp_app_get_route_var( 'username' );
-$user     = $app->get_collection_by_username( $username );
-if ( ! $user || ! $app->can_view_collection( $user ) ) {
+$collection_slug = wp_app_get_route_var( 'collection' );
+$collection      = $app->get_collection_by_username( $collection_slug );
+if ( ! $collection || ! $app->can_view_collection( $collection ) ) {
 	status_header( 404 );
 	include __DIR__ . '/404.php';
 	return;
 }
 
-$mode       = $app->get_collection_mode( $user );
-$view       = $app->get_collection_view( $user );
-$views      = $app->get_available_views();
+$mode             = $app->get_collection_mode( $collection );
+$view             = $app->get_collection_view( $collection );
+$views            = $app->get_available_views();
+$article_statuses = $app->get_article_statuses();
 $quick_edit_post_id = $app->get_quick_edit_post_id();
 $quick_edit = $app->is_quick_edit_mode() && 'links' === $view;
-$query      = $app->query_collection_posts( $user );
-$terms      = $app->get_collection_terms( $user );
+$query      = $app->query_collection_posts( $collection );
+$terms      = $app->get_collection_terms( $collection );
 $search     = isset( $_GET['pc-search'] ) ? sanitize_text_field( wp_unslash( $_GET['pc-search'] ) ) : '';
 $active_tag = isset( $_GET['pc-tag'] ) ? sanitize_title( wp_unslash( $_GET['pc-tag'] ) ) : '';
 $page       = isset( $_GET['pc-page'] ) ? max( 1, absint( wp_unslash( $_GET['pc-page'] ) ) ) : 1;
-$base_url   = $app->get_collection_url( $user );
+$base_url   = $app->get_collection_url( $collection );
 
 $page_args = array();
 if ( $view ) {
@@ -52,7 +53,7 @@ if ( '' !== $active_tag ) {
 <head>
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title><?php echo wp_app_title( $user->display_name ); ?></title>
+	<title><?php echo wp_app_title( $collection->name ); ?></title>
 	<?php wp_app_head(); ?>
 </head>
 <body <?php body_class( 'wp-app-body post-collection-app pc-mode-' . $mode . ' pc-view-' . $view . ( $quick_edit ? ' pc-quick-edit' : '' ) ); ?>>
@@ -62,20 +63,23 @@ if ( '' !== $active_tag ) {
 		<div class="pc-collection-title-row">
 			<div>
 				<p class="pc-kicker"><?php echo esc_html( 'bookmarks' === $mode ? __( 'Bookmark collection', 'post-collection' ) : __( 'Post collection', 'post-collection' ) ); ?></p>
-				<h1><?php echo esc_html( $user->display_name ); ?></h1>
-				<?php if ( $user->description ) : ?>
-					<p class="pc-description"><?php echo esc_html( $user->description ); ?></p>
+				<h1><?php echo esc_html( $collection->name ); ?></h1>
+				<?php if ( $collection->description ) : ?>
+					<p class="pc-description"><?php echo esc_html( $collection->description ); ?></p>
 				<?php endif; ?>
 			</div>
 			<div class="pc-collection-stats">
 				<strong><?php echo esc_html( number_format_i18n( $query->found_posts ) ); ?></strong>
 				<span><?php esc_html_e( 'visible items', 'post-collection' ); ?></span>
+				<?php if ( $app->can_manage_collections() ) : ?>
+					<a href="<?php echo esc_url( $app->get_collection_settings_url( $collection ) ); ?>"><?php esc_html_e( 'Settings', 'post-collection' ); ?></a>
+				<?php endif; ?>
 			</div>
 		</div>
 
 		<?php if ( $app->can_manage_collections() ) : ?>
 			<form class="pc-add-form" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>">
-				<input type="hidden" name="user" value="<?php echo esc_attr( $user->ID ); ?>">
+				<input type="hidden" name="collection" value="<?php echo esc_attr( $collection->term_id ); ?>">
 				<input type="url" name="collect-post" placeholder="https://example.com/article" required>
 				<button type="submit"><?php esc_html_e( 'Save', 'post-collection' ); ?></button>
 			</form>
@@ -134,6 +138,7 @@ if ( '' !== $active_tag ) {
 				<?php endforeach; ?>
 			</nav>
 		<?php endif; ?>
+
 	</header>
 
 	<main class="pc-shell">
@@ -146,11 +151,12 @@ if ( '' !== $active_tag ) {
 			<section class="pc-bookmark-board" aria-label="<?php esc_attr_e( 'Bookmarks', 'post-collection' ); ?>">
 				<?php foreach ( $query->posts as $post ) : ?>
 					<?php
-					$image_url  = $app->get_post_image_url( $post );
-					$embed_html = $app->get_post_embed_html( $post, 'board' );
-					$excerpt    = $app->get_post_excerpt( $post, 22 );
-					$source_url = $app->get_source_url( $post );
-					$host       = $app->get_source_host( $post );
+					$image_url   = $app->get_post_image_url( $post );
+					$embed_html  = $app->get_post_embed_html( $post, 'board' );
+					$excerpt     = $app->get_post_excerpt( $post, 22 );
+					$source_url  = $app->get_source_url( $post );
+					$host        = $app->get_source_host( $post );
+					$read_status = $app->get_article_note_status( $post );
 					?>
 					<article class="pc-bookmark-card">
 						<?php if ( $embed_html ) : ?>
@@ -171,7 +177,10 @@ if ( '' !== $active_tag ) {
 								<p><?php echo esc_html( $excerpt ); ?></p>
 							<?php endif; ?>
 							<div class="pc-card-actions">
-								<a href="<?php echo esc_url( $app->get_collection_url( $user, $post->ID ) ); ?>"><?php esc_html_e( 'Details', 'post-collection' ); ?></a>
+								<a href="<?php echo esc_url( $app->get_collection_url( $collection, $post->ID ) ); ?>"><?php esc_html_e( 'Details', 'post-collection' ); ?></a>
+								<?php if ( $app->can_manage_collections() ) : ?>
+									<span class="pc-read-status pc-read-status-<?php echo esc_attr( $read_status ); ?>"><?php echo esc_html( $app->get_article_note_status_label( $read_status ) ); ?></span>
+								<?php endif; ?>
 								<?php if ( 'private' === $post->post_status && $app->can_manage_collections() ) : ?>
 									<span><?php esc_html_e( 'Private', 'post-collection' ); ?></span>
 								<?php endif; ?>
@@ -184,15 +193,16 @@ if ( '' !== $active_tag ) {
 			<section class="pc-link-list" aria-label="<?php esc_attr_e( 'Links', 'post-collection' ); ?>">
 				<?php foreach ( $query->posts as $post ) : ?>
 					<?php
-					$source_url = $app->get_source_url( $post );
-					$host       = $app->get_source_host( $post );
-					$embed_html = $app->get_post_embed_html( $post, 'links' );
-					$excerpt    = $app->get_post_excerpt( $post, 24 );
-					$post_terms = $app->get_post_terms( $post );
-					$tag_names  = wp_list_pluck( $post_terms, 'name' );
-					$is_editing = $quick_edit && intval( $post->ID ) === intval( $quick_edit_post_id );
-					$edit_url   = add_query_arg( array( 'pc-view' => 'links', 'pc-edit' => $post->ID ) ) . '#pc-link-' . $post->ID;
-					$cancel_url = remove_query_arg( 'pc-edit' ) . '#pc-link-' . $post->ID;
+					$source_url  = $app->get_source_url( $post );
+					$host        = $app->get_source_host( $post );
+					$embed_html  = $app->get_post_embed_html( $post, 'links' );
+					$excerpt     = $app->get_post_excerpt( $post, 24 );
+					$post_terms  = $app->get_post_terms( $post );
+					$tag_names   = wp_list_pluck( $post_terms, 'name' );
+					$read_status = $app->get_article_note_status( $post );
+					$is_editing  = $quick_edit && intval( $post->ID ) === intval( $quick_edit_post_id );
+					$edit_url    = add_query_arg( array( 'pc-view' => 'links', 'pc-edit' => $post->ID ) ) . '#pc-link-' . $post->ID;
+					$cancel_url  = remove_query_arg( 'pc-edit' ) . '#pc-link-' . $post->ID;
 					?>
 					<article id="pc-link-<?php echo esc_attr( $post->ID ); ?>" class="pc-link-row<?php echo 'private' === $post->post_status ? ' is-private' : ''; ?><?php echo $is_editing ? ' is-editing' : ''; ?>">
 						<div class="pc-link-main">
@@ -210,10 +220,13 @@ if ( '' !== $active_tag ) {
 						<div class="pc-link-meta">
 							<time datetime="<?php echo esc_attr( get_the_date( DATE_W3C, $post ) ); ?>"><?php echo esc_html( get_the_date( '', $post ) ); ?></time>
 							<span class="pc-link-host"><?php echo esc_html( $host ); ?></span>
+							<?php if ( $app->can_manage_collections() ) : ?>
+								<span class="pc-read-status pc-read-status-<?php echo esc_attr( $read_status ); ?>"><?php echo esc_html( $app->get_article_note_status_label( $read_status ) ); ?></span>
+							<?php endif; ?>
 							<?php if ( 'private' === $post->post_status && $app->can_manage_collections() ) : ?>
 								<span class="pc-link-private"><?php esc_html_e( 'private', 'post-collection' ); ?></span>
 							<?php endif; ?>
-							<a href="<?php echo esc_url( $app->get_collection_url( $user, $post->ID ) ); ?>"><?php esc_html_e( 'Details', 'post-collection' ); ?></a>
+							<a href="<?php echo esc_url( $app->get_collection_url( $collection, $post->ID ) ); ?>"><?php esc_html_e( 'Details', 'post-collection' ); ?></a>
 							<?php if ( $app->can_manage_collections() ) : ?>
 								<?php if ( $is_editing ) : ?>
 									<a class="pc-quick-edit-cancel" href="<?php echo esc_url( $cancel_url ); ?>" data-edit-url="<?php echo esc_url( $edit_url ); ?>" data-cancel-url="<?php echo esc_url( $cancel_url ); ?>" data-edit-label="<?php esc_attr_e( 'Edit', 'post-collection' ); ?>" data-cancel-label="<?php esc_attr_e( 'Cancel edit', 'post-collection' ); ?>"><?php esc_html_e( 'Cancel edit', 'post-collection' ); ?></a>
@@ -253,6 +266,14 @@ if ( '' !== $active_tag ) {
 									<span><?php esc_html_e( 'Tags', 'post-collection' ); ?></span>
 									<input type="text" name="post_tags" value="<?php echo esc_attr( implode( ', ', $tag_names ) ); ?>">
 								</label>
+								<label>
+									<span><?php esc_html_e( 'Read status', 'post-collection' ); ?></span>
+									<select name="article_status">
+										<?php foreach ( $article_statuses as $status_key => $status_label ) : ?>
+											<option value="<?php echo esc_attr( $status_key ); ?>"<?php selected( $status_key, $read_status ); ?>><?php echo esc_html( $status_label ); ?></option>
+										<?php endforeach; ?>
+									</select>
+								</label>
 								<div class="pc-quick-edit-actions">
 									<label class="pc-quick-edit-public">
 										<input type="checkbox" name="post_status" value="publish" <?php checked( 'publish', $post->post_status ); ?>>
@@ -270,27 +291,31 @@ if ( '' !== $active_tag ) {
 			<section class="pc-post-list" aria-label="<?php esc_attr_e( 'Posts', 'post-collection' ); ?>">
 				<?php foreach ( $query->posts as $post ) : ?>
 					<?php
-					$image_url  = $app->get_post_image_url( $post );
-					$embed_html = $app->get_post_embed_html( $post, 'reader' );
-					$excerpt    = $app->get_post_excerpt( $post, 38 );
-					$host       = $app->get_source_host( $post );
+					$image_url   = $app->get_post_image_url( $post );
+					$embed_html  = $app->get_post_embed_html( $post, 'reader' );
+					$excerpt     = $app->get_post_excerpt( $post, 38 );
+					$host        = $app->get_source_host( $post );
+					$read_status = $app->get_article_note_status( $post );
 					?>
 					<article class="pc-post-row<?php echo $image_url || $embed_html ? ' has-image' : ' is-text-only'; ?>">
 						<?php if ( $embed_html ) : ?>
 							<div class="pc-post-embed"><?php echo $embed_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
 						<?php elseif ( $image_url ) : ?>
-							<a class="pc-post-thumb" href="<?php echo esc_url( $app->get_collection_url( $user, $post->ID ) ); ?>">
+							<a class="pc-post-thumb" href="<?php echo esc_url( $app->get_collection_url( $collection, $post->ID ) ); ?>">
 								<img src="<?php echo esc_url( $image_url ); ?>" alt="">
 							</a>
 						<?php endif; ?>
 						<div>
 							<p class="pc-source"><?php echo esc_html( $host ); ?></p>
-							<h2><a href="<?php echo esc_url( $app->get_collection_url( $user, $post->ID ) ); ?>"><?php echo esc_html( get_the_title( $post ) ); ?></a></h2>
+							<h2><a href="<?php echo esc_url( $app->get_collection_url( $collection, $post->ID ) ); ?>"><?php echo esc_html( get_the_title( $post ) ); ?></a></h2>
 							<?php if ( $excerpt ) : ?>
 								<p><?php echo esc_html( $excerpt ); ?></p>
 							<?php endif; ?>
 							<div class="pc-row-meta">
 								<time datetime="<?php echo esc_attr( get_the_date( DATE_W3C, $post ) ); ?>"><?php echo esc_html( get_the_date( '', $post ) ); ?></time>
+								<?php if ( $app->can_manage_collections() ) : ?>
+									<span class="pc-read-status pc-read-status-<?php echo esc_attr( $read_status ); ?>"><?php echo esc_html( $app->get_article_note_status_label( $read_status ) ); ?></span>
+								<?php endif; ?>
 								<a href="<?php echo esc_url( $app->get_source_url( $post ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Original', 'post-collection' ); ?></a>
 							</div>
 						</div>

--- a/templates/app/collection.php
+++ b/templates/app/collection.php
@@ -70,7 +70,7 @@ if ( '' !== $active_tag ) {
 			</div>
 			<div class="pc-collection-stats">
 				<strong><?php echo esc_html( number_format_i18n( $query->found_posts ) ); ?></strong>
-				<span><?php esc_html_e( 'visible items', 'post-collection' ); ?></span>
+				<span><?php echo esc_html( 'bookmarks' === $mode ? __( 'visible saved links', 'post-collection' ) : __( 'visible posts', 'post-collection' ) ); ?></span>
 				<?php if ( $app->can_manage_collections() ) : ?>
 					<a href="<?php echo esc_url( $app->get_collection_settings_url( $collection ) ); ?>"><?php esc_html_e( 'Settings', 'post-collection' ); ?></a>
 				<?php endif; ?>

--- a/templates/app/collection.php
+++ b/templates/app/collection.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * Frontend app collection view.
+ *
+ * @package Post_Collection
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$app = \PostCollection\Post_Collection_App::instance();
+if ( ! $app ) {
+	status_header( 500 );
+	return;
+}
+
+$username = wp_app_get_route_var( 'username' );
+$user     = $app->get_collection_by_username( $username );
+if ( ! $user || ! $app->can_view_collection( $user ) ) {
+	status_header( 404 );
+	include __DIR__ . '/404.php';
+	return;
+}
+
+$mode       = $app->get_collection_mode( $user );
+$view       = $app->get_collection_view( $user );
+$views      = $app->get_available_views();
+$quick_edit_post_id = $app->get_quick_edit_post_id();
+$quick_edit = $app->is_quick_edit_mode() && 'links' === $view;
+$query      = $app->query_collection_posts( $user );
+$terms      = $app->get_collection_terms( $user );
+$search     = isset( $_GET['pc-search'] ) ? sanitize_text_field( wp_unslash( $_GET['pc-search'] ) ) : '';
+$active_tag = isset( $_GET['pc-tag'] ) ? sanitize_title( wp_unslash( $_GET['pc-tag'] ) ) : '';
+$page       = isset( $_GET['pc-page'] ) ? max( 1, absint( wp_unslash( $_GET['pc-page'] ) ) ) : 1;
+$base_url   = $app->get_collection_url( $user );
+
+$page_args = array();
+if ( $view ) {
+	$page_args['pc-view'] = $view;
+}
+if ( $quick_edit ) {
+	$page_args['pc-edit'] = $quick_edit_post_id;
+}
+if ( '' !== $search ) {
+	$page_args['pc-search'] = $search;
+}
+if ( '' !== $active_tag ) {
+	$page_args['pc-tag'] = $active_tag;
+}
+?>
+<!DOCTYPE html>
+<html <?php echo wp_app_language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title><?php echo wp_app_title( $user->display_name ); ?></title>
+	<?php wp_app_head(); ?>
+</head>
+<body <?php body_class( 'post-collection-app pc-mode-' . $mode . ' pc-view-' . $view . ( $quick_edit ? ' pc-quick-edit' : '' ) ); ?>>
+	<?php wp_app_body_open(); ?>
+	<header class="pc-shell pc-collection-header">
+		<div class="pc-breadcrumb"><a href="<?php echo esc_url( $app->get_home_url() ); ?>"><?php esc_html_e( 'Collections', 'post-collection' ); ?></a></div>
+		<div class="pc-collection-title-row">
+			<div>
+				<p class="pc-kicker"><?php echo esc_html( 'bookmarks' === $mode ? __( 'Bookmark collection', 'post-collection' ) : __( 'Post collection', 'post-collection' ) ); ?></p>
+				<h1><?php echo esc_html( $user->display_name ); ?></h1>
+				<?php if ( $user->description ) : ?>
+					<p class="pc-description"><?php echo esc_html( $user->description ); ?></p>
+				<?php endif; ?>
+			</div>
+			<div class="pc-collection-stats">
+				<strong><?php echo esc_html( number_format_i18n( $query->found_posts ) ); ?></strong>
+				<span><?php esc_html_e( 'visible items', 'post-collection' ); ?></span>
+			</div>
+		</div>
+
+		<?php if ( $app->can_manage_collections() ) : ?>
+			<form class="pc-add-form" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+				<input type="hidden" name="user" value="<?php echo esc_attr( $user->ID ); ?>">
+				<input type="url" name="collect-post" placeholder="https://example.com/article" required>
+				<button type="submit"><?php esc_html_e( 'Save', 'post-collection' ); ?></button>
+			</form>
+		<?php endif; ?>
+
+		<form class="pc-filter-bar" method="get" action="<?php echo esc_url( $base_url ); ?>">
+			<label class="screen-reader-text" for="pc-search"><?php esc_html_e( 'Search this collection', 'post-collection' ); ?></label>
+			<input id="pc-search" type="search" name="pc-search" value="<?php echo esc_attr( $search ); ?>" placeholder="<?php esc_attr_e( 'Search saved items', 'post-collection' ); ?>">
+			<input type="hidden" name="pc-view" value="<?php echo esc_attr( $view ); ?>">
+			<?php if ( '' !== $active_tag ) : ?>
+				<input type="hidden" name="pc-tag" value="<?php echo esc_attr( $active_tag ); ?>">
+			<?php endif; ?>
+			<button type="submit"><?php esc_html_e( 'Search', 'post-collection' ); ?></button>
+			<?php if ( '' !== $search || '' !== $active_tag ) : ?>
+				<a class="pc-clear-link" href="<?php echo esc_url( add_query_arg( 'pc-view', $view, $base_url ) ); ?>"><?php esc_html_e( 'Clear', 'post-collection' ); ?></a>
+			<?php endif; ?>
+		</form>
+
+		<nav class="pc-view-switch" aria-label="<?php esc_attr_e( 'Collection view', 'post-collection' ); ?>">
+			<?php foreach ( $views as $view_key => $view_label ) : ?>
+				<?php
+				$view_url = add_query_arg(
+					array_filter(
+						array(
+							'pc-search' => $search,
+							'pc-tag'    => $active_tag,
+							'pc-view'   => $view_key,
+						)
+					),
+					$base_url
+				);
+				?>
+				<a class="<?php echo $view === $view_key ? 'is-active' : ''; ?>" href="<?php echo esc_url( $view_url ); ?>"><?php echo esc_html( $view_label ); ?></a>
+			<?php endforeach; ?>
+		</nav>
+
+		<?php if ( ! empty( $terms ) ) : ?>
+			<nav class="pc-tag-strip" aria-label="<?php esc_attr_e( 'Collection tags', 'post-collection' ); ?>">
+				<?php foreach ( $terms as $term ) : ?>
+					<?php
+					$tag_url = add_query_arg(
+						array_filter(
+							array(
+								'pc-search' => $search,
+								'pc-tag'    => $term->slug,
+								'pc-view'   => $view,
+							)
+						),
+						$base_url
+					);
+					?>
+					<a class="<?php echo $active_tag === $term->slug ? 'is-active' : ''; ?>" href="<?php echo esc_url( $tag_url ); ?>">
+						<?php echo esc_html( $term->name ); ?>
+						<span><?php echo esc_html( number_format_i18n( $term->count ) ); ?></span>
+					</a>
+				<?php endforeach; ?>
+			</nav>
+		<?php endif; ?>
+	</header>
+
+	<main class="pc-shell">
+		<?php if ( ! $query->have_posts() ) : ?>
+			<section class="pc-empty">
+				<h2><?php esc_html_e( 'No items found', 'post-collection' ); ?></h2>
+				<p><?php esc_html_e( 'Try another search or tag.', 'post-collection' ); ?></p>
+			</section>
+		<?php elseif ( 'board' === $view ) : ?>
+			<section class="pc-bookmark-board" aria-label="<?php esc_attr_e( 'Bookmarks', 'post-collection' ); ?>">
+				<?php foreach ( $query->posts as $post ) : ?>
+					<?php
+					$image_url  = $app->get_post_image_url( $post );
+					$source_url = $app->get_source_url( $post );
+					$host       = $app->get_source_host( $post );
+					?>
+					<article class="pc-bookmark-card">
+						<?php if ( $image_url ) : ?>
+							<a class="pc-card-image" href="<?php echo esc_url( $source_url ); ?>" target="_blank" rel="noopener noreferrer">
+								<img src="<?php echo esc_url( $image_url ); ?>" alt="">
+							</a>
+						<?php else : ?>
+							<a class="pc-card-host" href="<?php echo esc_url( $source_url ); ?>" target="_blank" rel="noopener noreferrer">
+								<?php echo esc_html( $host ? substr( $host, 0, 1 ) : '#' ); ?>
+							</a>
+						<?php endif; ?>
+						<div class="pc-card-body">
+							<p class="pc-source"><?php echo esc_html( $host ); ?></p>
+							<h2><a href="<?php echo esc_url( $source_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( get_the_title( $post ) ); ?></a></h2>
+							<p><?php echo esc_html( $app->get_post_excerpt( $post, 22 ) ); ?></p>
+							<div class="pc-card-actions">
+								<a href="<?php echo esc_url( $app->get_collection_url( $user, $post->ID ) ); ?>"><?php esc_html_e( 'Details', 'post-collection' ); ?></a>
+								<?php if ( 'private' === $post->post_status && $app->can_manage_collections() ) : ?>
+									<span><?php esc_html_e( 'Private', 'post-collection' ); ?></span>
+								<?php endif; ?>
+							</div>
+						</div>
+					</article>
+				<?php endforeach; ?>
+			</section>
+		<?php elseif ( 'links' === $view ) : ?>
+			<section class="pc-link-list" aria-label="<?php esc_attr_e( 'Links', 'post-collection' ); ?>">
+				<?php foreach ( $query->posts as $post ) : ?>
+					<?php
+					$source_url = $app->get_source_url( $post );
+					$host       = $app->get_source_host( $post );
+					$post_terms = $app->get_post_terms( $post );
+					$tag_names  = wp_list_pluck( $post_terms, 'name' );
+					$is_editing = $quick_edit && intval( $post->ID ) === intval( $quick_edit_post_id );
+					$edit_url   = add_query_arg( array( 'pc-view' => 'links', 'pc-edit' => $post->ID ) ) . '#pc-link-' . $post->ID;
+					$cancel_url = remove_query_arg( 'pc-edit' ) . '#pc-link-' . $post->ID;
+					?>
+					<article id="pc-link-<?php echo esc_attr( $post->ID ); ?>" class="pc-link-row<?php echo 'private' === $post->post_status ? ' is-private' : ''; ?><?php echo $is_editing ? ' is-editing' : ''; ?>">
+						<div class="pc-link-main">
+							<div class="pc-link-title-line">
+								<span class="pc-link-marker" aria-hidden="true"></span>
+								<h2><a class="pc-link-title" href="<?php echo esc_url( $source_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( get_the_title( $post ) ); ?></a></h2>
+							</div>
+							<a class="pc-link-url" href="<?php echo esc_url( $source_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( preg_replace( '#^https?://#', '', $source_url ) ); ?></a>
+							<?php if ( $app->get_post_excerpt( $post, 24 ) ) : ?>
+								<p class="pc-link-excerpt"><?php echo esc_html( $app->get_post_excerpt( $post, 24 ) ); ?></p>
+							<?php endif; ?>
+						</div>
+						<div class="pc-link-meta">
+							<time datetime="<?php echo esc_attr( get_the_date( DATE_W3C, $post ) ); ?>"><?php echo esc_html( get_the_date( '', $post ) ); ?></time>
+							<span class="pc-link-host"><?php echo esc_html( $host ); ?></span>
+							<?php if ( 'private' === $post->post_status && $app->can_manage_collections() ) : ?>
+								<span class="pc-link-private"><?php esc_html_e( 'private', 'post-collection' ); ?></span>
+							<?php endif; ?>
+							<a href="<?php echo esc_url( $app->get_collection_url( $user, $post->ID ) ); ?>"><?php esc_html_e( 'Details', 'post-collection' ); ?></a>
+							<?php if ( $app->can_manage_collections() ) : ?>
+								<?php if ( $is_editing ) : ?>
+									<a class="pc-quick-edit-cancel" href="<?php echo esc_url( $cancel_url ); ?>" data-edit-url="<?php echo esc_url( $edit_url ); ?>" data-cancel-url="<?php echo esc_url( $cancel_url ); ?>" data-edit-label="<?php esc_attr_e( 'Edit', 'post-collection' ); ?>" data-cancel-label="<?php esc_attr_e( 'Cancel edit', 'post-collection' ); ?>"><?php esc_html_e( 'Cancel edit', 'post-collection' ); ?></a>
+								<?php else : ?>
+									<a class="pc-quick-edit-open" href="<?php echo esc_url( $edit_url ); ?>" data-edit-url="<?php echo esc_url( $edit_url ); ?>" data-cancel-url="<?php echo esc_url( $cancel_url ); ?>" data-edit-label="<?php esc_attr_e( 'Edit', 'post-collection' ); ?>" data-cancel-label="<?php esc_attr_e( 'Cancel edit', 'post-collection' ); ?>"><?php esc_html_e( 'Edit', 'post-collection' ); ?></a>
+								<?php endif; ?>
+							<?php endif; ?>
+						</div>
+						<?php if ( ! empty( $post_terms ) ) : ?>
+							<div class="pc-link-tags">
+								<?php foreach ( $post_terms as $term ) : ?>
+									<a href="<?php echo esc_url( add_query_arg( array_filter( array( 'pc-tag' => $term->slug, 'pc-view' => $view ) ), $base_url ) ); ?>"><?php echo esc_html( $term->name ); ?></a>
+								<?php endforeach; ?>
+							</div>
+						<?php else : ?>
+							<div class="pc-link-tags"></div>
+						<?php endif; ?>
+						<?php if ( $app->can_manage_collections() ) : ?>
+							<form class="pc-quick-edit-form" method="post" action="<?php echo esc_url( $edit_url ); ?>" data-ajax-action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>">
+								<input type="hidden" name="action" value="post_collection_quick_edit">
+								<input type="hidden" name="post_collection_action" value="quick-edit">
+								<input type="hidden" name="post_id" value="<?php echo esc_attr( $post->ID ); ?>">
+								<?php wp_nonce_field( 'post-collection-quick-edit-' . $post->ID ); ?>
+								<label>
+									<span><?php esc_html_e( 'Title', 'post-collection' ); ?></span>
+									<input type="text" name="post_title" value="<?php echo esc_attr( get_the_title( $post ) ); ?>">
+								</label>
+								<label>
+									<span><?php esc_html_e( 'URL', 'post-collection' ); ?></span>
+									<input type="url" name="source_url" value="<?php echo esc_attr( $source_url ); ?>">
+								</label>
+								<label>
+									<span><?php esc_html_e( 'Description', 'post-collection' ); ?></span>
+									<textarea name="post_excerpt" rows="2"><?php echo esc_textarea( $post->post_excerpt ? $post->post_excerpt : $app->get_post_excerpt( $post, 28 ) ); ?></textarea>
+								</label>
+								<label>
+									<span><?php esc_html_e( 'Tags', 'post-collection' ); ?></span>
+									<input type="text" name="post_tags" value="<?php echo esc_attr( implode( ', ', $tag_names ) ); ?>">
+								</label>
+								<div class="pc-quick-edit-actions">
+									<label class="pc-quick-edit-public">
+										<input type="checkbox" name="post_status" value="publish" <?php checked( 'publish', $post->post_status ); ?>>
+										<span><?php esc_html_e( 'Public', 'post-collection' ); ?></span>
+									</label>
+									<button type="submit"><?php esc_html_e( 'Save', 'post-collection' ); ?></button>
+									<span class="pc-quick-edit-status" aria-live="polite"></span>
+								</div>
+							</form>
+						<?php endif; ?>
+					</article>
+				<?php endforeach; ?>
+			</section>
+		<?php else : ?>
+			<section class="pc-post-list" aria-label="<?php esc_attr_e( 'Posts', 'post-collection' ); ?>">
+				<?php foreach ( $query->posts as $post ) : ?>
+					<?php
+					$image_url = $app->get_post_image_url( $post );
+					$host      = $app->get_source_host( $post );
+					?>
+					<article class="pc-post-row<?php echo $image_url ? ' has-image' : ' is-text-only'; ?>">
+						<?php if ( $image_url ) : ?>
+							<a class="pc-post-thumb" href="<?php echo esc_url( $app->get_collection_url( $user, $post->ID ) ); ?>">
+								<img src="<?php echo esc_url( $image_url ); ?>" alt="">
+							</a>
+						<?php endif; ?>
+						<div>
+							<p class="pc-source"><?php echo esc_html( $host ); ?></p>
+							<h2><a href="<?php echo esc_url( $app->get_collection_url( $user, $post->ID ) ); ?>"><?php echo esc_html( get_the_title( $post ) ); ?></a></h2>
+							<p><?php echo esc_html( $app->get_post_excerpt( $post, 38 ) ); ?></p>
+							<div class="pc-row-meta">
+								<time datetime="<?php echo esc_attr( get_the_date( DATE_W3C, $post ) ); ?>"><?php echo esc_html( get_the_date( '', $post ) ); ?></time>
+								<a href="<?php echo esc_url( $app->get_source_url( $post ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Original', 'post-collection' ); ?></a>
+							</div>
+						</div>
+					</article>
+				<?php endforeach; ?>
+			</section>
+		<?php endif; ?>
+
+		<?php if ( $query->max_num_pages > 1 ) : ?>
+			<nav class="pc-pagination" aria-label="<?php esc_attr_e( 'Pagination', 'post-collection' ); ?>">
+				<?php if ( $page > 1 ) : ?>
+					<a href="<?php echo esc_url( add_query_arg( array_merge( $page_args, array( 'pc-page' => $page - 1 ) ), $base_url ) ); ?>"><?php esc_html_e( 'Previous', 'post-collection' ); ?></a>
+				<?php endif; ?>
+				<span>
+					<?php
+					echo esc_html(
+						sprintf(
+							// translators: %1$d is the current page, %2$d is the total number of pages.
+							__( 'Page %1$d of %2$d', 'post-collection' ),
+							$page,
+							$query->max_num_pages
+						)
+					);
+					?>
+				</span>
+				<?php if ( $page < $query->max_num_pages ) : ?>
+					<a href="<?php echo esc_url( add_query_arg( array_merge( $page_args, array( 'pc-page' => $page + 1 ) ), $base_url ) ); ?>"><?php esc_html_e( 'Next', 'post-collection' ); ?></a>
+				<?php endif; ?>
+			</nav>
+		<?php endif; ?>
+	</main>
+	<?php wp_app_body_close(); ?>
+</body>
+</html>

--- a/templates/app/collection.php
+++ b/templates/app/collection.php
@@ -147,11 +147,15 @@ if ( '' !== $active_tag ) {
 				<?php foreach ( $query->posts as $post ) : ?>
 					<?php
 					$image_url  = $app->get_post_image_url( $post );
+					$embed_html = $app->get_post_embed_html( $post, 'board' );
+					$excerpt    = $app->get_post_excerpt( $post, 22 );
 					$source_url = $app->get_source_url( $post );
 					$host       = $app->get_source_host( $post );
 					?>
 					<article class="pc-bookmark-card">
-						<?php if ( $image_url ) : ?>
+						<?php if ( $embed_html ) : ?>
+							<div class="pc-card-embed"><?php echo $embed_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
+						<?php elseif ( $image_url ) : ?>
 							<a class="pc-card-image" href="<?php echo esc_url( $source_url ); ?>" target="_blank" rel="noopener noreferrer">
 								<img src="<?php echo esc_url( $image_url ); ?>" alt="">
 							</a>
@@ -163,7 +167,9 @@ if ( '' !== $active_tag ) {
 						<div class="pc-card-body">
 							<p class="pc-source"><?php echo esc_html( $host ); ?></p>
 							<h2><a href="<?php echo esc_url( $source_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( get_the_title( $post ) ); ?></a></h2>
-							<p><?php echo esc_html( $app->get_post_excerpt( $post, 22 ) ); ?></p>
+							<?php if ( $excerpt ) : ?>
+								<p><?php echo esc_html( $excerpt ); ?></p>
+							<?php endif; ?>
 							<div class="pc-card-actions">
 								<a href="<?php echo esc_url( $app->get_collection_url( $user, $post->ID ) ); ?>"><?php esc_html_e( 'Details', 'post-collection' ); ?></a>
 								<?php if ( 'private' === $post->post_status && $app->can_manage_collections() ) : ?>
@@ -180,6 +186,8 @@ if ( '' !== $active_tag ) {
 					<?php
 					$source_url = $app->get_source_url( $post );
 					$host       = $app->get_source_host( $post );
+					$embed_html = $app->get_post_embed_html( $post, 'links' );
+					$excerpt    = $app->get_post_excerpt( $post, 24 );
 					$post_terms = $app->get_post_terms( $post );
 					$tag_names  = wp_list_pluck( $post_terms, 'name' );
 					$is_editing = $quick_edit && intval( $post->ID ) === intval( $quick_edit_post_id );
@@ -193,8 +201,10 @@ if ( '' !== $active_tag ) {
 								<h2><a class="pc-link-title" href="<?php echo esc_url( $source_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( get_the_title( $post ) ); ?></a></h2>
 							</div>
 							<a class="pc-link-url" href="<?php echo esc_url( $source_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( preg_replace( '#^https?://#', '', $source_url ) ); ?></a>
-							<?php if ( $app->get_post_excerpt( $post, 24 ) ) : ?>
-								<p class="pc-link-excerpt"><?php echo esc_html( $app->get_post_excerpt( $post, 24 ) ); ?></p>
+							<?php if ( $embed_html ) : ?>
+								<div class="pc-link-embed"><?php echo $embed_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
+							<?php elseif ( $excerpt ) : ?>
+								<p class="pc-link-excerpt"><?php echo esc_html( $excerpt ); ?></p>
 							<?php endif; ?>
 						</div>
 						<div class="pc-link-meta">
@@ -237,7 +247,7 @@ if ( '' !== $active_tag ) {
 								</label>
 								<label>
 									<span><?php esc_html_e( 'Description', 'post-collection' ); ?></span>
-									<textarea name="post_excerpt" rows="2"><?php echo esc_textarea( $post->post_excerpt ? $post->post_excerpt : $app->get_post_excerpt( $post, 28 ) ); ?></textarea>
+									<textarea name="post_excerpt" rows="2"><?php echo esc_textarea( $post->post_excerpt ); ?></textarea>
 								</label>
 								<label>
 									<span><?php esc_html_e( 'Tags', 'post-collection' ); ?></span>
@@ -260,11 +270,15 @@ if ( '' !== $active_tag ) {
 			<section class="pc-post-list" aria-label="<?php esc_attr_e( 'Posts', 'post-collection' ); ?>">
 				<?php foreach ( $query->posts as $post ) : ?>
 					<?php
-					$image_url = $app->get_post_image_url( $post );
-					$host      = $app->get_source_host( $post );
+					$image_url  = $app->get_post_image_url( $post );
+					$embed_html = $app->get_post_embed_html( $post, 'reader' );
+					$excerpt    = $app->get_post_excerpt( $post, 38 );
+					$host       = $app->get_source_host( $post );
 					?>
-					<article class="pc-post-row<?php echo $image_url ? ' has-image' : ' is-text-only'; ?>">
-						<?php if ( $image_url ) : ?>
+					<article class="pc-post-row<?php echo $image_url || $embed_html ? ' has-image' : ' is-text-only'; ?>">
+						<?php if ( $embed_html ) : ?>
+							<div class="pc-post-embed"><?php echo $embed_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
+						<?php elseif ( $image_url ) : ?>
 							<a class="pc-post-thumb" href="<?php echo esc_url( $app->get_collection_url( $user, $post->ID ) ); ?>">
 								<img src="<?php echo esc_url( $image_url ); ?>" alt="">
 							</a>
@@ -272,7 +286,9 @@ if ( '' !== $active_tag ) {
 						<div>
 							<p class="pc-source"><?php echo esc_html( $host ); ?></p>
 							<h2><a href="<?php echo esc_url( $app->get_collection_url( $user, $post->ID ) ); ?>"><?php echo esc_html( get_the_title( $post ) ); ?></a></h2>
-							<p><?php echo esc_html( $app->get_post_excerpt( $post, 38 ) ); ?></p>
+							<?php if ( $excerpt ) : ?>
+								<p><?php echo esc_html( $excerpt ); ?></p>
+							<?php endif; ?>
 							<div class="pc-row-meta">
 								<time datetime="<?php echo esc_attr( get_the_date( DATE_W3C, $post ) ); ?>"><?php echo esc_html( get_the_date( '', $post ) ); ?></time>
 								<a href="<?php echo esc_url( $app->get_source_url( $post ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Original', 'post-collection' ); ?></a>
@@ -286,7 +302,7 @@ if ( '' !== $active_tag ) {
 		<?php if ( $query->max_num_pages > 1 ) : ?>
 			<nav class="pc-pagination" aria-label="<?php esc_attr_e( 'Pagination', 'post-collection' ); ?>">
 				<?php if ( $page > 1 ) : ?>
-					<a href="<?php echo esc_url( add_query_arg( array_merge( $page_args, array( 'pc-page' => $page - 1 ) ), $base_url ) ); ?>"><?php esc_html_e( 'Previous', 'post-collection' ); ?></a>
+					<a class="pc-pagination-prev" href="<?php echo esc_url( add_query_arg( array_merge( $page_args, array( 'pc-page' => $page - 1 ) ), $base_url ) ); ?>"><?php esc_html_e( 'Previous', 'post-collection' ); ?></a>
 				<?php endif; ?>
 				<span>
 					<?php
@@ -301,7 +317,7 @@ if ( '' !== $active_tag ) {
 					?>
 				</span>
 				<?php if ( $page < $query->max_num_pages ) : ?>
-					<a href="<?php echo esc_url( add_query_arg( array_merge( $page_args, array( 'pc-page' => $page + 1 ) ), $base_url ) ); ?>"><?php esc_html_e( 'Next', 'post-collection' ); ?></a>
+					<a class="pc-pagination-next" rel="next" href="<?php echo esc_url( add_query_arg( array_merge( $page_args, array( 'pc-page' => $page + 1 ) ), $base_url ) ); ?>"><?php esc_html_e( 'Next', 'post-collection' ); ?></a>
 				<?php endif; ?>
 			</nav>
 		<?php endif; ?>

--- a/templates/app/collection.php
+++ b/templates/app/collection.php
@@ -55,7 +55,7 @@ if ( '' !== $active_tag ) {
 	<title><?php echo wp_app_title( $user->display_name ); ?></title>
 	<?php wp_app_head(); ?>
 </head>
-<body <?php body_class( 'post-collection-app pc-mode-' . $mode . ' pc-view-' . $view . ( $quick_edit ? ' pc-quick-edit' : '' ) ); ?>>
+<body <?php body_class( 'wp-app-body post-collection-app pc-mode-' . $mode . ' pc-view-' . $view . ( $quick_edit ? ' pc-quick-edit' : '' ) ); ?>>
 	<?php wp_app_body_open(); ?>
 	<header class="pc-shell pc-collection-header">
 		<div class="pc-breadcrumb"><a href="<?php echo esc_url( $app->get_home_url() ); ?>"><?php esc_html_e( 'Collections', 'post-collection' ); ?></a></div>

--- a/templates/app/index.php
+++ b/templates/app/index.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Frontend app collection overview.
+ *
+ * @package Post_Collection
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$app = \PostCollection\Post_Collection_App::instance();
+if ( ! $app ) {
+	status_header( 500 );
+	return;
+}
+
+$collections = array_filter( $app->get_collections(), array( $app, 'can_view_collection' ) );
+?>
+<!DOCTYPE html>
+<html <?php echo wp_app_language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title><?php echo wp_app_title( __( 'Post Collection', 'post-collection' ) ); ?></title>
+	<?php wp_app_head(); ?>
+</head>
+<body <?php body_class( 'post-collection-app' ); ?>>
+	<?php wp_app_body_open(); ?>
+	<header class="pc-shell pc-app-header">
+		<div>
+			<p class="pc-kicker"><?php esc_html_e( 'Saved from the web', 'post-collection' ); ?></p>
+			<h1><?php esc_html_e( 'Post Collection', 'post-collection' ); ?></h1>
+		</div>
+		<?php if ( $app->can_manage_collections() ) : ?>
+			<a class="pc-button pc-button-primary" href="<?php echo esc_url( self_admin_url( 'admin.php?page=create-post-collection' ) ); ?>"><?php esc_html_e( 'New Collection', 'post-collection' ); ?></a>
+		<?php endif; ?>
+	</header>
+
+	<main class="pc-shell">
+		<?php if ( empty( $collections ) ) : ?>
+			<section class="pc-empty">
+				<h2><?php esc_html_e( 'No collections to show', 'post-collection' ); ?></h2>
+				<p><?php esc_html_e( 'Published collections will appear here.', 'post-collection' ); ?></p>
+			</section>
+		<?php else : ?>
+			<section class="pc-collection-grid" aria-label="<?php esc_attr_e( 'Collections', 'post-collection' ); ?>">
+				<?php foreach ( $collections as $collection_user ) : ?>
+					<?php
+					$count = $app->count_collection_posts( $collection_user );
+					$mode  = $app->get_collection_mode( $collection_user );
+					$posts = $app->query_collection_posts(
+						$collection_user,
+						array(
+							'posts_per_page'                => 3,
+							'post_collection_apply_filters' => false,
+							'no_found_rows'                 => true,
+						)
+					);
+					?>
+					<article class="pc-collection-card pc-collection-card-<?php echo esc_attr( $mode ); ?>">
+						<a class="pc-collection-card-main" href="<?php echo esc_url( $app->get_collection_url( $collection_user ) ); ?>">
+							<span class="pc-mode-label"><?php echo esc_html( 'bookmarks' === $mode ? __( 'Bookmarks', 'post-collection' ) : __( 'Posts', 'post-collection' ) ); ?></span>
+							<h2><?php echo esc_html( $collection_user->display_name ); ?></h2>
+							<?php if ( $collection_user->description ) : ?>
+								<p><?php echo esc_html( wp_trim_words( $collection_user->description, 18 ) ); ?></p>
+							<?php endif; ?>
+							<span class="pc-count">
+								<?php
+								echo esc_html(
+									sprintf(
+										// translators: %d is the number of posts.
+										_n( '%d item', '%d items', $count, 'post-collection' ),
+										$count
+									)
+								);
+								?>
+							</span>
+						</a>
+						<?php if ( $posts->have_posts() ) : ?>
+							<ul class="pc-mini-list">
+								<?php foreach ( $posts->posts as $post ) : ?>
+									<li>
+										<a href="<?php echo esc_url( $app->get_collection_url( $collection_user, $post->ID ) ); ?>"><?php echo esc_html( get_the_title( $post ) ); ?></a>
+									</li>
+								<?php endforeach; ?>
+							</ul>
+						<?php endif; ?>
+					</article>
+				<?php endforeach; ?>
+			</section>
+		<?php endif; ?>
+	</main>
+	<?php wp_app_body_close(); ?>
+</body>
+</html>

--- a/templates/app/index.php
+++ b/templates/app/index.php
@@ -23,7 +23,7 @@ $collections = array_filter( $app->get_collections(), array( $app, 'can_view_col
 	<title><?php echo wp_app_title( __( 'Post Collection', 'post-collection' ) ); ?></title>
 	<?php wp_app_head(); ?>
 </head>
-<body <?php body_class( 'post-collection-app' ); ?>>
+<body <?php body_class( 'wp-app-body post-collection-app' ); ?>>
 	<?php wp_app_body_open(); ?>
 	<header class="pc-shell pc-app-header">
 		<div>

--- a/templates/app/index.php
+++ b/templates/app/index.php
@@ -13,7 +13,67 @@ if ( ! $app ) {
 	return;
 }
 
-$collections = array_filter( $app->get_collections(), array( $app, 'can_view_collection' ) );
+$collections        = array_filter( $app->get_collections(), array( $app, 'can_view_collection' ) );
+$visible_collections = array();
+$hidden_collections  = array();
+
+foreach ( $collections as $collection ) {
+	if ( $app->is_collection_hidden_from_home( $collection ) ) {
+		$hidden_collections[] = $collection;
+	} else {
+		$visible_collections[] = $collection;
+	}
+}
+
+$render_collection_card = static function ( $collection ) use ( $app ) {
+	$count = $app->count_collection_posts( $collection );
+	$mode  = $app->get_collection_mode( $collection );
+	$posts = $app->query_collection_posts(
+		$collection,
+		array(
+			'posts_per_page'                => 3,
+			'post_collection_apply_filters' => false,
+			'no_found_rows'                 => true,
+		)
+	);
+	?>
+	<article class="pc-collection-card pc-collection-card-<?php echo esc_attr( $mode ); ?>">
+		<a class="pc-collection-card-main" href="<?php echo esc_url( $app->get_collection_url( $collection ) ); ?>">
+			<span class="pc-mode-label"><?php echo esc_html( 'bookmarks' === $mode ? __( 'Bookmarks', 'post-collection' ) : __( 'Posts', 'post-collection' ) ); ?></span>
+			<h2><?php echo esc_html( $collection->name ); ?></h2>
+			<?php if ( $collection->description ) : ?>
+				<p><?php echo esc_html( wp_trim_words( $collection->description, 18 ) ); ?></p>
+			<?php endif; ?>
+			<span class="pc-count">
+				<?php
+				echo esc_html(
+					sprintf(
+						'bookmarks' === $mode
+							// translators: %d is the number of saved links.
+							? _n( '%d saved link', '%d saved links', $count, 'post-collection' )
+							// translators: %d is the number of posts.
+							: _n( '%d post', '%d posts', $count, 'post-collection' ),
+						$count
+					)
+				);
+				?>
+			</span>
+		</a>
+		<?php if ( $posts->have_posts() ) : ?>
+			<div class="pc-mini-list-wrap">
+				<p class="pc-mini-list-title"><?php echo esc_html( 'bookmarks' === $mode ? __( 'Recent saved links', 'post-collection' ) : __( 'Recent posts', 'post-collection' ) ); ?></p>
+				<ul class="pc-mini-list">
+					<?php foreach ( $posts->posts as $post ) : ?>
+						<li>
+							<a href="<?php echo esc_url( $app->get_collection_url( $collection, $post->ID ) ); ?>"><?php echo esc_html( get_the_title( $post ) ); ?></a>
+						</li>
+					<?php endforeach; ?>
+				</ul>
+			</div>
+		<?php endif; ?>
+	</article>
+	<?php
+};
 ?>
 <!DOCTYPE html>
 <html <?php echo wp_app_language_attributes(); ?>>
@@ -42,51 +102,38 @@ $collections = array_filter( $app->get_collections(), array( $app, 'can_view_col
 				<p><?php esc_html_e( 'Published collections will appear here.', 'post-collection' ); ?></p>
 			</section>
 		<?php else : ?>
-			<section class="pc-collection-grid" aria-label="<?php esc_attr_e( 'Collections', 'post-collection' ); ?>">
-				<?php foreach ( $collections as $collection ) : ?>
-					<?php
-					$count = $app->count_collection_posts( $collection );
-					$mode  = $app->get_collection_mode( $collection );
-					$posts = $app->query_collection_posts(
-						$collection,
-						array(
-							'posts_per_page'                => 3,
-							'post_collection_apply_filters' => false,
-							'no_found_rows'                 => true,
-						)
-					);
-					?>
-					<article class="pc-collection-card pc-collection-card-<?php echo esc_attr( $mode ); ?>">
-						<a class="pc-collection-card-main" href="<?php echo esc_url( $app->get_collection_url( $collection ) ); ?>">
-							<span class="pc-mode-label"><?php echo esc_html( 'bookmarks' === $mode ? __( 'Bookmarks', 'post-collection' ) : __( 'Posts', 'post-collection' ) ); ?></span>
-							<h2><?php echo esc_html( $collection->name ); ?></h2>
-							<?php if ( $collection->description ) : ?>
-								<p><?php echo esc_html( wp_trim_words( $collection->description, 18 ) ); ?></p>
-							<?php endif; ?>
-							<span class="pc-count">
-								<?php
-								echo esc_html(
-									sprintf(
-										// translators: %d is the number of posts.
-										_n( '%d item', '%d items', $count, 'post-collection' ),
-										$count
-									)
-								);
-								?>
-							</span>
-						</a>
-						<?php if ( $posts->have_posts() ) : ?>
-							<ul class="pc-mini-list">
-								<?php foreach ( $posts->posts as $post ) : ?>
-									<li>
-										<a href="<?php echo esc_url( $app->get_collection_url( $collection, $post->ID ) ); ?>"><?php echo esc_html( get_the_title( $post ) ); ?></a>
-									</li>
-								<?php endforeach; ?>
-							</ul>
-						<?php endif; ?>
-					</article>
-				<?php endforeach; ?>
-			</section>
+			<?php if ( ! empty( $visible_collections ) ) : ?>
+				<section class="pc-collection-grid" aria-label="<?php esc_attr_e( 'Collections', 'post-collection' ); ?>">
+					<?php foreach ( $visible_collections as $collection ) : ?>
+						<?php $render_collection_card( $collection ); ?>
+					<?php endforeach; ?>
+				</section>
+			<?php endif; ?>
+
+			<?php if ( empty( $visible_collections ) && ! empty( $hidden_collections ) ) : ?>
+				<p class="pc-muted-note"><?php esc_html_e( 'All collections are hidden from the default view.', 'post-collection' ); ?></p>
+			<?php endif; ?>
+
+			<?php if ( ! empty( $hidden_collections ) ) : ?>
+				<details class="pc-hidden-collections">
+					<summary>
+						<?php
+						echo esc_html(
+							sprintf(
+								// translators: %d is the number of hidden collections.
+								_n( '%d hidden collection', '%d hidden collections', count( $hidden_collections ), 'post-collection' ),
+								count( $hidden_collections )
+							)
+						);
+						?>
+					</summary>
+					<section class="pc-collection-grid pc-collection-grid-hidden" aria-label="<?php esc_attr_e( 'Hidden collections', 'post-collection' ); ?>">
+						<?php foreach ( $hidden_collections as $collection ) : ?>
+							<?php $render_collection_card( $collection ); ?>
+						<?php endforeach; ?>
+					</section>
+				</details>
+			<?php endif; ?>
 		<?php endif; ?>
 	</main>
 	<?php wp_app_body_close(); ?>

--- a/templates/app/index.php
+++ b/templates/app/index.php
@@ -31,7 +31,7 @@ $collections = array_filter( $app->get_collections(), array( $app, 'can_view_col
 			<h1><?php esc_html_e( 'Post Collection', 'post-collection' ); ?></h1>
 		</div>
 		<?php if ( $app->can_manage_collections() ) : ?>
-			<a class="pc-button pc-button-primary" href="<?php echo esc_url( self_admin_url( 'admin.php?page=create-post-collection' ) ); ?>"><?php esc_html_e( 'New Collection', 'post-collection' ); ?></a>
+			<a class="pc-button pc-button-primary" href="<?php echo esc_url( $app->get_new_collection_url() ); ?>"><?php esc_html_e( 'New Collection', 'post-collection' ); ?></a>
 		<?php endif; ?>
 	</header>
 
@@ -43,12 +43,12 @@ $collections = array_filter( $app->get_collections(), array( $app, 'can_view_col
 			</section>
 		<?php else : ?>
 			<section class="pc-collection-grid" aria-label="<?php esc_attr_e( 'Collections', 'post-collection' ); ?>">
-				<?php foreach ( $collections as $collection_user ) : ?>
+				<?php foreach ( $collections as $collection ) : ?>
 					<?php
-					$count = $app->count_collection_posts( $collection_user );
-					$mode  = $app->get_collection_mode( $collection_user );
+					$count = $app->count_collection_posts( $collection );
+					$mode  = $app->get_collection_mode( $collection );
 					$posts = $app->query_collection_posts(
-						$collection_user,
+						$collection,
 						array(
 							'posts_per_page'                => 3,
 							'post_collection_apply_filters' => false,
@@ -57,11 +57,11 @@ $collections = array_filter( $app->get_collections(), array( $app, 'can_view_col
 					);
 					?>
 					<article class="pc-collection-card pc-collection-card-<?php echo esc_attr( $mode ); ?>">
-						<a class="pc-collection-card-main" href="<?php echo esc_url( $app->get_collection_url( $collection_user ) ); ?>">
+						<a class="pc-collection-card-main" href="<?php echo esc_url( $app->get_collection_url( $collection ) ); ?>">
 							<span class="pc-mode-label"><?php echo esc_html( 'bookmarks' === $mode ? __( 'Bookmarks', 'post-collection' ) : __( 'Posts', 'post-collection' ) ); ?></span>
-							<h2><?php echo esc_html( $collection_user->display_name ); ?></h2>
-							<?php if ( $collection_user->description ) : ?>
-								<p><?php echo esc_html( wp_trim_words( $collection_user->description, 18 ) ); ?></p>
+							<h2><?php echo esc_html( $collection->name ); ?></h2>
+							<?php if ( $collection->description ) : ?>
+								<p><?php echo esc_html( wp_trim_words( $collection->description, 18 ) ); ?></p>
 							<?php endif; ?>
 							<span class="pc-count">
 								<?php
@@ -79,7 +79,7 @@ $collections = array_filter( $app->get_collections(), array( $app, 'can_view_col
 							<ul class="pc-mini-list">
 								<?php foreach ( $posts->posts as $post ) : ?>
 									<li>
-										<a href="<?php echo esc_url( $app->get_collection_url( $collection_user, $post->ID ) ); ?>"><?php echo esc_html( get_the_title( $post ) ); ?></a>
+										<a href="<?php echo esc_url( $app->get_collection_url( $collection, $post->ID ) ); ?>"><?php echo esc_html( get_the_title( $post ) ); ?></a>
 									</li>
 								<?php endforeach; ?>
 							</ul>

--- a/templates/app/new.php
+++ b/templates/app/new.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Frontend app collection creation.
+ *
+ * @package Post_Collection
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$app = \PostCollection\Post_Collection_App::instance();
+if ( ! $app ) {
+	status_header( 500 );
+	return;
+}
+
+if ( ! $app->can_manage_collections() ) {
+	status_header( 403 );
+	include __DIR__ . '/403.php';
+	return;
+}
+?>
+<!DOCTYPE html>
+<html <?php echo wp_app_language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title><?php echo wp_app_title( __( 'New Collection', 'post-collection' ) ); ?></title>
+	<?php wp_app_head(); ?>
+</head>
+<body <?php body_class( 'wp-app-body post-collection-app' ); ?>>
+	<?php wp_app_body_open(); ?>
+	<header class="pc-shell pc-detail-header">
+		<div class="pc-breadcrumb"><a href="<?php echo esc_url( $app->get_home_url() ); ?>"><?php esc_html_e( 'Collections', 'post-collection' ); ?></a></div>
+		<p class="pc-kicker"><?php esc_html_e( 'New collection', 'post-collection' ); ?></p>
+		<h1><?php esc_html_e( 'Create Collection', 'post-collection' ); ?></h1>
+	</header>
+
+	<main class="pc-shell">
+		<form class="pc-create-collection-form" method="post" action="<?php echo esc_url( $app->get_new_collection_url() ); ?>">
+			<input type="hidden" name="post_collection_action" value="create-collection">
+			<?php wp_nonce_field( 'post-collection-create' ); ?>
+			<label>
+				<span><?php esc_html_e( 'Display name', 'post-collection' ); ?></span>
+				<input type="text" name="display_name" required>
+			</label>
+			<label>
+				<span><?php esc_html_e( 'Slug', 'post-collection' ); ?></span>
+				<input type="text" name="user_login">
+			</label>
+			<label>
+				<span><?php esc_html_e( 'Type', 'post-collection' ); ?></span>
+				<select name="frontend_mode">
+					<option value="auto"><?php esc_html_e( 'Auto', 'post-collection' ); ?></option>
+					<option value="bookmarks"><?php esc_html_e( 'Bookmarks', 'post-collection' ); ?></option>
+					<option value="posts"><?php esc_html_e( 'Posts', 'post-collection' ); ?></option>
+				</select>
+			</label>
+			<label>
+				<span><?php esc_html_e( 'Default layout', 'post-collection' ); ?></span>
+				<select name="frontend_view">
+					<option value="auto"><?php esc_html_e( 'Auto', 'post-collection' ); ?></option>
+					<option value="board"><?php esc_html_e( 'Board', 'post-collection' ); ?></option>
+					<option value="links"><?php esc_html_e( 'Compact links', 'post-collection' ); ?></option>
+					<option value="reader"><?php esc_html_e( 'Reader list', 'post-collection' ); ?></option>
+				</select>
+			</label>
+			<div class="pc-form-actions">
+				<a class="pc-button" href="<?php echo esc_url( $app->get_home_url() ); ?>"><?php esc_html_e( 'Cancel', 'post-collection' ); ?></a>
+				<button type="submit"><?php esc_html_e( 'Create Collection', 'post-collection' ); ?></button>
+			</div>
+		</form>
+	</main>
+	<?php wp_app_body_close(); ?>
+</body>
+</html>

--- a/templates/app/new.php
+++ b/templates/app/new.php
@@ -27,7 +27,7 @@ if ( ! $app->can_manage_collections() ) {
 	<title><?php echo wp_app_title( __( 'New Collection', 'post-collection' ) ); ?></title>
 	<?php wp_app_head(); ?>
 </head>
-<body <?php body_class( 'wp-app-body post-collection-app' ); ?>>
+<body <?php body_class( 'wp-app-body post-collection-app pc-new-collection-page' ); ?>>
 	<?php wp_app_body_open(); ?>
 	<header class="pc-shell pc-detail-header">
 		<div class="pc-breadcrumb"><a href="<?php echo esc_url( $app->get_home_url() ); ?>"><?php esc_html_e( 'Collections', 'post-collection' ); ?></a></div>
@@ -50,19 +50,21 @@ if ( ! $app->can_manage_collections() ) {
 			<label>
 				<span><?php esc_html_e( 'Type', 'post-collection' ); ?></span>
 				<select name="frontend_mode">
-					<option value="auto"><?php esc_html_e( 'Auto', 'post-collection' ); ?></option>
-					<option value="bookmarks"><?php esc_html_e( 'Bookmarks', 'post-collection' ); ?></option>
 					<option value="posts"><?php esc_html_e( 'Posts', 'post-collection' ); ?></option>
+					<option value="bookmarks"><?php esc_html_e( 'Bookmarks', 'post-collection' ); ?></option>
 				</select>
 			</label>
 			<label>
 				<span><?php esc_html_e( 'Default layout', 'post-collection' ); ?></span>
 				<select name="frontend_view">
-					<option value="auto"><?php esc_html_e( 'Auto', 'post-collection' ); ?></option>
+					<option value="reader"><?php esc_html_e( 'Reader list', 'post-collection' ); ?></option>
 					<option value="board"><?php esc_html_e( 'Board', 'post-collection' ); ?></option>
 					<option value="links"><?php esc_html_e( 'Compact links', 'post-collection' ); ?></option>
-					<option value="reader"><?php esc_html_e( 'Reader list', 'post-collection' ); ?></option>
 				</select>
+			</label>
+			<label class="pc-checkbox-field">
+				<input type="checkbox" name="hide_from_home" value="1">
+				<span><?php esc_html_e( 'Hide from the default collections view', 'post-collection' ); ?></span>
 			</label>
 			<div class="pc-form-actions">
 				<a class="pc-button" href="<?php echo esc_url( $app->get_home_url() ); ?>"><?php esc_html_e( 'Cancel', 'post-collection' ); ?></a>

--- a/templates/app/post.php
+++ b/templates/app/post.php
@@ -29,6 +29,7 @@ $source_url = $app->get_source_url( $post );
 $host       = $app->get_source_host( $post );
 $embed_html = $app->get_post_description_embed_html( $post, 'detail' );
 $terms      = $app->get_post_terms( $post );
+$back_label = 'bookmarks' === $mode ? __( 'Back to Bookmarks', 'post-collection' ) : __( 'Back to Collection', 'post-collection' );
 ?>
 <!DOCTYPE html>
 <html <?php echo wp_app_language_attributes(); ?>>
@@ -38,7 +39,7 @@ $terms      = $app->get_post_terms( $post );
 	<title><?php echo wp_app_title( get_the_title( $post ) ); ?></title>
 	<?php wp_app_head(); ?>
 </head>
-<body <?php body_class( 'wp-app-body post-collection-app pc-mode-' . $mode ); ?>>
+<body <?php body_class( 'wp-app-body post-collection-app pc-post-detail-page pc-mode-' . $mode ); ?>>
 	<?php wp_app_body_open(); ?>
 	<header class="pc-shell pc-detail-header">
 		<div class="pc-breadcrumb">
@@ -59,7 +60,7 @@ $terms      = $app->get_post_terms( $post );
 		</div>
 		<div class="pc-detail-actions">
 			<a class="pc-button pc-button-primary" href="<?php echo esc_url( $source_url ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Open Original', 'post-collection' ); ?></a>
-			<a class="pc-button" href="<?php echo esc_url( $app->get_collection_url( $collection ) ); ?>"><?php esc_html_e( 'Back to Collection', 'post-collection' ); ?></a>
+			<a class="pc-button" href="<?php echo esc_url( $app->get_collection_url( $collection ) ); ?>"><?php echo esc_html( $back_label ); ?></a>
 		</div>
 		<?php if ( ! empty( $terms ) ) : ?>
 			<nav class="pc-tag-strip pc-detail-tags" aria-label="<?php esc_attr_e( 'Tags', 'post-collection' ); ?>">
@@ -79,6 +80,9 @@ $terms      = $app->get_post_terms( $post );
 				<?php echo apply_filters( 'the_content', $post->post_content ); ?>
 			<?php endif; ?>
 		</article>
+		<nav class="pc-detail-footer-actions" aria-label="<?php esc_attr_e( 'Post navigation', 'post-collection' ); ?>">
+			<a class="pc-button" href="<?php echo esc_url( $app->get_collection_url( $collection ) ); ?>"><?php echo esc_html( $back_label ); ?></a>
+		</nav>
 	</main>
 	<?php wp_app_body_close(); ?>
 </body>

--- a/templates/app/post.php
+++ b/templates/app/post.php
@@ -13,18 +13,18 @@ if ( ! $app ) {
 	return;
 }
 
-$username = wp_app_get_route_var( 'username' );
+$username = wp_app_get_route_var( 'collection' );
 $post_id  = absint( wp_app_get_route_var( 'post_id' ) );
-$user     = $app->get_collection_by_username( $username );
-$post     = $user ? $app->get_visible_post( $post_id, $user ) : null;
+$collection = $app->get_collection_by_username( $username );
+$post       = $collection ? $app->get_visible_post( $post_id, $collection ) : null;
 
-if ( ! $user || ! $post || ! $app->can_view_collection( $user ) ) {
+if ( ! $collection || ! $post || ! $app->can_view_collection( $collection ) ) {
 	status_header( 404 );
 	include __DIR__ . '/404.php';
 	return;
 }
 
-$mode       = $app->get_collection_mode( $user );
+$mode       = $app->get_collection_mode( $collection );
 $source_url = $app->get_source_url( $post );
 $host       = $app->get_source_host( $post );
 $embed_html = $app->get_post_description_embed_html( $post, 'detail' );
@@ -44,7 +44,7 @@ $terms      = $app->get_post_terms( $post );
 		<div class="pc-breadcrumb">
 			<a href="<?php echo esc_url( $app->get_home_url() ); ?>"><?php esc_html_e( 'Collections', 'post-collection' ); ?></a>
 			<span>/</span>
-			<a href="<?php echo esc_url( $app->get_collection_url( $user ) ); ?>"><?php echo esc_html( $user->display_name ); ?></a>
+			<a href="<?php echo esc_url( $app->get_collection_url( $collection ) ); ?>"><?php echo esc_html( $collection->name ); ?></a>
 		</div>
 		<p class="pc-source"><?php echo esc_html( $host ); ?></p>
 		<h1><?php echo esc_html( get_the_title( $post ) ); ?></h1>
@@ -59,12 +59,12 @@ $terms      = $app->get_post_terms( $post );
 		</div>
 		<div class="pc-detail-actions">
 			<a class="pc-button pc-button-primary" href="<?php echo esc_url( $source_url ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Open Original', 'post-collection' ); ?></a>
-			<a class="pc-button" href="<?php echo esc_url( $app->get_collection_url( $user ) ); ?>"><?php esc_html_e( 'Back to Collection', 'post-collection' ); ?></a>
+			<a class="pc-button" href="<?php echo esc_url( $app->get_collection_url( $collection ) ); ?>"><?php esc_html_e( 'Back to Collection', 'post-collection' ); ?></a>
 		</div>
 		<?php if ( ! empty( $terms ) ) : ?>
 			<nav class="pc-tag-strip pc-detail-tags" aria-label="<?php esc_attr_e( 'Tags', 'post-collection' ); ?>">
 				<?php foreach ( $terms as $term ) : ?>
-					<a href="<?php echo esc_url( add_query_arg( 'pc-tag', $term->slug, $app->get_collection_url( $user ) ) ); ?>"><?php echo esc_html( $term->name ); ?></a>
+					<a href="<?php echo esc_url( add_query_arg( 'pc-tag', $term->slug, $app->get_collection_url( $collection ) ) ); ?>"><?php echo esc_html( $term->name ); ?></a>
 				<?php endforeach; ?>
 			</nav>
 		<?php endif; ?>

--- a/templates/app/post.php
+++ b/templates/app/post.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Frontend app post detail view.
+ *
+ * @package Post_Collection
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$app = \PostCollection\Post_Collection_App::instance();
+if ( ! $app ) {
+	status_header( 500 );
+	return;
+}
+
+$username = wp_app_get_route_var( 'username' );
+$post_id  = absint( wp_app_get_route_var( 'post_id' ) );
+$user     = $app->get_collection_by_username( $username );
+$post     = $user ? $app->get_visible_post( $post_id, $user ) : null;
+
+if ( ! $user || ! $post || ! $app->can_view_collection( $user ) ) {
+	status_header( 404 );
+	include __DIR__ . '/404.php';
+	return;
+}
+
+$mode       = $app->get_collection_mode( $user );
+$source_url = $app->get_source_url( $post );
+$host       = $app->get_source_host( $post );
+$terms      = $app->get_post_terms( $post );
+?>
+<!DOCTYPE html>
+<html <?php echo wp_app_language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title><?php echo wp_app_title( get_the_title( $post ) ); ?></title>
+	<?php wp_app_head(); ?>
+</head>
+<body <?php body_class( 'post-collection-app pc-mode-' . $mode ); ?>>
+	<?php wp_app_body_open(); ?>
+	<header class="pc-shell pc-detail-header">
+		<div class="pc-breadcrumb">
+			<a href="<?php echo esc_url( $app->get_home_url() ); ?>"><?php esc_html_e( 'Collections', 'post-collection' ); ?></a>
+			<span>/</span>
+			<a href="<?php echo esc_url( $app->get_collection_url( $user ) ); ?>"><?php echo esc_html( $user->display_name ); ?></a>
+		</div>
+		<p class="pc-source"><?php echo esc_html( $host ); ?></p>
+		<h1><?php echo esc_html( get_the_title( $post ) ); ?></h1>
+		<div class="pc-detail-meta">
+			<time datetime="<?php echo esc_attr( get_the_date( DATE_W3C, $post ) ); ?>"><?php echo esc_html( get_the_date( '', $post ) ); ?></time>
+			<?php if ( 'private' === $post->post_status && $app->can_manage_collections() ) : ?>
+				<span><?php esc_html_e( 'Private', 'post-collection' ); ?></span>
+			<?php endif; ?>
+			<?php if ( $app->can_manage_collections() ) : ?>
+				<a href="<?php echo esc_url( get_edit_post_link( $post->ID ) ); ?>"><?php esc_html_e( 'Edit', 'post-collection' ); ?></a>
+			<?php endif; ?>
+		</div>
+		<div class="pc-detail-actions">
+			<a class="pc-button pc-button-primary" href="<?php echo esc_url( $source_url ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Open Original', 'post-collection' ); ?></a>
+			<a class="pc-button" href="<?php echo esc_url( $app->get_collection_url( $user ) ); ?>"><?php esc_html_e( 'Back to Collection', 'post-collection' ); ?></a>
+		</div>
+		<?php if ( ! empty( $terms ) ) : ?>
+			<nav class="pc-tag-strip pc-detail-tags" aria-label="<?php esc_attr_e( 'Tags', 'post-collection' ); ?>">
+				<?php foreach ( $terms as $term ) : ?>
+					<a href="<?php echo esc_url( add_query_arg( 'pc-tag', $term->slug, $app->get_collection_url( $user ) ) ); ?>"><?php echo esc_html( $term->name ); ?></a>
+				<?php endforeach; ?>
+			</nav>
+		<?php endif; ?>
+	</header>
+
+	<main class="pc-shell pc-detail-layout">
+		<article class="pc-detail-content">
+			<?php echo apply_filters( 'the_content', $post->post_content ); ?>
+		</article>
+	</main>
+	<?php wp_app_body_close(); ?>
+</body>
+</html>

--- a/templates/app/post.php
+++ b/templates/app/post.php
@@ -27,6 +27,7 @@ if ( ! $user || ! $post || ! $app->can_view_collection( $user ) ) {
 $mode       = $app->get_collection_mode( $user );
 $source_url = $app->get_source_url( $post );
 $host       = $app->get_source_host( $post );
+$embed_html = $app->get_post_description_embed_html( $post, 'detail' );
 $terms      = $app->get_post_terms( $post );
 ?>
 <!DOCTYPE html>
@@ -71,7 +72,12 @@ $terms      = $app->get_post_terms( $post );
 
 	<main class="pc-shell pc-detail-layout">
 		<article class="pc-detail-content">
-			<?php echo apply_filters( 'the_content', $post->post_content ); ?>
+			<?php if ( $embed_html ) : ?>
+				<?php echo $embed_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			<?php endif; ?>
+			<?php if ( '' !== trim( $post->post_content ) ) : ?>
+				<?php echo apply_filters( 'the_content', $post->post_content ); ?>
+			<?php endif; ?>
 		</article>
 	</main>
 	<?php wp_app_body_close(); ?>

--- a/templates/app/post.php
+++ b/templates/app/post.php
@@ -38,7 +38,7 @@ $terms      = $app->get_post_terms( $post );
 	<title><?php echo wp_app_title( get_the_title( $post ) ); ?></title>
 	<?php wp_app_head(); ?>
 </head>
-<body <?php body_class( 'post-collection-app pc-mode-' . $mode ); ?>>
+<body <?php body_class( 'wp-app-body post-collection-app pc-mode-' . $mode ); ?>>
 	<?php wp_app_body_open(); ?>
 	<header class="pc-shell pc-detail-header">
 		<div class="pc-breadcrumb">

--- a/templates/app/settings.php
+++ b/templates/app/settings.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Frontend app collection settings.
+ *
+ * @package Post_Collection
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$app = \PostCollection\Post_Collection_App::instance();
+if ( ! $app ) {
+	status_header( 500 );
+	return;
+}
+
+$collection_slug = wp_app_get_route_var( 'collection' );
+$collection      = $app->get_collection_by_username( $collection_slug );
+if ( ! $collection || ! $app->can_manage_collections() ) {
+	status_header( 404 );
+	include __DIR__ . '/404.php';
+	return;
+}
+
+$configured_mode = get_term_meta( $collection->term_id, 'post_collection_frontend_mode', true );
+$configured_view = get_term_meta( $collection->term_id, 'post_collection_frontend_view', true );
+?>
+<!DOCTYPE html>
+<html <?php echo wp_app_language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title><?php echo wp_app_title( sprintf( __( '%s Settings', 'post-collection' ), $collection->name ) ); ?></title>
+	<?php wp_app_head(); ?>
+</head>
+<body <?php body_class( 'wp-app-body post-collection-app' ); ?>>
+	<?php wp_app_body_open(); ?>
+	<header class="pc-shell pc-detail-header">
+		<div class="pc-breadcrumb">
+			<a href="<?php echo esc_url( $app->get_home_url() ); ?>"><?php esc_html_e( 'Collections', 'post-collection' ); ?></a>
+			<span>/</span>
+			<a href="<?php echo esc_url( $app->get_collection_url( $collection ) ); ?>"><?php echo esc_html( $collection->name ); ?></a>
+		</div>
+		<p class="pc-kicker"><?php esc_html_e( 'Collection settings', 'post-collection' ); ?></p>
+		<h1><?php echo esc_html( $collection->name ); ?></h1>
+	</header>
+
+	<main class="pc-shell">
+		<form class="pc-collection-settings pc-settings-page-form" method="post" action="<?php echo esc_url( $app->get_collection_settings_url( $collection ) ); ?>">
+			<input type="hidden" name="post_collection_action" value="collection-settings">
+			<input type="hidden" name="collection_term_id" value="<?php echo esc_attr( $collection->term_id ); ?>">
+			<?php wp_nonce_field( 'post-collection-settings-' . $collection->term_id ); ?>
+			<label>
+				<span><?php esc_html_e( 'Type', 'post-collection' ); ?></span>
+				<select name="frontend_mode">
+					<option value="auto"<?php selected( ! $configured_mode ); ?>><?php esc_html_e( 'Auto', 'post-collection' ); ?></option>
+					<option value="bookmarks"<?php selected( 'bookmarks', $configured_mode ); ?>><?php esc_html_e( 'Bookmarks', 'post-collection' ); ?></option>
+					<option value="posts"<?php selected( 'posts', $configured_mode ); ?>><?php esc_html_e( 'Posts', 'post-collection' ); ?></option>
+				</select>
+			</label>
+			<label>
+				<span><?php esc_html_e( 'Default layout', 'post-collection' ); ?></span>
+				<select name="frontend_view">
+					<option value="auto"<?php selected( ! $configured_view ); ?>><?php esc_html_e( 'Auto', 'post-collection' ); ?></option>
+					<option value="board"<?php selected( 'board', $configured_view ); ?>><?php esc_html_e( 'Board', 'post-collection' ); ?></option>
+					<option value="links"<?php selected( 'links', $configured_view ); ?>><?php esc_html_e( 'Compact links', 'post-collection' ); ?></option>
+					<option value="reader"<?php selected( 'reader', $configured_view ); ?>><?php esc_html_e( 'Reader list', 'post-collection' ); ?></option>
+				</select>
+			</label>
+			<div class="pc-form-actions">
+				<a class="pc-button" href="<?php echo esc_url( $app->get_collection_url( $collection ) ); ?>"><?php esc_html_e( 'Back to collection', 'post-collection' ); ?></a>
+				<button type="submit"><?php esc_html_e( 'Save settings', 'post-collection' ); ?></button>
+			</div>
+		</form>
+	</main>
+	<?php wp_app_body_close(); ?>
+</body>
+</html>

--- a/templates/app/settings.php
+++ b/templates/app/settings.php
@@ -23,6 +23,7 @@ if ( ! $collection || ! $app->can_manage_collections() ) {
 
 $configured_mode = get_term_meta( $collection->term_id, 'post_collection_frontend_mode', true );
 $configured_view = get_term_meta( $collection->term_id, 'post_collection_frontend_view', true );
+$hide_from_home  = get_term_meta( $collection->term_id, 'post_collection_hide_from_home', true );
 ?>
 <!DOCTYPE html>
 <html <?php echo wp_app_language_attributes(); ?>>
@@ -32,7 +33,7 @@ $configured_view = get_term_meta( $collection->term_id, 'post_collection_fronten
 	<title><?php echo wp_app_title( sprintf( __( '%s Settings', 'post-collection' ), $collection->name ) ); ?></title>
 	<?php wp_app_head(); ?>
 </head>
-<body <?php body_class( 'wp-app-body post-collection-app' ); ?>>
+<body <?php body_class( 'wp-app-body post-collection-app pc-settings-page' ); ?>>
 	<?php wp_app_body_open(); ?>
 	<header class="pc-shell pc-detail-header">
 		<div class="pc-breadcrumb">
@@ -52,19 +53,21 @@ $configured_view = get_term_meta( $collection->term_id, 'post_collection_fronten
 			<label>
 				<span><?php esc_html_e( 'Type', 'post-collection' ); ?></span>
 				<select name="frontend_mode">
-					<option value="auto"<?php selected( ! $configured_mode ); ?>><?php esc_html_e( 'Auto', 'post-collection' ); ?></option>
+					<option value="posts"<?php selected( 'posts', $configured_mode ?: 'posts' ); ?>><?php esc_html_e( 'Posts', 'post-collection' ); ?></option>
 					<option value="bookmarks"<?php selected( 'bookmarks', $configured_mode ); ?>><?php esc_html_e( 'Bookmarks', 'post-collection' ); ?></option>
-					<option value="posts"<?php selected( 'posts', $configured_mode ); ?>><?php esc_html_e( 'Posts', 'post-collection' ); ?></option>
 				</select>
 			</label>
 			<label>
 				<span><?php esc_html_e( 'Default layout', 'post-collection' ); ?></span>
 				<select name="frontend_view">
-					<option value="auto"<?php selected( ! $configured_view ); ?>><?php esc_html_e( 'Auto', 'post-collection' ); ?></option>
+					<option value="reader"<?php selected( 'reader', $configured_view ?: 'reader' ); ?>><?php esc_html_e( 'Reader list', 'post-collection' ); ?></option>
 					<option value="board"<?php selected( 'board', $configured_view ); ?>><?php esc_html_e( 'Board', 'post-collection' ); ?></option>
 					<option value="links"<?php selected( 'links', $configured_view ); ?>><?php esc_html_e( 'Compact links', 'post-collection' ); ?></option>
-					<option value="reader"<?php selected( 'reader', $configured_view ); ?>><?php esc_html_e( 'Reader list', 'post-collection' ); ?></option>
 				</select>
+			</label>
+			<label class="pc-checkbox-field">
+				<input type="checkbox" name="hide_from_home" value="1" <?php checked( $hide_from_home ); ?>>
+				<span><?php esc_html_e( 'Hide from the default collections view', 'post-collection' ); ?></span>
 			</label>
 			<div class="pc-form-actions">
 				<a class="pc-button" href="<?php echo esc_url( $app->get_collection_url( $collection ) ); ?>"><?php esc_html_e( 'Back to collection', 'post-collection' ); ?></a>


### PR DESCRIPTION
## Summary
- add a wp-app-powered frontend at /post-collection/
- add collection overview, collection, detail, 403, and 404 app templates
- add board, compact links, and reader views with per-collection admin defaults
- make bookmark collections default to the compact Pinboard/Delicious-style links view
- route standalone collection/user URLs through the new frontend when Friends is absent

## Status
This is intentionally a draft. The frontend direction is in place, but design and interaction details are still expected to evolve.

## Testing
- php -l post-collection.php class-post-collection.php class-post-collection-app.php class-user.php
- php -l templates/app/index.php templates/app/collection.php templates/app/post.php templates/app/403.php templates/app/404.php templates/admin/edit-post-collection.php
- composer test
- composer validate --no-check-publish (passes with existing no-license warning)