### PR TITLE
Add Post Collection abilities

### DIFF
--- a/class-post-collection-abilities.php
+++ b/class-post-collection-abilities.php
@@ -1,0 +1,1252 @@
+<?php
+/**
+ * WordPress Ability API integration for Post Collection.
+ *
+ * @package Post_Collection
+ */
+
+namespace PostCollection;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers app-specific abilities for AI Assistant and other Ability API clients.
+ */
+class Post_Collection_Abilities {
+	const CATEGORY = 'post-collection';
+
+	/**
+	 * Main plugin instance.
+	 *
+	 * @var Post_Collection
+	 */
+	private $plugin;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Post_Collection $plugin The main plugin instance.
+	 */
+	public function __construct( Post_Collection $plugin ) {
+		$this->plugin = $plugin;
+
+		if ( function_exists( 'did_action' ) && did_action( 'wp_abilities_api_categories_init' ) ) {
+			$this->register_ability_category();
+		} else {
+			add_action( 'wp_abilities_api_categories_init', array( $this, 'register_ability_category' ) );
+		}
+
+		if ( function_exists( 'did_action' ) && did_action( 'wp_abilities_api_init' ) ) {
+			$this->register_abilities();
+		} else {
+			add_action( 'wp_abilities_api_init', array( $this, 'register_abilities' ) );
+		}
+
+		add_filter( 'ai_assistant_ability_domains', array( $this, 'ai_assistant_ability_domains' ) );
+		add_filter( 'ai_assistant_ability_instructions', array( $this, 'ai_assistant_ability_instructions' ), 10, 4 );
+	}
+
+	/**
+	 * Register domain terms so AI Assistant discovers these abilities for relevant requests.
+	 *
+	 * @param array $domains Existing ability domains.
+	 * @return array Updated ability domains.
+	 */
+	public function ai_assistant_ability_domains( $domains ) {
+		if ( ! is_array( $domains ) ) {
+			$domains = array();
+		}
+
+		$domains[ self::CATEGORY ] = 'post collection, collected posts, collect posts, save URL, save article, read later, bookmarks, article notes, reading notes, reading status, reviewed articles';
+
+		return $domains;
+	}
+
+	/**
+	 * Provide result-specific instructions after ability execution.
+	 *
+	 * @param string $instructions Current instructions.
+	 * @param string $ability_id   Ability ID.
+	 * @param array  $args         Ability arguments.
+	 * @param mixed  $result       Ability result.
+	 * @return string Instructions for AI Assistant.
+	 */
+	public function ai_assistant_ability_instructions( $instructions, $ability_id, $args, $result ) {
+		switch ( $ability_id ) {
+			case 'post-collection/list-articles':
+				return __( 'When presenting collected articles, include the article id, title, collection, reading status, rating, source_url, and view_url. Use post-collection/get-article when the user needs full content.', 'post-collection' );
+
+			case 'post-collection/save-url':
+				return __( 'Present the saved article title and include view_url. Mention whether the article was newly created or already existed in the target collection.', 'post-collection' );
+
+			case 'post-collection/update-note':
+				return __( 'Confirm the updated reading status, rating, and notes. Include the article title and view_url.', 'post-collection' );
+		}
+
+		return $instructions;
+	}
+
+	/**
+	 * Register the Post Collection ability category.
+	 */
+	public function register_ability_category() {
+		if ( ! function_exists( 'wp_register_ability_category' ) ) {
+			return;
+		}
+
+		if ( function_exists( 'wp_get_ability_category' ) && wp_get_ability_category( self::CATEGORY ) ) {
+			return;
+		}
+
+		wp_register_ability_category(
+			self::CATEGORY,
+			array(
+				'label'       => __( 'Post Collection', 'post-collection' ),
+				'description' => __( 'Read and manage post collections, collected articles, and article notes.', 'post-collection' ),
+			)
+		);
+	}
+
+	/**
+	 * Register Post Collection abilities.
+	 */
+	public function register_abilities() {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		$this->register_ability(
+			'post-collection/list-collections',
+			array(
+				'label'               => __( 'List Post Collections', 'post-collection' ),
+				'description'         => __( 'Lists post collection users with IDs, names, settings, post counts, and URLs.', 'post-collection' ),
+				'category'            => self::CATEGORY,
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'include_inactive' => array(
+							'type'        => 'boolean',
+							'description' => __( 'Whether to include collections hidden from the dropdown.', 'post-collection' ),
+							'default'     => false,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'collections' => array(
+							'type'  => 'array',
+							'items' => self::collection_schema(),
+						),
+						'total'       => array(
+							'type' => 'integer',
+						),
+					),
+				),
+				'execute_callback'    => array( $this, 'ability_list_collections' ),
+				'permission_callback' => array( $this, 'can_manage_post_collections' ),
+				'meta'                => self::ability_meta(
+					true,
+					false,
+					true,
+					__( 'Use this first when the user refers to a collection by name or asks what collections exist. Use collection id values with post-collection/save-url, post-collection/list-articles, or post-collection/update-collection.', 'post-collection' )
+				),
+			)
+		);
+
+		$this->register_ability(
+			'post-collection/create-collection',
+			array(
+				'label'               => __( 'Create Post Collection', 'post-collection' ),
+				'description'         => __( 'Creates a new post collection user and returns its settings and URLs.', 'post-collection' ),
+				'category'            => self::CATEGORY,
+				'input_schema'        => self::collection_write_input_schema( true ),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'collection' => self::collection_schema(),
+					),
+				),
+				'execute_callback'    => array( $this, 'ability_create_collection' ),
+				'permission_callback' => array( $this, 'can_manage_post_collections' ),
+				'meta'                => self::ability_meta(
+					false,
+					false,
+					false,
+					__( 'Use this when the user asks to add a new post collection. If user_login is omitted, it will be generated from display_name.', 'post-collection' )
+				),
+			)
+		);
+
+		$this->register_ability(
+			'post-collection/update-collection',
+			array(
+				'label'               => __( 'Update Post Collection', 'post-collection' ),
+				'description'         => __( 'Updates a post collection name, description, dropdown mode, or feed publishing setting.', 'post-collection' ),
+				'category'            => self::CATEGORY,
+				'input_schema'        => self::collection_write_input_schema( false ),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'collection' => self::collection_schema(),
+					),
+				),
+				'execute_callback'    => array( $this, 'ability_update_collection' ),
+				'permission_callback' => array( $this, 'can_manage_post_collections' ),
+				'meta'                => self::ability_meta(
+					false,
+					false,
+					true,
+					__( 'Use post-collection/list-collections first if you need a collection id. dropdown_mode accepts move, copy, or inactive.', 'post-collection' )
+				),
+			)
+		);
+
+		$this->register_ability(
+			'post-collection/save-url',
+			array(
+				'label'               => __( 'Save URL to Post Collection', 'post-collection' ),
+				'description'         => __( 'Downloads or extracts a URL and saves it as a collected article in the target post collection. Existing articles with the same URL and collection are reused.', 'post-collection' ),
+				'category'            => self::CATEGORY,
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'collection_id', 'url' ),
+					'properties'           => array(
+						'collection_id' => array(
+							'type'        => 'integer',
+							'description' => __( 'Collection user ID from post-collection/list-collections.', 'post-collection' ),
+						),
+						'url'           => array(
+							'type'        => 'string',
+							'description' => __( 'The article URL to collect.', 'post-collection' ),
+						),
+						'title'         => array(
+							'type'        => 'string',
+							'description' => __( 'Optional title override for the collected article.', 'post-collection' ),
+						),
+						'html'          => array(
+							'type'        => 'string',
+							'description' => __( 'Optional raw page HTML. When omitted, Post Collection downloads the URL.', 'post-collection' ),
+						),
+						'tags'          => array(
+							'type'        => 'array',
+							'description' => __( 'Optional tag names to assign to the collected article.', 'post-collection' ),
+							'items'       => array(
+								'type' => 'string',
+							),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'article' => self::article_schema(),
+						'created' => array(
+							'type'        => 'boolean',
+							'description' => __( 'Whether a new collected article was created.', 'post-collection' ),
+						),
+					),
+				),
+				'execute_callback'    => array( $this, 'ability_save_url' ),
+				'permission_callback' => array( $this, 'can_manage_post_collections' ),
+				'meta'                => self::ability_meta(
+					false,
+					false,
+					true,
+					__( 'Use post-collection/list-collections first when the target collection is ambiguous. This ability is idempotent by URL and collection.', 'post-collection' )
+				),
+			)
+		);
+
+		$this->register_ability(
+			'post-collection/list-articles',
+			array(
+				'label'               => __( 'List Collected Articles', 'post-collection' ),
+				'description'         => __( 'Lists collected articles with IDs, titles, source URLs, collection details, local URLs, and note summaries.', 'post-collection' ),
+				'category'            => self::CATEGORY,
+				'input_schema'        => self::article_list_input_schema(),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'articles' => array(
+							'type'  => 'array',
+							'items' => self::article_schema(),
+						),
+						'total'    => array(
+							'type' => 'integer',
+						),
+						'limit'    => array(
+							'type' => 'integer',
+						),
+						'offset'   => array(
+							'type' => 'integer',
+						),
+					),
+				),
+				'execute_callback'    => array( $this, 'ability_list_articles' ),
+				'permission_callback' => array( $this, 'can_manage_post_collections' ),
+				'meta'                => self::ability_meta(
+					true,
+					false,
+					true,
+					__( 'Use this for article lookup and filtering. Use post-collection/get-article for full article content.', 'post-collection' )
+				),
+			)
+		);
+
+		$this->register_ability(
+			'post-collection/get-article',
+			array(
+				'label'               => __( 'Get Collected Article', 'post-collection' ),
+				'description'         => __( 'Returns one collected article by ID, including source URL, local URL, full content, and note data.', 'post-collection' ),
+				'category'            => self::CATEGORY,
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'article_id' ),
+					'properties'           => array(
+						'article_id' => array(
+							'type'        => 'integer',
+							'description' => __( 'Collected article post ID from post-collection/list-articles or post-collection/save-url.', 'post-collection' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'article' => self::article_schema( true ),
+					),
+				),
+				'execute_callback'    => array( $this, 'ability_get_article' ),
+				'permission_callback' => array( $this, 'can_manage_post_collections' ),
+				'meta'                => self::ability_meta(
+					true,
+					false,
+					true,
+					__( 'Use this when the user asks for full article content or complete note details. Prefer source_url when citing the original source.', 'post-collection' )
+				),
+			)
+		);
+
+		$this->register_ability(
+			'post-collection/update-article-visibility',
+			array(
+				'label'               => __( 'Update Collected Article Visibility', 'post-collection' ),
+				'description'         => __( 'Sets a collected article to private or publish, controlling whether it appears in the public feed.', 'post-collection' ),
+				'category'            => self::CATEGORY,
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'article_id', 'post_status' ),
+					'properties'           => array(
+						'article_id'  => array(
+							'type'        => 'integer',
+							'description' => __( 'Collected article post ID.', 'post-collection' ),
+						),
+						'post_status' => array(
+							'type'        => 'string',
+							'enum'        => array( 'private', 'publish' ),
+							'description' => __( 'private hides the article from the feed; publish shows it in the feed.', 'post-collection' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'article' => self::article_schema(),
+					),
+				),
+				'execute_callback'    => array( $this, 'ability_update_article_visibility' ),
+				'permission_callback' => array( $this, 'can_manage_post_collections' ),
+				'meta'                => self::ability_meta(
+					false,
+					false,
+					true,
+					__( 'Use publish to show a collected article in the feed and private to hide it.', 'post-collection' )
+				),
+			)
+		);
+
+		$this->register_ability(
+			'post-collection/update-note',
+			array(
+				'label'               => __( 'Update Article Note', 'post-collection' ),
+				'description'         => __( 'Creates or updates the reading status, rating, and notes for a collected article.', 'post-collection' ),
+				'category'            => self::CATEGORY,
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'article_id' ),
+					'properties'           => array(
+						'article_id' => array(
+							'type'        => 'integer',
+							'description' => __( 'Collected article post ID.', 'post-collection' ),
+						),
+						'status'     => array(
+							'type'        => 'string',
+							'enum'        => Article_Notes::get_all_status_values(),
+							'description' => __( 'Reading status: unread, read, skipped, or archived.', 'post-collection' ),
+						),
+						'rating'     => array(
+							'type'        => 'integer',
+							'minimum'     => 0,
+							'maximum'     => 5,
+							'description' => __( 'Star rating from 0 to 5.', 'post-collection' ),
+						),
+						'notes'      => array(
+							'type'        => 'string',
+							'description' => __( 'Freeform reading notes. HTML allowed by wp_kses_post is preserved.', 'post-collection' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'article' => self::article_schema(),
+						'note'    => self::note_schema(),
+					),
+				),
+				'execute_callback'    => array( $this, 'ability_update_note' ),
+				'permission_callback' => array( $this, 'can_manage_post_collections' ),
+				'meta'                => self::ability_meta(
+					false,
+					false,
+					true,
+					__( 'Use this when the user asks to mark an article read, unread, skipped, archived, rate it, or add/update notes.', 'post-collection' )
+				),
+			)
+		);
+	}
+
+	/**
+	 * Check whether the current user can manage post collections.
+	 *
+	 * @param mixed $input Ability input.
+	 * @return bool Whether the user can manage post collections.
+	 */
+	public function can_manage_post_collections( $input = null ) {
+		return current_user_can( $this->plugin->get_required_role() );
+	}
+
+	/**
+	 * List post collections.
+	 *
+	 * @param array $input Ability input.
+	 * @return array Ability result.
+	 */
+	public function ability_list_collections( $input ) {
+		$input = is_array( $input ) ? $input : array();
+		$include_inactive = ! empty( $input['include_inactive'] );
+		$collections = array();
+
+		foreach ( $this->plugin->get_post_collection_users()->get_results() as $user ) {
+			if ( ! $include_inactive && get_user_option( 'friends_post_collection_inactive', $user->ID ) ) {
+				continue;
+			}
+
+			$collections[] = $this->prepare_collection_data( $user );
+		}
+
+		return array(
+			'collections' => $collections,
+			'total'       => count( $collections ),
+		);
+	}
+
+	/**
+	 * Create a post collection.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error Ability result or error.
+	 */
+	public function ability_create_collection( $input ) {
+		$input = is_array( $input ) ? $input : array();
+
+		$display_name = $this->sanitize_label( $input['display_name'] ?? '' );
+		if ( '' === $display_name ) {
+			return new \WP_Error( 'missing-display-name', __( 'A display name is required.', 'post-collection' ) );
+		}
+
+		$user_login = '';
+		if ( isset( $input['user_login'] ) ) {
+			$user_login = sanitize_user( $input['user_login'] );
+		}
+		if ( '' === $user_login ) {
+			$user_login = User::sanitize_username( $display_name );
+		}
+
+		if ( '' === $user_login ) {
+			return new \WP_Error( 'invalid-user-login', __( 'A valid username is required.', 'post-collection' ) );
+		}
+
+		if ( username_exists( $user_login ) ) {
+			return new \WP_Error( 'user-login-exists', __( 'That username is already registered.', 'post-collection' ) );
+		}
+
+		$userdata = array(
+			'user_login'   => $user_login,
+			'display_name' => $display_name,
+			'user_pass'    => wp_generate_password( 256 ),
+			'role'         => 'post_collection',
+		);
+
+		if ( isset( $input['description'] ) ) {
+			$userdata['description'] = sanitize_textarea_field( $input['description'] );
+		}
+
+		$user_id = wp_insert_user( $userdata );
+		if ( is_wp_error( $user_id ) ) {
+			return $user_id;
+		}
+
+		$user = User::get_user_by_id( $user_id );
+		if ( ! $user ) {
+			return new \WP_Error( 'collection-not-found', __( 'The collection was created but could not be loaded.', 'post-collection' ) );
+		}
+
+		$this->apply_collection_settings( $user, $input );
+
+		return array(
+			'collection' => $this->prepare_collection_data( $user ),
+		);
+	}
+
+	/**
+	 * Update a post collection.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error Ability result or error.
+	 */
+	public function ability_update_collection( $input ) {
+		$input = is_array( $input ) ? $input : array();
+		$user = $this->get_collection_user( $input['collection_id'] ?? 0 );
+		if ( is_wp_error( $user ) ) {
+			return $user;
+		}
+
+		$userdata = array(
+			'ID' => $user->ID,
+		);
+
+		if ( array_key_exists( 'display_name', $input ) ) {
+			$display_name = $this->sanitize_label( $input['display_name'] );
+			if ( '' === $display_name ) {
+				return new \WP_Error( 'invalid-display-name', __( 'A valid display name is required.', 'post-collection' ) );
+			}
+			$userdata['display_name'] = $display_name;
+		}
+
+		if ( array_key_exists( 'description', $input ) ) {
+			$userdata['description'] = sanitize_textarea_field( $input['description'] );
+		}
+
+		if ( count( $userdata ) > 1 ) {
+			$updated = wp_update_user( $userdata );
+			if ( is_wp_error( $updated ) ) {
+				return $updated;
+			}
+		}
+
+		$this->apply_collection_settings( $user, $input );
+		$user = User::get_user_by_id( $user->ID );
+
+		return array(
+			'collection' => $this->prepare_collection_data( $user ),
+		);
+	}
+
+	/**
+	 * Save a URL to a collection.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error Ability result or error.
+	 */
+	public function ability_save_url( $input ) {
+		$input = is_array( $input ) ? $input : array();
+		$user = $this->get_collection_user( $input['collection_id'] ?? 0 );
+		if ( is_wp_error( $user ) ) {
+			return $user;
+		}
+
+		if ( get_user_option( 'friends_post_collection_inactive', $user->ID ) ) {
+			return new \WP_Error( 'inactive-collection', __( 'This post collection is inactive.', 'post-collection' ) );
+		}
+
+		$url = isset( $input['url'] ) ? esc_url_raw( trim( (string) $input['url'] ) ) : '';
+		if ( ! $this->plugin->check_url( $url ) ) {
+			return new \WP_Error( 'invalid-url', __( 'You entered an invalid URL.', 'post-collection' ) );
+		}
+
+		$args = array();
+		if ( isset( $input['title'] ) ) {
+			$args['title'] = $this->sanitize_label( $input['title'] );
+		}
+		if ( isset( $input['tags'] ) && is_array( $input['tags'] ) ) {
+			$args['tags'] = $this->sanitize_tags( $input['tags'] );
+		}
+
+		$html = null;
+		if ( isset( $input['html'] ) && is_string( $input['html'] ) ) {
+			$html = (string) $input['html'];
+		}
+
+		$existing_post_id = $this->plugin->url_to_postid( $url, $user->ID );
+		$post_id = $this->plugin->save_url_for_collection( $url, $user, $html, $args );
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return new \WP_Error( 'article-not-found', __( 'The article was saved but could not be loaded.', 'post-collection' ) );
+		}
+
+		return array(
+			'article' => $this->prepare_article_data( $post ),
+			'created' => ! $existing_post_id,
+		);
+	}
+
+	/**
+	 * List collected articles.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error Ability result or error.
+	 */
+	public function ability_list_articles( $input ) {
+		$input = is_array( $input ) ? $input : array();
+		$limit = $this->clamp_int( $input['limit'] ?? 20, 1, 50 );
+		$offset = max( 0, (int) ( $input['offset'] ?? 0 ) );
+		$post_status = $input['post_status'] ?? 'any';
+		$note_status = $input['note_status'] ?? 'all';
+
+		$args = array(
+			'post_type'      => Post_Collection::CPT,
+			'post_status'    => 'any' === $post_status ? array( 'private', 'publish' ) : $post_status,
+			'posts_per_page' => $limit,
+			'offset'         => $offset,
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+		);
+
+		if ( ! empty( $input['collection_id'] ) ) {
+			$user = $this->get_collection_user( $input['collection_id'] );
+			if ( is_wp_error( $user ) ) {
+				return $user;
+			}
+			$args['author'] = $user->ID;
+		}
+
+		if ( ! empty( $input['search'] ) ) {
+			$args['s'] = sanitize_text_field( $input['search'] );
+		}
+
+		if ( 'none' === $note_status ) {
+			$args['meta_query'] = array(
+				array(
+					'key'     => Article_Notes::NOTE_ID_META,
+					'compare' => 'NOT EXISTS',
+				),
+			);
+		} elseif ( 'all' !== $note_status ) {
+			$article_ids = $this->get_article_ids_by_note_status( $note_status );
+			if ( empty( $article_ids ) ) {
+				return array(
+					'articles' => array(),
+					'total'    => 0,
+					'limit'    => $limit,
+					'offset'   => $offset,
+				);
+			}
+			$args['post__in'] = $article_ids;
+		}
+
+		$query = new \WP_Query( $args );
+		$articles = array();
+		foreach ( $query->posts as $post ) {
+			$articles[] = $this->prepare_article_data( $post );
+		}
+
+		return array(
+			'articles' => $articles,
+			'total'    => (int) $query->found_posts,
+			'limit'    => $limit,
+			'offset'   => $offset,
+		);
+	}
+
+	/**
+	 * Get a collected article.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error Ability result or error.
+	 */
+	public function ability_get_article( $input ) {
+		$input = is_array( $input ) ? $input : array();
+		$post = $this->get_collected_article( $input['article_id'] ?? 0 );
+		if ( is_wp_error( $post ) ) {
+			return $post;
+		}
+
+		return array(
+			'article' => $this->prepare_article_data( $post, true ),
+		);
+	}
+
+	/**
+	 * Update collected article visibility.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error Ability result or error.
+	 */
+	public function ability_update_article_visibility( $input ) {
+		$input = is_array( $input ) ? $input : array();
+		$post = $this->get_collected_article( $input['article_id'] ?? 0 );
+		if ( is_wp_error( $post ) ) {
+			return $post;
+		}
+
+		$post_status = $input['post_status'] ?? '';
+		if ( ! in_array( $post_status, array( 'private', 'publish' ), true ) ) {
+			return new \WP_Error( 'invalid-post-status', __( 'A valid post status is required.', 'post-collection' ) );
+		}
+
+		$updated = wp_update_post(
+			array(
+				'ID'          => $post->ID,
+				'post_status' => $post_status,
+			),
+			true
+		);
+		if ( is_wp_error( $updated ) ) {
+			return $updated;
+		}
+
+		$post = get_post( $post->ID );
+		if ( ! $post ) {
+			return new \WP_Error( 'article-not-found', __( 'The article was updated but could not be loaded.', 'post-collection' ) );
+		}
+
+		return array(
+			'article' => $this->prepare_article_data( $post ),
+		);
+	}
+
+	/**
+	 * Update an article note.
+	 *
+	 * @param array $input Ability input.
+	 * @return array|\WP_Error Ability result or error.
+	 */
+	public function ability_update_note( $input ) {
+		$input = is_array( $input ) ? $input : array();
+		$post = $this->get_collected_article( $input['article_id'] ?? 0 );
+		if ( is_wp_error( $post ) ) {
+			return $post;
+		}
+
+		if ( ! array_key_exists( 'status', $input ) && ! array_key_exists( 'rating', $input ) && ! array_key_exists( 'notes', $input ) ) {
+			return new \WP_Error( 'missing-note-update', __( 'Provide status, rating, or notes to update.', 'post-collection' ) );
+		}
+
+		$status = null;
+		if ( array_key_exists( 'status', $input ) ) {
+			$status = sanitize_text_field( $input['status'] );
+			if ( ! in_array( $status, Article_Notes::get_all_status_values(), true ) ) {
+				return new \WP_Error( 'invalid-note-status', __( 'A valid note status is required.', 'post-collection' ) );
+			}
+		}
+
+		$rating = null;
+		if ( array_key_exists( 'rating', $input ) ) {
+			$rating = $this->clamp_int( $input['rating'], 0, 5 );
+		}
+
+		$notes = null;
+		if ( array_key_exists( 'notes', $input ) ) {
+			$notes = wp_kses_post( $input['notes'] );
+		}
+
+		$note_id = $this->plugin->get_article_notes()->save_note( $post->ID, $status, $rating, $notes );
+		if ( ! $note_id ) {
+			return new \WP_Error( 'note-not-saved', __( 'Failed to save note.', 'post-collection' ) );
+		}
+
+		$post = get_post( $post->ID );
+		if ( ! $post ) {
+			return new \WP_Error( 'article-not-found', __( 'The note was updated but the article could not be loaded.', 'post-collection' ) );
+		}
+
+		$note = $this->prepare_note_data( $post->ID );
+
+		return array(
+			'article' => $this->prepare_article_data( $post ),
+			'note'    => $note,
+		);
+	}
+
+	/**
+	 * Register a single ability if it is not already registered.
+	 *
+	 * @param string $ability_id Ability ID.
+	 * @param array  $args       Ability arguments.
+	 */
+	private function register_ability( $ability_id, $args ) {
+		if ( function_exists( 'wp_get_ability' ) && wp_get_ability( $ability_id ) ) {
+			return;
+		}
+
+		wp_register_ability( $ability_id, $args );
+	}
+
+	/**
+	 * Get a post collection user.
+	 *
+	 * @param int $collection_id Collection user ID.
+	 * @return User|\WP_Error Collection user or error.
+	 */
+	private function get_collection_user( $collection_id ) {
+		$collection_id = absint( $collection_id );
+		if ( ! $collection_id ) {
+			return new \WP_Error( 'missing-collection-id', __( 'A collection ID is required.', 'post-collection' ) );
+		}
+
+		$user = User::get_user_by_id( $collection_id );
+		if ( ! $user || ! $user->has_cap( 'post_collection' ) ) {
+			return new \WP_Error( 'invalid-collection', __( 'Invalid post collection.', 'post-collection' ) );
+		}
+
+		return $user;
+	}
+
+	/**
+	 * Get a collected article post.
+	 *
+	 * @param int $article_id Article post ID.
+	 * @return \WP_Post|\WP_Error Article post or error.
+	 */
+	private function get_collected_article( $article_id ) {
+		$article_id = absint( $article_id );
+		if ( ! $article_id ) {
+			return new \WP_Error( 'missing-article-id', __( 'An article ID is required.', 'post-collection' ) );
+		}
+
+		$post = get_post( $article_id );
+		if ( ! $post || Post_Collection::CPT !== $post->post_type ) {
+			return new \WP_Error( 'invalid-article', __( 'Invalid collected article.', 'post-collection' ) );
+		}
+
+		return $post;
+	}
+
+	/**
+	 * Prepare collection data for ability output.
+	 *
+	 * @param User $user Collection user.
+	 * @return array Collection data.
+	 */
+	private function prepare_collection_data( User $user ) {
+		$inactive = (bool) get_user_option( 'friends_post_collection_inactive', $user->ID );
+		$copy_mode = (bool) get_user_option( 'friends_post_collection_copy_mode', $user->ID );
+
+		if ( $inactive ) {
+			$dropdown_mode = 'inactive';
+		} elseif ( $copy_mode ) {
+			$dropdown_mode = 'copy';
+		} else {
+			$dropdown_mode = 'move';
+		}
+
+		return array(
+			'id'            => (int) $user->ID,
+			'user_login'    => (string) $user->user_login,
+			'display_name'  => (string) $user->display_name,
+			'description'   => (string) $user->description,
+			'active'        => ! $inactive,
+			'dropdown_mode' => $dropdown_mode,
+			'copy_mode'     => $copy_mode,
+			'publish_feed'  => (bool) get_user_option( 'friends_publish_post_collection', $user->ID ),
+			'posts_count'   => (int) count_user_posts( $user->ID, Post_Collection::CPT ),
+			'url'           => (string) $user->get_local_friends_page_url(),
+			'edit_url'      => (string) get_edit_user_link( $user->ID ),
+		);
+	}
+
+	/**
+	 * Prepare collected article data for ability output.
+	 *
+	 * @param \WP_Post $post            Article post.
+	 * @param bool     $include_content Whether to include full content.
+	 * @return array Article data.
+	 */
+	private function prepare_article_data( \WP_Post $post, $include_content = false ) {
+		$user = User::get_post_author( $post );
+		$source_url = get_post_meta( $post->ID, 'url', true );
+		if ( ! $source_url ) {
+			$source_url = $post->guid;
+		}
+
+		$author = get_post_meta( $post->ID, 'author', true );
+		if ( ! $author ) {
+			$author = $this->plugin->get_post_author_name( $post );
+		}
+
+		$data = array(
+			'id'            => (int) $post->ID,
+			'title'         => html_entity_decode( get_the_title( $post ), ENT_QUOTES, 'UTF-8' ),
+			'collection_id' => (int) $post->post_author,
+			'collection'    => (string) $user->display_name,
+			'post_status'   => (string) $post->post_status,
+			'source_url'    => (string) $source_url,
+			'view_url'      => (string) $user->get_local_friends_page_url( $post->ID ),
+			'edit_url'      => (string) get_edit_post_link( $post->ID, 'raw' ),
+			'author'        => (string) $author,
+			'excerpt'       => (string) get_the_excerpt( $post ),
+			'date'          => (string) $post->post_date,
+			'modified'      => (string) $post->post_modified,
+			'note'          => $this->prepare_note_data( $post->ID ),
+		);
+
+		if ( $include_content ) {
+			$data['content'] = wp_kses_post( $post->post_content );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Prepare article note data for ability output.
+	 *
+	 * @param int $article_id Article post ID.
+	 * @return array Note data.
+	 */
+	private function prepare_note_data( $article_id ) {
+		$note = $this->plugin->get_article_notes()->get_note( $article_id );
+		if ( ! $note ) {
+			return array(
+				'note_id' => 0,
+				'status'  => Article_Notes::STATUS_UNREAD,
+				'rating'  => 0,
+				'notes'   => '',
+				'updated' => '',
+			);
+		}
+
+		return array(
+			'note_id' => (int) $note['id'],
+			'status'  => (string) $note['status'],
+			'rating'  => (int) $note['rating'],
+			'notes'   => (string) $note['notes'],
+			'updated' => (string) $note['updated'],
+		);
+	}
+
+	/**
+	 * Apply collection options from ability input.
+	 *
+	 * @param User  $user  Collection user.
+	 * @param array $input Ability input.
+	 */
+	private function apply_collection_settings( User $user, $input ) {
+		if ( array_key_exists( 'publish_feed', $input ) ) {
+			if ( $input['publish_feed'] ) {
+				update_user_option( $user->ID, 'friends_publish_post_collection', true );
+			} else {
+				delete_user_option( $user->ID, 'friends_publish_post_collection' );
+			}
+		}
+
+		if ( ! array_key_exists( 'dropdown_mode', $input ) ) {
+			return;
+		}
+
+		switch ( $input['dropdown_mode'] ) {
+			case 'inactive':
+				update_user_option( $user->ID, 'friends_post_collection_inactive', true );
+				break;
+
+			case 'copy':
+				delete_user_option( $user->ID, 'friends_post_collection_inactive' );
+				update_user_option( $user->ID, 'friends_post_collection_copy_mode', true );
+				break;
+
+			case 'move':
+				delete_user_option( $user->ID, 'friends_post_collection_inactive' );
+				delete_user_option( $user->ID, 'friends_post_collection_copy_mode' );
+				break;
+		}
+	}
+
+	/**
+	 * Get article IDs by note status.
+	 *
+	 * @param string $status Note status.
+	 * @return array Article IDs.
+	 */
+	private function get_article_ids_by_note_status( $status ) {
+		if ( ! in_array( $status, Article_Notes::get_all_status_values(), true ) ) {
+			return array();
+		}
+
+		$note_ids = get_posts(
+			array(
+				'post_type'      => Article_Notes::POST_TYPE,
+				'posts_per_page' => -1,
+				'post_status'    => 'publish',
+				'fields'         => 'ids',
+				'meta_query'     => array(
+					array(
+						'key'   => Article_Notes::STATUS_META,
+						'value' => $status,
+					),
+				),
+			)
+		);
+
+		$article_ids = array();
+		foreach ( $note_ids as $note_id ) {
+			$parent_id = wp_get_post_parent_id( $note_id );
+			if ( $parent_id ) {
+				$article_ids[] = (int) $parent_id;
+			}
+		}
+
+		return array_values( array_unique( $article_ids ) );
+	}
+
+	/**
+	 * Sanitize a human label.
+	 *
+	 * @param string $value Input value.
+	 * @return string Sanitized label.
+	 */
+	private function sanitize_label( $value ) {
+		return wp_strip_all_tags( trim( sanitize_text_field( (string) $value ) ) );
+	}
+
+	/**
+	 * Sanitize tag names.
+	 *
+	 * @param array $tags Raw tags.
+	 * @return array Sanitized tags.
+	 */
+	private function sanitize_tags( $tags ) {
+		$sanitized = array();
+		foreach ( $tags as $tag ) {
+			$tag = $this->sanitize_label( $tag );
+			if ( '' !== $tag ) {
+				$sanitized[] = $tag;
+			}
+		}
+
+		return array_values( array_unique( $sanitized ) );
+	}
+
+	/**
+	 * Clamp an integer to a range.
+	 *
+	 * @param mixed $value Input value.
+	 * @param int   $min   Minimum value.
+	 * @param int   $max   Maximum value.
+	 * @return int Clamped value.
+	 */
+	private function clamp_int( $value, $min, $max ) {
+		return max( $min, min( $max, (int) $value ) );
+	}
+
+	/**
+	 * Ability metadata helper.
+	 *
+	 * @param bool   $readonly     Whether the ability is readonly.
+	 * @param bool   $destructive  Whether the ability is destructive.
+	 * @param bool   $idempotent   Whether the ability is idempotent.
+	 * @param string $instructions Instructions for AI tools.
+	 * @return array Ability meta.
+	 */
+	private static function ability_meta( $readonly, $destructive, $idempotent, $instructions ) {
+		return array(
+			'annotations'  => array(
+				'instructions' => $instructions,
+				'readonly'     => $readonly,
+				'destructive'  => $destructive,
+				'idempotent'   => $idempotent,
+			),
+			'show_in_rest' => true,
+		);
+	}
+
+	/**
+	 * Schema for writing collection settings.
+	 *
+	 * @param bool $creating Whether this schema is for creation.
+	 * @return array Input schema.
+	 */
+	private static function collection_write_input_schema( $creating ) {
+		$properties = array(
+			'display_name'  => array(
+				'type'        => 'string',
+				'description' => __( 'Human-readable collection name.', 'post-collection' ),
+			),
+			'user_login'    => array(
+				'type'        => 'string',
+				'description' => __( 'Optional username for a new collection. Used only when creating.', 'post-collection' ),
+			),
+			'description'   => array(
+				'type'        => 'string',
+				'description' => __( 'Collection description.', 'post-collection' ),
+			),
+			'dropdown_mode' => array(
+				'type'        => 'string',
+				'enum'        => array( 'move', 'copy', 'inactive' ),
+				'description' => __( 'move shows Move to, copy shows Copy to, inactive hides the collection from save menus.', 'post-collection' ),
+			),
+			'publish_feed'  => array(
+				'type'        => 'boolean',
+				'description' => __( 'Whether to publish this collection as a feed.', 'post-collection' ),
+			),
+		);
+
+		if ( ! $creating ) {
+			$properties = array_merge(
+				array(
+					'collection_id' => array(
+						'type'        => 'integer',
+						'description' => __( 'Collection user ID from post-collection/list-collections.', 'post-collection' ),
+					),
+				),
+				$properties
+			);
+		}
+
+		return array(
+			'type'                 => 'object',
+			'required'             => $creating ? array( 'display_name' ) : array( 'collection_id' ),
+			'properties'           => $properties,
+			'additionalProperties' => false,
+		);
+	}
+
+	/**
+	 * Input schema for listing articles.
+	 *
+	 * @return array Input schema.
+	 */
+	private static function article_list_input_schema() {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'collection_id' => array(
+					'type'        => 'integer',
+					'description' => __( 'Optional collection user ID to filter by.', 'post-collection' ),
+				),
+				'search'        => array(
+					'type'        => 'string',
+					'description' => __( 'Optional search term for article title or content.', 'post-collection' ),
+				),
+				'post_status'   => array(
+					'type'        => 'string',
+					'enum'        => array( 'any', 'private', 'publish' ),
+					'description' => __( 'Article visibility filter. Defaults to any.', 'post-collection' ),
+					'default'     => 'any',
+				),
+				'note_status'   => array(
+					'type'        => 'string',
+					'enum'        => array( 'all', 'none', 'unread', 'read', 'skipped', 'archived' ),
+					'description' => __( 'Article note status filter. none means articles without a note.', 'post-collection' ),
+					'default'     => 'all',
+				),
+				'limit'         => array(
+					'type'        => 'integer',
+					'minimum'     => 1,
+					'maximum'     => 50,
+					'description' => __( 'Maximum number of articles to return. Defaults to 20.', 'post-collection' ),
+					'default'     => 20,
+				),
+				'offset'        => array(
+					'type'        => 'integer',
+					'minimum'     => 0,
+					'description' => __( 'Number of matching articles to skip.', 'post-collection' ),
+					'default'     => 0,
+				),
+			),
+			'additionalProperties' => false,
+		);
+	}
+
+	/**
+	 * Collection output schema.
+	 *
+	 * @return array Output schema.
+	 */
+	private static function collection_schema() {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'id'            => array( 'type' => 'integer' ),
+				'user_login'    => array( 'type' => 'string' ),
+				'display_name'  => array( 'type' => 'string' ),
+				'description'   => array( 'type' => 'string' ),
+				'active'        => array( 'type' => 'boolean' ),
+				'dropdown_mode' => array( 'type' => 'string' ),
+				'copy_mode'     => array( 'type' => 'boolean' ),
+				'publish_feed'  => array( 'type' => 'boolean' ),
+				'posts_count'   => array( 'type' => 'integer' ),
+				'url'           => array( 'type' => 'string' ),
+				'edit_url'      => array( 'type' => 'string' ),
+			),
+		);
+	}
+
+	/**
+	 * Article output schema.
+	 *
+	 * @param bool $include_content Whether full content may be present.
+	 * @return array Output schema.
+	 */
+	private static function article_schema( $include_content = false ) {
+		$properties = array(
+			'id'            => array( 'type' => 'integer' ),
+			'title'         => array( 'type' => 'string' ),
+			'collection_id' => array( 'type' => 'integer' ),
+			'collection'    => array( 'type' => 'string' ),
+			'post_status'   => array( 'type' => 'string' ),
+			'source_url'    => array( 'type' => 'string' ),
+			'view_url'      => array( 'type' => 'string' ),
+			'edit_url'      => array( 'type' => 'string' ),
+			'author'        => array( 'type' => 'string' ),
+			'excerpt'       => array( 'type' => 'string' ),
+			'date'          => array( 'type' => 'string' ),
+			'modified'      => array( 'type' => 'string' ),
+			'note'          => self::note_schema(),
+		);
+
+		if ( $include_content ) {
+			$properties['content'] = array( 'type' => 'string' );
+		}
+
+		return array(
+			'type'       => 'object',
+			'properties' => $properties,
+		);
+	}
+
+	/**
+	 * Note output schema.
+	 *
+	 * @return array Output schema.
+	 */
+	private static function note_schema() {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'note_id' => array( 'type' => 'integer' ),
+				'status'  => array( 'type' => 'string' ),
+				'rating'  => array( 'type' => 'integer' ),
+				'notes'   => array( 'type' => 'string' ),
+				'updated' => array( 'type' => 'string' ),
+			),
+		);
+	}
+}

