### PR TITLE
Improve full content extraction for noisy pages

### DIFF
--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -1770,6 +1770,7 @@ class Post_Collection {
 	 */
 	public function extract_content( $html, $url ) {
 		$item = new ExtractedPage( $url );
+		$html = $this->prepare_html_for_readability( $html );
 
 		$config = new \andreskrey\Readability\Configuration();
 		$logger = null;
@@ -1818,6 +1819,71 @@ class Post_Collection {
 		}
 
 		return $item;
+	}
+
+	/**
+	 * Remove obvious non-content markup before handing HTML to Readability.
+	 *
+	 * @param string $html HTML to prepare.
+	 * @return string Prepared HTML.
+	 */
+	private function prepare_html_for_readability( $html ) {
+		if ( ! class_exists( '\DOMDocument' ) || ! class_exists( '\DOMXPath' ) ) {
+			return $html;
+		}
+
+		$previous_errors = libxml_use_internal_errors( true );
+		$dom             = new \DOMDocument();
+		$loaded          = $dom->loadHTML( '<?xml encoding="UTF-8">' . $html, LIBXML_NOWARNING | LIBXML_NOERROR );
+
+		if ( ! $loaded ) {
+			libxml_clear_errors();
+			libxml_use_internal_errors( $previous_errors );
+			return $html;
+		}
+
+		$xpath = new \DOMXPath( $dom );
+		$title = '';
+		$title_nodes = $xpath->query( '//title' );
+		if ( $title_nodes && $title_nodes->length ) {
+			$title = trim( $title_nodes->item( 0 )->textContent );
+		}
+
+		$rich_text_blocks = $xpath->query(
+			'//*[contains(concat(" ", normalize-space(@class), " "), " u-rich-text-blog ") and contains(concat(" ", normalize-space(@class), " "), " w-richtext ")]'
+		);
+
+		if ( $rich_text_blocks && $rich_text_blocks->length ) {
+			$body = '';
+			foreach ( $rich_text_blocks as $node ) {
+				$text = trim( preg_replace( '/\s+/', ' ', $node->textContent ) );
+				if ( strlen( $text ) < 100 ) {
+					continue;
+				}
+				$body .= $dom->saveHTML( $node );
+			}
+
+			if ( $body ) {
+				libxml_clear_errors();
+				libxml_use_internal_errors( $previous_errors );
+				return '<html><head><title>' . htmlspecialchars( $title, ENT_QUOTES, 'UTF-8' ) . '</title></head><body><article>' . $body . '</article></body></html>';
+			}
+		}
+
+		$remove_nodes = $xpath->query( '//script|//style|//noscript|//svg|//nav|//header|//footer|//template|//iframe' );
+		if ( $remove_nodes ) {
+			foreach ( iterator_to_array( $remove_nodes ) as $node ) {
+				if ( $node->parentNode ) {
+					$node->parentNode->removeChild( $node );
+				}
+			}
+		}
+
+		$prepared_html = $dom->saveHTML();
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous_errors );
+
+		return $prepared_html ? $prepared_html : $html;
 	}
 
 	public function remove_artificial_line_breaks( $html ) {

--- a/tests/Test_Extract_Content.php
+++ b/tests/Test_Extract_Content.php
@@ -1,0 +1,31 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use PostCollection\Post_Collection;
+
+require_once __DIR__ . '/../class-post-collection.php';
+
+class Post_Collection_Extract_Content_Test_Plugin extends Post_Collection {
+	public function __construct() {}
+}
+
+class Test_Extract_Content extends TestCase {
+	public function test_webflow_rich_text_blocks_are_used_before_script_noise() {
+		$plugin = new Post_Collection_Extract_Content_Test_Plugin();
+		$html   = '<!doctype html><html><head><title>Getting started with loops | Claude by Anthropic</title></head><body>'
+			. '<script>const bubble = ensureBubble(); document.body.appendChild(bubble); const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);'
+			. str_repeat( ' tooltip script content', 120 )
+			. '</script>'
+			. '<main><div class="u-rich-text-blog u-margin-trim w-richtext"><p>There is a lot of talk right now about designing loops instead of prompting your coding agent. This introduction should stay with the article.</p></div>'
+			. '<div class="u-rich-text-blog u-margin-trim w-richtext"><h2>Turn-based loops</h2><p>Every prompt starts a manual loop with Claude gathering context, taking action, checking work, and responding with a useful result.</p></div></main>'
+			. '</body></html>';
+
+		$item = $plugin->extract_content( $html, 'https://claude.com/blog/getting-started-with-loops' );
+
+		$this->assertFalse( is_wp_error( $item ) );
+		$this->assertSame( 'Getting started with loops | Claude by Anthropic', $item->title );
+		$this->assertStringContainsString( 'There is a lot of talk right now', wp_strip_all_tags( $item->content ) );
+		$this->assertStringContainsString( 'Turn-based loops', wp_strip_all_tags( $item->content ) );
+		$this->assertStringNotContainsString( 'tooltip script content', wp_strip_all_tags( $item->content ) );
+	}
+}


### PR DESCRIPTION
## Summary
- preprocess HTML before Readability runs so obvious non-content nodes do not win extraction scoring
- prefer split Webflow rich-text article blocks, which fixes Claude blog pages like /blog/getting-started-with-loops
- add a regression test for noisy Webflow-style HTML with script content before article blocks

## Testing
- php -l class-post-collection.php
- vendor/bin/phpunit tests/Test_Extract_Content.php
- verified the saved Claude page HTML extracts the article intro instead of embedded JavaScript

Full vendor/bin/phpunit currently has unrelated existing bootstrap errors: WP_REST_Request is missing in Test_Browser_Extension_Action.