### PR TITLE
Fix copying Friends posts to collections

### DIFF
--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -2302,6 +2302,10 @@ class Post_Collection {
 		$old_author = User::get_post_author( $post );
 
 		$post->post_author = $new_author->ID;
+		if ( $new_author->has_cap( 'post_collection' ) ) {
+			$post->post_type   = self::CPT;
+			$post->post_status = 'private';
+		}
 		if ( get_user_option( 'friends_post_collection_copy_mode', $new_author->ID ) ) {
 			unset( $post->ID );
 			$new_author->insert_post( (array) $post );

--- a/post-collection.js
+++ b/post-collection.js
@@ -28,14 +28,23 @@ jQuery( function ( $ ) {
 	} );
 	$document.on( 'click', 'a.post-collection-change-author', function () {
 		var $this = $( this );
+		if ( $this.data( 'loading' ) ) {
+			return false;
+		}
 		wp.ajax.send( 'post-collection-change-author', {
 			data: {
 				id: $this.data( 'id' ),
 				author: $this.data( 'author' ),
 				originalauthor: $this.data( 'originalauthor' )
 			},
+			beforeSend: function () {
+				$this.data( 'loading', true );
+			},
 			success: function ( response ) {
 				$this.text( response.new_text ).data( 'author', response.old_author );
+			},
+			complete: function () {
+				$this.data( 'loading', false );
 			}
 		} );
 		return false;


### PR DESCRIPTION
## Summary
- Normalize posts copied or moved into post-collection users to the post_collection CPT
- Keep copied collection items private, matching the normal save path
- Prevent duplicate AJAX requests from repeated clicks while a copy/move is in flight

## Context
Copying a Friends cached post to Gesammeltes inserted rows as friend_post_cache. The Gesammeltes Friends page filters post-collection users to post_collection posts, so the copies existed but were not visible at /friends/gesammeltes/.

## Testing
- php -l class-post-collection.php
- Confirmed the original hidden duplicate rows were deleted
- Manually retried Copy to Gesammeltes and confirmed the copied post appeared