--- a/class-post-collection-abilities.php
+++ b/class-post-collection-abilities.php
@@ -94,7 +94,7 @@ class Post_Collection_Abilities {
 			return;
 		}
 
-		if ( function_exists( 'wp_get_ability_category' ) && wp_get_ability_category( self::CATEGORY ) ) {
+		if ( function_exists( 'wp_has_ability_category' ) && wp_has_ability_category( self::CATEGORY ) ) {
 			return;
 		}
 
@@ -794,7 +794,7 @@ class Post_Collection_Abilities {
 	 * @param array  $args       Ability arguments.
 	 */
 	private function register_ability( $ability_id, $args ) {
-		if ( function_exists( 'wp_get_ability' ) && wp_get_ability( $ability_id ) ) {
+		if ( function_exists( 'wp_has_ability' ) && wp_has_ability( $ability_id ) ) {
 			return;
 		}
 

--- a/class-post-collection-abilities.php
+++ b/class-post-collection-abilities.php
@@ -438,7 +438,7 @@ class Post_Collection_Abilities {
 	 */
 	public function ability_list_collections( $input ) {
 		$input = is_array( $input ) ? $input : array();
-		$include_inactive = ! empty( $input['include_inactive'] );
+		$include_inactive = $this->input_bool( $input, 'include_inactive', false );
 		$collections = array();
 
 		foreach ( $this->plugin->get_post_collection_users()->get_results() as $user ) {
@@ -650,6 +650,23 @@ class Post_Collection_Abilities {
 					'compare' => 'NOT EXISTS',
 				),
 			);
+		} elseif ( Article_Notes::STATUS_UNREAD === $note_status ) {
+			$note_ids = $this->get_note_ids_by_status( $note_status );
+			$args['meta_query'] = array(
+				'relation' => 'OR',
+				array(
+					'key'     => Article_Notes::NOTE_ID_META,
+					'compare' => 'NOT EXISTS',
+				),
+			);
+
+			if ( ! empty( $note_ids ) ) {
+				$args['meta_query'][] = array(
+					'key'     => Article_Notes::NOTE_ID_META,
+					'value'   => $note_ids,
+					'compare' => 'IN',
+				);
+			}
 		} elseif ( 'all' !== $note_status ) {
 			$article_ids = $this->get_article_ids_by_note_status( $note_status );
 			if ( empty( $article_ids ) ) {
@@ -951,7 +968,7 @@ class Post_Collection_Abilities {
 	 */
 	private function apply_collection_settings( User $user, $input ) {
 		if ( array_key_exists( 'publish_feed', $input ) ) {
-			if ( $input['publish_feed'] ) {
+			if ( $this->input_bool( $input, 'publish_feed', false ) ) {
 				update_user_option( $user->ID, 'friends_publish_post_collection', true );
 			} else {
 				delete_user_option( $user->ID, 'friends_publish_post_collection' );
@@ -986,11 +1003,34 @@ class Post_Collection_Abilities {
 	 * @return array Article IDs.
 	 */
 	private function get_article_ids_by_note_status( $status ) {
+		$note_ids = $this->get_note_ids_by_status( $status );
+		if ( empty( $note_ids ) ) {
+			return array();
+		}
+
+		$article_ids = array();
+		foreach ( $note_ids as $note_id ) {
+			$parent_id = wp_get_post_parent_id( $note_id );
+			if ( $parent_id ) {
+				$article_ids[] = (int) $parent_id;
+			}
+		}
+
+		return array_values( array_unique( $article_ids ) );
+	}
+
+	/**
+	 * Get note IDs by status.
+	 *
+	 * @param string $status Note status.
+	 * @return array Note IDs.
+	 */
+	private function get_note_ids_by_status( $status ) {
 		if ( ! in_array( $status, Article_Notes::get_all_status_values(), true ) ) {
 			return array();
 		}
 
-		$note_ids = get_posts(
+		return get_posts(
 			array(
 				'post_type'      => Article_Notes::POST_TYPE,
 				'posts_per_page' => -1,
@@ -1004,16 +1044,26 @@ class Post_Collection_Abilities {
 				),
 			)
 		);
+	}
 
-		$article_ids = array();
-		foreach ( $note_ids as $note_id ) {
-			$parent_id = wp_get_post_parent_id( $note_id );
-			if ( $parent_id ) {
-				$article_ids[] = (int) $parent_id;
-			}
+	/**
+	 * Read a boolean input value.
+	 *
+	 * @param array  $input   Ability input.
+	 * @param string $key     Input key.
+	 * @param bool   $default Default value.
+	 * @return bool Boolean value.
+	 */
+	private function input_bool( array $input, $key, $default = false ) {
+		if ( ! array_key_exists( $key, $input ) ) {
+			return $default;
 		}
 
-		return array_values( array_unique( $article_ids ) );
+		if ( function_exists( 'rest_sanitize_boolean' ) ) {
+			return rest_sanitize_boolean( $input[ $key ] );
+		}
+
+		return filter_var( $input[ $key ], FILTER_VALIDATE_BOOLEAN );
 	}
 
 	/**

--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -60,6 +60,13 @@ class Post_Collection {
 	private $article_notes;
 
 	/**
+	 * Contains the abilities integration instance.
+	 *
+	 * @var Post_Collection_Abilities|null
+	 */
+	private $abilities;
+
+	/**
 	 * Constructor
 	 *
 	 * @param Friends|null $friends A reference to the Friends object (optional).
@@ -67,6 +74,9 @@ class Post_Collection {
 	public function __construct( ?Friends $friends = null ) {
 		$this->friends = $friends;
 		$this->article_notes = new Article_Notes( $this );
+		if ( class_exists( __NAMESPACE__ . '\Post_Collection_Abilities' ) ) {
+			$this->abilities = new Post_Collection_Abilities( $this );
+		}
 		$this->register_hooks();
 	}
 
@@ -1154,6 +1164,19 @@ class Post_Collection {
 		}
 
 		return (int) $post_id;
+	}
+
+	/**
+	 * Save a URL to a post collection and return the saved post ID.
+	 *
+	 * @param  string $url         The URL to save.
+	 * @param  User   $friend_user The post collection user.
+	 * @param  string $content     Optional HTML content.
+	 * @param  array  $args        Optional arguments: title and tags.
+	 * @return int|\WP_Error The saved post ID or an error.
+	 */
+	public function save_url_for_collection( $url, User $friend_user, $content = null, $args = array() ) {
+		return $this->save_url_to_collection( $url, $friend_user, $content, $args );
 	}
 
 	/**

--- a/post-collection.php
+++ b/post-collection.php
@@ -30,6 +30,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/class-user.php';
 require_once __DIR__ . '/class-user-query.php';
 require_once __DIR__ . '/class-post-collection.php';
+require_once __DIR__ . '/class-post-collection-abilities.php';
 require_once __DIR__ . '/class-extracted-page.php';
 require_once __DIR__ . '/site-configs/class-site-config.php';
 require_once __DIR__ . '/site-configs/class-youtube.php';

--- a/tests/Test_Post_Collection_Abilities.php
+++ b/tests/Test_Post_Collection_Abilities.php
@@ -1,0 +1,220 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use PostCollection\Article_Notes;
+use PostCollection\Post_Collection;
+use PostCollection\Post_Collection_Abilities;
+use PostCollection\User;
+
+require_once __DIR__ . '/../class-post-collection.php';
+require_once __DIR__ . '/../class-post-collection-abilities.php';
+
+class Post_Collection_Abilities_Test_Plugin extends Post_Collection {
+	public $collection_users = array();
+
+	public function __construct() {}
+
+	public function get_required_role() {
+		return 'edit_private_posts';
+	}
+
+	public function get_post_collection_users() {
+		return new Post_Collection_Abilities_Test_User_Query( $this->collection_users );
+	}
+
+	public function get_article_notes() {
+		return new Article_Notes( $this );
+	}
+
+	public function get_post_author_name( \WP_Post $post ) {
+		return 'Test Author';
+	}
+}
+
+class Post_Collection_Abilities_Test_User_Query {
+	private $users;
+
+	public function __construct( array $users ) {
+		$this->users = $users;
+	}
+
+	public function get_results() {
+		return $this->users;
+	}
+}
+
+class Test_Post_Collection_Abilities extends TestCase {
+	private $plugin;
+	private $abilities;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$GLOBALS['wp_test_actions']            = array();
+		$GLOBALS['wp_test_filters']            = array();
+		$GLOBALS['wp_test_did_actions']        = array();
+		$GLOBALS['wp_test_doing_actions']      = array();
+		$GLOBALS['wp_test_ability_categories'] = array();
+		$GLOBALS['wp_test_abilities']          = array();
+		$GLOBALS['wp_test_current_user_caps']  = array(
+			'edit_private_posts' => true,
+		);
+		$GLOBALS['wp_test_posts']              = array();
+		$GLOBALS['wp_test_post_meta']          = array();
+		$GLOBALS['wp_test_users']              = array();
+		$GLOBALS['wp_test_user_options']       = array();
+
+		$this->plugin    = new Post_Collection_Abilities_Test_Plugin();
+		$this->abilities = new Post_Collection_Abilities( $this->plugin );
+	}
+
+	public function test_registers_category_and_abilities() {
+		$this->abilities->register_ability_category();
+		$this->abilities->register_abilities();
+
+		$this->assertArrayHasKey( 'post-collection', $GLOBALS['wp_test_ability_categories'] );
+		$this->assertArrayHasKey( 'post-collection/list-collections', $GLOBALS['wp_test_abilities'] );
+		$this->assertArrayHasKey( 'post-collection/create-collection', $GLOBALS['wp_test_abilities'] );
+		$this->assertArrayHasKey( 'post-collection/update-collection', $GLOBALS['wp_test_abilities'] );
+		$this->assertArrayHasKey( 'post-collection/save-url', $GLOBALS['wp_test_abilities'] );
+		$this->assertArrayHasKey( 'post-collection/list-articles', $GLOBALS['wp_test_abilities'] );
+		$this->assertArrayHasKey( 'post-collection/get-article', $GLOBALS['wp_test_abilities'] );
+		$this->assertArrayHasKey( 'post-collection/update-article-visibility', $GLOBALS['wp_test_abilities'] );
+		$this->assertArrayHasKey( 'post-collection/update-note', $GLOBALS['wp_test_abilities'] );
+		$this->assertTrue( $GLOBALS['wp_test_abilities']['post-collection/list-articles']['meta']['annotations']['readonly'] );
+		$this->assertFalse( $GLOBALS['wp_test_abilities']['post-collection/update-note']['meta']['annotations']['destructive'] );
+		$this->assertTrue( $GLOBALS['wp_test_abilities']['post-collection/update-note']['meta']['annotations']['idempotent'] );
+	}
+
+	public function test_registers_ai_assistant_domain_and_instructions() {
+		$domains = $this->abilities->ai_assistant_ability_domains( array() );
+
+		$this->assertArrayHasKey( 'post-collection', $domains );
+		$this->assertStringContainsString( 'article notes', $domains['post-collection'] );
+
+		$instructions = $this->abilities->ai_assistant_ability_instructions( '', 'post-collection/save-url', array(), array() );
+		$this->assertStringContainsString( 'view_url', $instructions );
+	}
+
+	public function test_list_collections_treats_string_false_as_false() {
+		$active = $this->create_collection_user( 1, 'active', 'Active Collection' );
+		$inactive = $this->create_collection_user( 2, 'inactive', 'Inactive Collection' );
+		update_user_option( $inactive->ID, 'friends_post_collection_inactive', true );
+
+		$this->plugin->collection_users = array( $active, $inactive );
+
+		$result = $this->abilities->ability_list_collections(
+			array(
+				'include_inactive' => 'false',
+			)
+		);
+
+		$this->assertSame( 1, $result['total'] );
+		$this->assertSame( $active->ID, $result['collections'][0]['id'] );
+	}
+
+	public function test_update_collection_treats_string_false_as_false() {
+		$collection = $this->create_collection_user( 3, 'articles', 'Articles' );
+		update_user_option( $collection->ID, 'friends_publish_post_collection', true );
+
+		$result = $this->abilities->ability_update_collection(
+			array(
+				'collection_id' => $collection->ID,
+				'publish_feed'  => 'false',
+			)
+		);
+
+		$this->assertFalse( is_wp_error( $result ) );
+		$this->assertFalse( get_user_option( 'friends_publish_post_collection', $collection->ID ) );
+		$this->assertFalse( $result['collection']['publish_feed'] );
+	}
+
+	public function test_list_articles_unread_includes_articles_without_notes() {
+		$collection = $this->create_collection_user( 4, 'reading', 'Reading' );
+		$this->plugin->collection_users = array( $collection );
+
+		$without_note = $this->create_article( 101, $collection->ID, 'No Note' );
+		$unread = $this->create_article( 102, $collection->ID, 'Explicit Unread' );
+		$read = $this->create_article( 103, $collection->ID, 'Read' );
+
+		$this->create_note( 201, $unread->ID, Article_Notes::STATUS_UNREAD );
+		$this->create_note( 202, $read->ID, Article_Notes::STATUS_READ );
+
+		$result = $this->abilities->ability_list_articles(
+			array(
+				'note_status' => Article_Notes::STATUS_UNREAD,
+				'limit'       => 10,
+			)
+		);
+
+		$ids = array_map(
+			function ( $article ) {
+				return $article['id'];
+			},
+			$result['articles']
+		);
+
+		$this->assertContains( $without_note->ID, $ids );
+		$this->assertContains( $unread->ID, $ids );
+		$this->assertNotContains( $read->ID, $ids );
+		$this->assertSame( 2, $result['total'] );
+	}
+
+	private function create_collection_user( $id, $login, $display_name ) {
+		$user = new User(
+			(object) array(
+				'ID'           => $id,
+				'user_login'   => $login,
+				'display_name' => $display_name,
+				'description'  => '',
+				'roles'        => array( 'post_collection' ),
+				'caps'         => array( 'post_collection' => true ),
+			)
+		);
+
+		$GLOBALS['wp_test_users'][ $id ] = $user;
+
+		return $user;
+	}
+
+	private function create_article( $id, $collection_id, $title ) {
+		$post = new \WP_Post(
+			(object) array(
+				'ID'            => $id,
+				'post_author'   => $collection_id,
+				'post_title'    => $title,
+				'post_content'  => 'Article content for ' . $title,
+				'post_excerpt'  => 'Excerpt for ' . $title,
+				'post_status'   => 'private',
+				'post_type'     => Post_Collection::CPT,
+				'post_date'     => '2026-01-01 00:00:00',
+				'post_modified' => '2026-01-01 00:00:00',
+				'guid'          => 'https://example.com/source/' . $id,
+			)
+		);
+
+		$GLOBALS['wp_test_posts'][ $id ] = $post;
+
+		return $post;
+	}
+
+	private function create_note( $note_id, $article_id, $status ) {
+		$note = new \WP_Post(
+			(object) array(
+				'ID'            => $note_id,
+				'post_parent'   => $article_id,
+				'post_content'  => 'Note ' . $note_id,
+				'post_status'   => 'publish',
+				'post_type'     => Article_Notes::POST_TYPE,
+				'post_date'     => '2026-01-01 00:00:00',
+				'post_modified' => '2026-01-01 00:00:00',
+			)
+		);
+
+		$GLOBALS['wp_test_posts'][ $note_id ] = $note;
+		update_post_meta( $article_id, Article_Notes::NOTE_ID_META, $note_id );
+		update_post_meta( $note_id, Article_Notes::STATUS_META, $status );
+
+		return $note;
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,13 +1,28 @@
 <?php
 
 namespace {
+	if ( ! defined( 'ABSPATH' ) ) {
+		define( 'ABSPATH', '/tmp/' );
+	}
+
 	require_once __DIR__ . '/../vendor/autoload.php';
 
 	if ( ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
 		require_once __DIR__ . '/stubs/class-wp-html-tag-processor.php';
 	}
 
-	require_once __DIR__ . '/../class-extracted-page.php';
+	$GLOBALS['wp_test_actions']            = array();
+	$GLOBALS['wp_test_filters']            = array();
+	$GLOBALS['wp_test_did_actions']        = array();
+	$GLOBALS['wp_test_doing_actions']      = array();
+	$GLOBALS['wp_test_ability_categories'] = array();
+	$GLOBALS['wp_test_abilities']          = array();
+	$GLOBALS['wp_test_current_user_caps']  = array();
+	$GLOBALS['wp_test_current_user_id']    = 0;
+	$GLOBALS['wp_test_posts']              = array();
+	$GLOBALS['wp_test_post_meta']          = array();
+	$GLOBALS['wp_test_users']              = array();
+	$GLOBALS['wp_test_user_options']       = array();
 
 	function __( $text, $domain = 'default' ) {
 		return $text;
@@ -45,6 +60,10 @@ namespace {
 		return htmlspecialchars( $url, ENT_QUOTES, 'UTF-8' );
 	}
 
+	function esc_url_raw( $url, $protocols = null ) {
+		return (string) $url;
+	}
+
 	function wp_kses_post( $data ) {
 		return $data;
 	}
@@ -58,14 +77,584 @@ namespace {
 	}
 
 	function add_action( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['wp_test_actions'][ $tag ][] = compact( 'function_to_add', 'priority', 'accepted_args' );
 		return true;
 	}
 
 	function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
+		$GLOBALS['wp_test_filters'][ $tag ][] = compact( 'function_to_add', 'priority', 'accepted_args' );
 		return true;
 	}
 
+	function apply_filters( $tag, $value, ...$args ) {
+		if ( empty( $GLOBALS['wp_test_filters'][ $tag ] ) ) {
+			return $value;
+		}
+
+		foreach ( $GLOBALS['wp_test_filters'][ $tag ] as $filter ) {
+			$value = call_user_func_array(
+				$filter['function_to_add'],
+				array_slice( array_merge( array( $value ), $args ), 0, $filter['accepted_args'] )
+			);
+		}
+
+		return $value;
+	}
+
 	function did_action( $hook_name ) {
+		return (int) ( $GLOBALS['wp_test_did_actions'][ $hook_name ] ?? 0 );
+	}
+
+	function doing_action( $hook_name = null ) {
+		if ( null === $hook_name ) {
+			return ! empty( $GLOBALS['wp_test_doing_actions'] );
+		}
+		return ! empty( $GLOBALS['wp_test_doing_actions'][ $hook_name ] );
+	}
+
+	function current_user_can( $capability, ...$args ) {
+		return ! empty( $GLOBALS['wp_test_current_user_caps'][ $capability ] );
+	}
+
+	function get_current_user_id() {
+		return (int) $GLOBALS['wp_test_current_user_id'];
+	}
+
+	function wp_get_current_user() {
+		return new WP_User( get_current_user_id() );
+	}
+
+	function wp_set_current_user( $id ) {
+		$GLOBALS['wp_test_current_user_id'] = (int) $id;
+		return wp_get_current_user();
+	}
+
+	function is_user_logged_in() {
+		return get_current_user_id() > 0;
+	}
+
+	function rest_sanitize_boolean( $value ) {
+		if ( is_string( $value ) ) {
+			$value = strtolower( $value );
+			if ( in_array( $value, array( 'false', '0' ), true ) ) {
+				return false;
+			}
+		}
+		return (bool) $value;
+	}
+
+	function wp_register_ability_category( $slug, $args = array() ) {
+		$GLOBALS['wp_test_ability_categories'][ $slug ] = $args;
+		return true;
+	}
+
+	function wp_has_ability_category( $slug ) {
+		return array_key_exists( $slug, $GLOBALS['wp_test_ability_categories'] );
+	}
+
+	function wp_register_ability( $name, $args = array() ) {
+		$GLOBALS['wp_test_abilities'][ $name ] = $args;
+		return true;
+	}
+
+	function wp_has_ability( $name ) {
+		return array_key_exists( $name, $GLOBALS['wp_test_abilities'] );
+	}
+
+	function wp_get_ability( $name ) {
+		return $GLOBALS['wp_test_abilities'][ $name ] ?? null;
+	}
+
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
+
+	class WP_Error {
+		public $errors = array();
+		public $error_data = array();
+
+		public function __construct( $code = '', $message = '', $data = '' ) {
+			if ( $code ) {
+				$this->errors[ $code ][] = $message;
+				if ( '' !== $data ) {
+					$this->error_data[ $code ] = $data;
+				}
+			}
+		}
+
+		public function get_error_code() {
+			return array_key_first( $this->errors );
+		}
+
+		public function get_error_message( $code = '' ) {
+			if ( '' === $code ) {
+				$code = $this->get_error_code();
+			}
+			return $this->errors[ $code ][0] ?? '';
+		}
+	}
+
+	class WP_User {
+		public $ID = 0;
+		public $user_login = '';
+		public $display_name = '';
+		public $description = '';
+		public $caps = array();
+		public $roles = array();
+
+		public function __construct( $id = 0 ) {
+			if ( $id instanceof self ) {
+				foreach ( get_object_vars( $id ) as $key => $value ) {
+					$this->$key = $value;
+				}
+				return;
+			}
+
+			if ( is_object( $id ) ) {
+				foreach ( get_object_vars( $id ) as $key => $value ) {
+					$this->$key = $value;
+				}
+				return;
+			}
+
+			$id = (int) $id;
+			if ( $id && isset( $GLOBALS['wp_test_users'][ $id ] ) ) {
+				foreach ( get_object_vars( $GLOBALS['wp_test_users'][ $id ] ) as $key => $value ) {
+					$this->$key = $value;
+				}
+				return;
+			}
+
+			$this->ID = $id;
+		}
+
+		public function exists() {
+			return $this->ID > 0;
+		}
+
+		public function has_cap( $cap ) {
+			return ! empty( $this->caps[ $cap ] ) || in_array( $cap, $this->roles, true );
+		}
+	}
+
+	class WP_User_Query {
+		private $query_results = array();
+
+		public function __construct( $args = array() ) {
+			$users = array_values( $GLOBALS['wp_test_users'] );
+			if ( ! empty( $args['role'] ) ) {
+				$role = $args['role'];
+				$users = array_filter(
+					$users,
+					function ( $user ) use ( $role ) {
+						return in_array( $role, (array) $user->roles, true ) || ! empty( $user->caps[ $role ] );
+					}
+				);
+			}
+			$this->query_results = array_values( $users );
+		}
+
+		public function query() {}
+
+		public function get_results() {
+			return $this->query_results;
+		}
+
+		public function get_total() {
+			return count( $this->query_results );
+		}
+	}
+
+	class WP_Post {
+		public $ID = 0;
+		public $post_author = 1;
+		public $post_title = '';
+		public $post_content = '';
+		public $post_excerpt = '';
+		public $post_status = 'publish';
+		public $post_type = 'post';
+		public $post_date = '2026-01-01 00:00:00';
+		public $post_modified = '2026-01-01 00:00:00';
+		public $post_parent = 0;
+		public $guid = '';
+
+		public function __construct( $post = null ) {
+			if ( is_object( $post ) ) {
+				foreach ( get_object_vars( $post ) as $key => $value ) {
+					$this->$key = $value;
+				}
+			}
+		}
+	}
+
+	class WP_Query {
+		public $posts = array();
+		public $found_posts = 0;
+		public $query_vars = array();
+
+		public function __construct( $query = '' ) {
+			$this->query_vars  = is_array( $query ) ? $query : array();
+			$filtered          = post_collection_test_filter_posts( array_values( $GLOBALS['wp_test_posts'] ), $this->query_vars, false );
+			$this->found_posts = count( $filtered );
+			$this->posts       = post_collection_test_filter_posts( $filtered, $this->query_vars, true, false );
+		}
+
+		public function get_posts() {
+			return $this->posts;
+		}
+	}
+
+	function post_collection_test_filter_posts( $posts, $args, $paginate = true, $filter = true ) {
+		if ( $filter ) {
+			if ( ! empty( $args['post_type'] ) ) {
+				$post_types = (array) $args['post_type'];
+				$posts = array_filter(
+					$posts,
+					function ( $post ) use ( $post_types ) {
+						return in_array( $post->post_type, $post_types, true );
+					}
+				);
+			}
+
+			if ( ! empty( $args['post_status'] ) && 'any' !== $args['post_status'] ) {
+				$statuses = (array) $args['post_status'];
+				$posts = array_filter(
+					$posts,
+					function ( $post ) use ( $statuses ) {
+						return in_array( $post->post_status, $statuses, true );
+					}
+				);
+			}
+
+			if ( ! empty( $args['author'] ) ) {
+				$author = (int) $args['author'];
+				$posts = array_filter(
+					$posts,
+					function ( $post ) use ( $author ) {
+						return (int) $post->post_author === $author;
+					}
+				);
+			}
+
+			if ( ! empty( $args['post__in'] ) ) {
+				$post_ids = array_map( 'intval', (array) $args['post__in'] );
+				$posts = array_filter(
+					$posts,
+					function ( $post ) use ( $post_ids ) {
+						return in_array( (int) $post->ID, $post_ids, true );
+					}
+				);
+			}
+
+			if ( ! empty( $args['s'] ) ) {
+				$search = strtolower( (string) $args['s'] );
+				$posts = array_filter(
+					$posts,
+					function ( $post ) use ( $search ) {
+						return false !== strpos( strtolower( $post->post_title . ' ' . $post->post_content ), $search );
+					}
+				);
+			}
+
+			if ( ! empty( $args['meta_query'] ) ) {
+				$meta_query = $args['meta_query'];
+				$posts = array_filter(
+					$posts,
+					function ( $post ) use ( $meta_query ) {
+						return post_collection_test_post_matches_meta_query( $post, $meta_query );
+					}
+				);
+			}
+		}
+
+		$posts = array_values( $posts );
+
+		if ( ! $paginate ) {
+			return $posts;
+		}
+
+		$offset = isset( $args['offset'] ) ? max( 0, (int) $args['offset'] ) : 0;
+		$limit  = isset( $args['posts_per_page'] ) ? (int) $args['posts_per_page'] : -1;
+
+		if ( -1 === $limit ) {
+			return array_slice( $posts, $offset );
+		}
+
+		return array_slice( $posts, $offset, $limit );
+	}
+
+	function post_collection_test_post_matches_meta_query( $post, $meta_query ) {
+		$relation = 'AND';
+		if ( isset( $meta_query['relation'] ) ) {
+			$relation = strtoupper( $meta_query['relation'] );
+		}
+
+		$clauses = array();
+		foreach ( $meta_query as $key => $clause ) {
+			if ( ! is_array( $clause ) || ! isset( $clause['key'] ) ) {
+				continue;
+			}
+			if ( isset( $clause['relation'] ) && ! isset( $clause['key'] ) ) {
+				$relation = strtoupper( $clause['relation'] );
+				continue;
+			}
+			$clauses[] = $clause;
+		}
+
+		if ( empty( $clauses ) ) {
+			return true;
+		}
+
+		$matches = array_map(
+			function ( $clause ) use ( $post ) {
+				$key     = $clause['key'];
+				$compare = strtoupper( $clause['compare'] ?? '=' );
+				$value   = $clause['value'] ?? null;
+				$stored  = get_post_meta( $post->ID, $key, true );
+				$has     = '' !== $stored && null !== $stored;
+
+				if ( 'NOT EXISTS' === $compare ) {
+					return ! $has;
+				}
+				if ( 'EXISTS' === $compare ) {
+					return $has;
+				}
+				if ( 'IN' === $compare ) {
+					return in_array( (string) $stored, array_map( 'strval', (array) $value ), true );
+				}
+				return (string) $stored === (string) $value;
+			},
+			$clauses
+		);
+
+		return 'OR' === $relation ? in_array( true, $matches, true ) : ! in_array( false, $matches, true );
+	}
+
+	function get_posts( $args = array() ) {
+		$posts = post_collection_test_filter_posts( array_values( $GLOBALS['wp_test_posts'] ), $args );
+		if ( isset( $args['fields'] ) && 'ids' === $args['fields'] ) {
+			return array_map(
+				function ( $post ) {
+					return (int) $post->ID;
+				},
+				$posts
+			);
+		}
+		return $posts;
+	}
+
+	function get_post( $post = null ) {
+		if ( $post instanceof WP_Post ) {
+			return $post;
+		}
+		$post_id = is_object( $post ) ? (int) $post->ID : (int) $post;
+		return $GLOBALS['wp_test_posts'][ $post_id ] ?? null;
+	}
+
+	function wp_get_post_parent_id( $post_id ) {
+		$post = get_post( $post_id );
+		return $post ? (int) $post->post_parent : 0;
+	}
+
+	function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true ) {
+		$post_id = isset( $postarr['ID'] ) ? (int) $postarr['ID'] : ( count( $GLOBALS['wp_test_posts'] ) + 1 );
+		$post = new WP_Post(
+			(object) array_merge(
+				array(
+					'ID' => $post_id,
+				),
+				$postarr
+			)
+		);
+		$GLOBALS['wp_test_posts'][ $post_id ] = $post;
+		return $post_id;
+	}
+
+	function wp_update_post( $postarr, $wp_error = false ) {
+		$post_id = (int) ( $postarr['ID'] ?? 0 );
+		if ( ! $post_id || empty( $GLOBALS['wp_test_posts'][ $post_id ] ) ) {
+			return $wp_error ? new WP_Error( 'invalid-post', 'Invalid post.' ) : 0;
+		}
+		foreach ( $postarr as $key => $value ) {
+			$GLOBALS['wp_test_posts'][ $post_id ]->$key = $value;
+		}
+		return $post_id;
+	}
+
+	function wp_untrash_post( $post_id ) {
+		return true;
+	}
+
+	function get_post_meta( $post_id, $key = '', $single = false ) {
+		if ( '' === $key ) {
+			return $GLOBALS['wp_test_post_meta'][ $post_id ] ?? array();
+		}
+		if ( ! array_key_exists( $post_id, $GLOBALS['wp_test_post_meta'] ) || ! array_key_exists( $key, $GLOBALS['wp_test_post_meta'][ $post_id ] ) ) {
+			return $single ? '' : array();
+		}
+		$value = $GLOBALS['wp_test_post_meta'][ $post_id ][ $key ];
+		return $single ? $value : (array) $value;
+	}
+
+	function update_post_meta( $post_id, $meta_key, $meta_value, $prev_value = '' ) {
+		$GLOBALS['wp_test_post_meta'][ $post_id ][ $meta_key ] = $meta_value;
+		return true;
+	}
+
+	function delete_post_meta( $post_id, $meta_key, $meta_value = '' ) {
+		unset( $GLOBALS['wp_test_post_meta'][ $post_id ][ $meta_key ] );
+		return true;
+	}
+
+	function wp_set_post_terms( $post_id, $terms, $taxonomy, $append = false ) {
+		$GLOBALS['wp_test_terms'][ $post_id ][ $taxonomy ] = (array) $terms;
+		return $terms;
+	}
+
+	function get_the_title( $post = 0 ) {
+		$post = get_post( $post );
+		return $post ? $post->post_title : '';
+	}
+
+	function get_the_excerpt( $post = null ) {
+		$post = get_post( $post );
+		return $post ? $post->post_excerpt : '';
+	}
+
+	function get_permalink( $post = 0 ) {
+		$post_id = is_object( $post ) ? $post->ID : (int) $post;
+		return 'https://example.com/?p=' . $post_id;
+	}
+
+	function get_edit_post_link( $id = 0, $context = 'display' ) {
+		return 'https://example.com/wp-admin/post.php?post=' . (int) $id . '&action=edit';
+	}
+
+	function get_edit_user_link( $user_id = null ) {
+		return 'https://example.com/wp-admin/user-edit.php?user_id=' . (int) $user_id;
+	}
+
+	function get_user_by( $field, $value ) {
+		foreach ( $GLOBALS['wp_test_users'] as $user ) {
+			if ( 'ID' === $field && (int) $user->ID === (int) $value ) {
+				return new WP_User( $user );
+			}
+			if ( 'login' === $field && $user->user_login === $value ) {
+				return new WP_User( $user );
+			}
+		}
 		return false;
 	}
+
+	function username_exists( $user_login ) {
+		$user = get_user_by( 'login', $user_login );
+		return $user ? $user->ID : false;
+	}
+
+	function wp_insert_user( $userdata ) {
+		$user_id = isset( $userdata['ID'] ) ? (int) $userdata['ID'] : ( count( $GLOBALS['wp_test_users'] ) + 1 );
+		$user = new WP_User(
+			(object) array(
+				'ID'           => $user_id,
+				'user_login'   => $userdata['user_login'] ?? '',
+				'display_name' => $userdata['display_name'] ?? '',
+				'description'  => $userdata['description'] ?? '',
+				'roles'        => isset( $userdata['role'] ) ? array( $userdata['role'] ) : array(),
+				'caps'         => isset( $userdata['role'] ) ? array( $userdata['role'] => true ) : array(),
+			)
+		);
+		$GLOBALS['wp_test_users'][ $user_id ] = $user;
+		return $user_id;
+	}
+
+	function wp_update_user( $userdata ) {
+		$user_id = (int) ( $userdata['ID'] ?? 0 );
+		if ( ! $user_id || empty( $GLOBALS['wp_test_users'][ $user_id ] ) ) {
+			return new WP_Error( 'invalid-user', 'Invalid user.' );
+		}
+		foreach ( $userdata as $key => $value ) {
+			if ( 'ID' !== $key ) {
+				$GLOBALS['wp_test_users'][ $user_id ]->$key = $value;
+			}
+		}
+		return $user_id;
+	}
+
+	function get_user_option( $option, $user_id = 0 ) {
+		return $GLOBALS['wp_test_user_options'][ $user_id ][ $option ] ?? false;
+	}
+
+	function update_user_option( $user_id, $option, $value, $global = false ) {
+		$GLOBALS['wp_test_user_options'][ $user_id ][ $option ] = $value;
+		return true;
+	}
+
+	function delete_user_option( $user_id, $option, $global = false ) {
+		unset( $GLOBALS['wp_test_user_options'][ $user_id ][ $option ] );
+		return true;
+	}
+
+	function count_user_posts( $user_id, $post_type = 'post' ) {
+		return count(
+			array_filter(
+				$GLOBALS['wp_test_posts'],
+				function ( $post ) use ( $user_id, $post_type ) {
+					return (int) $post->post_author === (int) $user_id && $post->post_type === $post_type;
+				}
+			)
+		);
+	}
+
+	function home_url( $path = '', $scheme = null ) {
+		return 'https://example.com' . $path;
+	}
+
+	function sanitize_text_field( $str ) {
+		return trim( strip_tags( (string) $str ) );
+	}
+
+	function sanitize_textarea_field( $str ) {
+		return trim( strip_tags( (string) $str ) );
+	}
+
+	function sanitize_user( $username, $strict = false ) {
+		$username = strtolower( (string) $username );
+		$username = preg_replace( $strict ? '/[^a-z0-9._-]/' : '/[^a-z0-9._@-]/', '', $username );
+		return trim( $username );
+	}
+
+	function sanitize_title( $title, $fallback_title = '', $context = 'save' ) {
+		$title = strtolower( remove_accents( (string) $title ) );
+		$title = preg_replace( '/[^a-z0-9-]+/', '-', $title );
+		return trim( $title, '-' );
+	}
+
+	function sanitize_key( $key ) {
+		return preg_replace( '/[^a-z0-9_-]/', '', strtolower( (string) $key ) );
+	}
+
+	function remove_accents( $text ) {
+		return $text;
+	}
+
+	function wp_strip_all_tags( $text, $remove_breaks = false ) {
+		return strip_tags( (string) $text );
+	}
+
+	function wp_generate_password( $length = 12, $special_chars = true, $extra_special_chars = false ) {
+		return str_repeat( 'x', $length );
+	}
+
+	function absint( $maybeint ) {
+		return abs( (int) $maybeint );
+	}
+
+	function date_i18n( $format, $timestamp = false, $gmt = false ) {
+		return date( $format, $timestamp ?: time() );
+	}
+
+	require_once __DIR__ . '/../class-extracted-page.php';
+	require_once __DIR__ . '/../class-user.php';
+	require_once __DIR__ . '/../class-user-query.php';
+	require_once __DIR__ . '/../includes/class-article-notes.php';
 }


### PR DESCRIPTION
Summary:
- Add a Post Collection Ability API integration class with abilities for listing/updating collections, saving URLs, listing/getting articles, changing article visibility, and updating notes.
- Register AI Assistant domain hints and post-result instructions for Post Collection workflows.
- Wire the ability layer into plugin bootstrap and expose a non-redirecting save wrapper for URL ingestion.

Checks:
- php -l class-post-collection-abilities.php
- php -l class-post-collection.php
- php -l post-collection.php
- composer test