### PR TITLE
Catch extractor throwables

### DIFF
--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -1369,6 +1369,16 @@ class Post_Collection {
 				),
 				$logger
 			);
+		} catch ( \Throwable $e ) {
+			return new \WP_Error(
+				'could-not-extract-content',
+				sprintf(
+				// translators: $s is an error message.
+					__( 'Error processing HTML: %s', 'post-collection' ),
+					$e->getMessage()
+				),
+				$logger
+			);
 		}
 
 		return $item;


### PR DESCRIPTION
## Summary
- catch non-ParseException throwables during Readability extraction
- return a WP_Error so Friends feed/action callbacks can recover instead of fataling

## Testing
- php -l class-post-collection.php
- git diff --check