### PR TITLE
Add frontend article review workflow

### DIFF
--- a/assets/css/post-collection-app.css
+++ b/assets/css/post-collection-app.css
@@ -65,6 +65,13 @@ body.pc-new-collection-page .pc-detail-header {
 	gap: 24px;
 }
 
+.pc-app-header-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+	justify-content: flex-end;
+}
+
 .pc-kicker,
 .pc-source {
 	margin: 0 0 6px;
@@ -648,12 +655,30 @@ body.pc-new-collection-page .pc-detail-header {
 	display: inline-flex;
 	align-items: center;
 	min-height: 20px;
+	border: 0;
 	padding: 2px 7px;
 	border-radius: 999px;
 	background: var(--pc-color-surface-alt);
 	color: var(--pc-color-muted);
+	font-family: inherit;
 	font-size: 0.72rem;
 	font-weight: 700;
+}
+
+.pc-read-status-toggle {
+	cursor: pointer;
+}
+
+.pc-read-status-toggle:hover,
+.pc-read-status-toggle:focus-visible {
+	color: var(--pc-color-primary);
+	outline: 1px solid currentColor;
+	outline-offset: 2px;
+}
+
+.pc-read-status-toggle:disabled {
+	cursor: wait;
+	opacity: 0.7;
 }
 
 .pc-read-status-read {
@@ -958,6 +983,282 @@ body.pc-new-collection-page .pc-detail-header {
 	color: var(--pc-color-on-primary);
 }
 
+.pc-article-notes {
+	display: grid;
+	gap: 14px;
+	margin-top: 18px;
+	padding: 18px;
+	border: 1px solid var(--pc-color-border);
+	border-radius: 8px;
+	background: var(--pc-color-surface);
+}
+
+.pc-article-notes-controls {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 16px;
+	align-items: center;
+	justify-content: space-between;
+}
+
+.pc-note-statuses {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+}
+
+.pc-note-status {
+	min-height: 30px;
+	border: 1px solid var(--pc-color-border);
+	padding: 0 10px;
+	border-radius: 999px;
+	background: var(--pc-color-surface-alt);
+	color: var(--pc-color-muted);
+	font: inherit;
+	font-size: 0.78rem;
+	font-weight: 700;
+	cursor: pointer;
+}
+
+.pc-note-status:hover,
+.pc-note-status:focus-visible {
+	border-color: var(--pc-color-primary);
+	color: var(--pc-color-primary);
+	outline: none;
+}
+
+.pc-note-status.is-active {
+	border-color: var(--pc-color-primary);
+	background: var(--pc-color-primary);
+	color: var(--pc-color-on-primary);
+}
+
+.pc-note-rating {
+	display: flex;
+	gap: 2px;
+}
+
+.pc-note-star {
+	width: 28px;
+	height: 28px;
+	border: 0;
+	padding: 0;
+	background: transparent;
+	color: var(--pc-color-border);
+	font-size: 1.22rem;
+	line-height: 1;
+	cursor: pointer;
+}
+
+.pc-note-star:hover,
+.pc-note-star:focus-visible,
+.pc-note-star.is-previewed,
+.pc-note-star.is-active {
+	color: #b66a00;
+	outline: none;
+}
+
+.pc-note-text {
+	width: 100%;
+	min-height: 120px;
+	border: 1px solid var(--pc-color-border);
+	border-radius: 6px;
+	padding: 10px 12px;
+	background: var(--pc-color-background);
+	color: var(--pc-color-text);
+	font: inherit;
+	resize: vertical;
+}
+
+.pc-note-text:focus {
+	border-color: var(--pc-color-primary);
+	outline: 2px solid color-mix(in srgb, var(--pc-color-primary), transparent 70%);
+	outline-offset: 0;
+}
+
+.pc-article-notes-actions {
+	display: flex;
+	gap: 10px;
+	align-items: center;
+}
+
+.pc-note-save {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 36px;
+	border: 1px solid var(--pc-color-border);
+	padding: 0 12px;
+	border-radius: 6px;
+	background: var(--pc-color-surface-alt);
+	color: var(--pc-color-text);
+	font: inherit;
+	font-weight: 700;
+	cursor: pointer;
+}
+
+.pc-note-save:hover,
+.pc-note-save:focus-visible {
+	border-color: var(--pc-color-primary);
+	color: var(--pc-color-primary);
+	outline: none;
+}
+
+.pc-note-save-status {
+	color: var(--pc-color-muted);
+	font-size: 0.86rem;
+}
+
+.pc-note-save-status.is-error {
+	color: #b32d2e;
+}
+
+.pc-note-save-status.is-saved {
+	color: var(--pc-color-primary);
+}
+
+.pc-review-shell {
+	padding-bottom: 72px;
+}
+
+.pc-review-list {
+	display: grid;
+	gap: 12px;
+}
+
+.pc-review-item.pc-article-notes {
+	margin-top: 0;
+}
+
+.pc-review-item-main {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr);
+	gap: 10px;
+	align-items: start;
+}
+
+.pc-review-item.is-collapsed {
+	gap: 0;
+	cursor: pointer;
+}
+
+.pc-review-item.is-collapsed:hover {
+	border-color: var(--pc-color-primary);
+}
+
+.pc-review-item.is-collapsed .pc-review-title-block h2 a {
+	pointer-events: none;
+}
+
+.pc-review-item.is-collapsed .pc-review-preview,
+.pc-review-item.is-collapsed .pc-review-collapse,
+.pc-review-item.is-collapsed .pc-article-notes-controls,
+.pc-review-item.is-collapsed .pc-note-text,
+.pc-review-item.is-collapsed .pc-article-notes-actions {
+	display: none;
+}
+
+.pc-review-title-block h2 {
+	margin: 0;
+	font-size: 1rem;
+	line-height: 1.25;
+}
+
+.pc-review-title-block p {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin: 4px 0 0;
+	color: var(--pc-color-muted);
+	font-size: 0.82rem;
+}
+
+.pc-review-title-block p span::before {
+	content: "/";
+	margin-right: 8px;
+	color: var(--pc-color-border);
+}
+
+.pc-review-preview {
+	border: 1px solid var(--pc-color-border);
+	border-radius: 6px;
+	background: var(--pc-color-background);
+	overflow: hidden;
+}
+
+.pc-review-preview summary {
+	padding: 8px 10px;
+	color: var(--pc-color-muted);
+	font-size: 0.84rem;
+	font-weight: 700;
+	cursor: pointer;
+}
+
+.pc-review-preview > div {
+	max-height: 260px;
+	padding: 12px 14px;
+	border-top: 1px solid var(--pc-color-border);
+	overflow: auto;
+	font-size: 0.95rem;
+}
+
+.pc-review-collapse {
+	justify-self: start;
+	min-height: 32px;
+	border: 1px solid var(--pc-color-border);
+	padding: 0 10px;
+	border-radius: 6px;
+	background: var(--pc-color-surface-alt);
+	color: var(--pc-color-muted);
+	font: inherit;
+	font-size: 0.82rem;
+	font-weight: 700;
+	cursor: pointer;
+}
+
+.pc-review-collapse:hover,
+.pc-review-collapse:focus-visible {
+	border-color: var(--pc-color-primary);
+	color: var(--pc-color-primary);
+	outline: none;
+}
+
+.pc-review-load-more {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 36px;
+	border: 1px solid var(--pc-color-border);
+	padding: 0 12px;
+	border-radius: 6px;
+	background: var(--pc-color-surface-alt);
+	color: var(--pc-color-text);
+	font: inherit;
+	font-weight: 700;
+	cursor: pointer;
+}
+
+.pc-review-load-more:hover,
+.pc-review-load-more:focus-visible {
+	border-color: var(--pc-color-primary);
+	color: var(--pc-color-primary);
+	outline: none;
+}
+
+.pc-review-load-more {
+	margin-top: 16px;
+}
+
+.pc-review-empty {
+	margin: 0;
+	padding: 20px;
+	border: 1px solid var(--pc-color-border);
+	border-radius: 8px;
+	background: var(--pc-color-surface);
+	color: var(--pc-color-muted);
+	text-align: center;
+}
+
 .pc-detail-footer-actions {
 	margin-top: 18px;
 }
@@ -1033,6 +1334,11 @@ body.pc-new-collection-page .pc-detail-header {
 	.pc-collection-title-row,
 	.pc-post-row {
 		display: block;
+	}
+
+	.pc-app-header-actions {
+		justify-content: flex-start;
+		margin-top: 18px;
 	}
 
 	.pc-app-header h1,

--- a/assets/css/post-collection-app.css
+++ b/assets/css/post-collection-app.css
@@ -1157,6 +1157,18 @@ body.pc-new-collection-page .pc-detail-header {
 	pointer-events: none;
 }
 
+.pc-review-collapsed-meta {
+	display: none;
+}
+
+.pc-review-item.is-collapsed .pc-review-collapsed-meta {
+	display: inline;
+}
+
+.pc-review-item.is-collapsed .pc-review-collapsed-meta:empty {
+	display: none;
+}
+
 .pc-review-item.is-collapsed .pc-review-preview,
 .pc-review-item.is-collapsed .pc-review-collapse,
 .pc-review-item.is-collapsed .pc-article-notes-controls,

--- a/assets/css/post-collection-app.css
+++ b/assets/css/post-collection-app.css
@@ -72,13 +72,6 @@ body.pc-new-collection-page .pc-detail-header {
 	justify-content: flex-end;
 }
 
-.pc-collection-actions {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 10px;
-	margin-top: 18px;
-}
-
 .pc-kicker,
 .pc-source {
 	margin: 0 0 6px;
@@ -118,7 +111,14 @@ body.pc-new-collection-page .pc-detail-header {
 	display: grid;
 	grid-template-columns: minmax(0, 1fr) auto;
 	gap: 24px;
-	align-items: end;
+	align-items: start;
+}
+
+.pc-collection-header-aside {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: 18px;
 }
 
 .pc-collection-stats {
@@ -1346,6 +1346,16 @@ body.pc-new-collection-page .pc-detail-header {
 	.pc-app-header-actions {
 		justify-content: flex-start;
 		margin-top: 18px;
+	}
+
+	.pc-collection-header-aside {
+		align-items: flex-start;
+		margin-top: 18px;
+	}
+
+	.pc-collection-header-aside .pc-app-header-actions,
+	.pc-collection-header-aside .pc-collection-stats {
+		margin-top: 0;
 	}
 
 	.pc-app-header h1,

--- a/assets/css/post-collection-app.css
+++ b/assets/css/post-collection-app.css
@@ -72,6 +72,13 @@ body.pc-new-collection-page .pc-detail-header {
 	justify-content: flex-end;
 }
 
+.pc-collection-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+	margin-top: 18px;
+}
+
 .pc-kicker,
 .pc-source {
 	margin: 0 0 6px;

--- a/assets/js/post-collection-app.js
+++ b/assets/js/post-collection-app.js
@@ -1,13 +1,17 @@
 ( function () {
 	function closest( element, selector ) {
 		while ( element && element !== document ) {
-			if ( element.matches( selector ) ) {
+			if ( matches( element, selector ) ) {
 				return element;
 			}
 			element = element.parentNode;
 		}
 
 		return null;
+	}
+
+	function matches( element, selector ) {
+		return !! ( element && element.matches && element.matches( selector ) );
 	}
 
 	function closeEditors( exceptRow ) {
@@ -295,6 +299,9 @@
 		data.append( '_ajax_nonce', context.nonce || '' );
 		data.append( 'offset', button.dataset.offset || '0' );
 		data.append( 'type', button.dataset.type || 'all' );
+		if ( shell.dataset.collectionId && '0' !== shell.dataset.collectionId ) {
+			data.append( 'collection_id', shell.dataset.collectionId );
+		}
 
 		var originalLabel = button.textContent;
 		button.disabled = true;
@@ -702,7 +709,7 @@
 	} );
 
 	document.addEventListener( 'input', function ( event ) {
-		if ( event.target && event.target.matches( '.pc-note-text' ) ) {
+		if ( matches( event.target, '.pc-note-text' ) ) {
 			queueNoteTextSave( event.target );
 		}
 	} );
@@ -723,7 +730,7 @@
 	} );
 
 	document.addEventListener( 'focusin', function ( event ) {
-		if ( event.target && event.target.matches( '.pc-note-star' ) ) {
+		if ( matches( event.target, '.pc-note-star' ) ) {
 			var ratingContainer = closest( event.target, '.pc-note-rating' );
 			if ( ratingContainer ) {
 				previewNoteStars( ratingContainer, parseInt( event.target.dataset.rating, 10 ) || 0 );
@@ -732,7 +739,7 @@
 	} );
 
 	document.addEventListener( 'focusout', function ( event ) {
-		if ( event.target && event.target.matches( '.pc-note-star' ) ) {
+		if ( matches( event.target, '.pc-note-star' ) ) {
 			var ratingContainer = closest( event.target, '.pc-note-rating' );
 			if ( ratingContainer && ! ratingContainer.contains( event.relatedTarget ) ) {
 				clearNoteStarPreview( ratingContainer );
@@ -741,7 +748,7 @@
 	} );
 
 	document.addEventListener( 'blur', function ( event ) {
-		if ( event.target && event.target.matches( '.pc-note-text' ) ) {
+		if ( matches( event.target, '.pc-note-text' ) ) {
 			var notes = closest( event.target, '.pc-article-notes' );
 			if ( notes ) {
 				saveNoteTextNow( notes );

--- a/assets/js/post-collection-app.js
+++ b/assets/js/post-collection-app.js
@@ -63,6 +63,25 @@
 		}
 	}
 
+	function escapeHtml( value ) {
+		var div = document.createElement( 'div' );
+		div.textContent = value || '';
+		return div.innerHTML;
+	}
+
+	function getReviewShell( element ) {
+		return closest( element, '.pc-review-shell' );
+	}
+
+	function getArticleNotesContext( notes ) {
+		var shell = getReviewShell( notes );
+		return {
+			ajaxAction: notes.dataset.ajaxAction || ( shell ? shell.dataset.ajaxAction : '' ),
+			nonce: notes.dataset.nonce || ( shell ? shell.dataset.nonce : '' ),
+			statuses: shell && shell.dataset.statuses ? JSON.parse( shell.dataset.statuses ) : null,
+		};
+	}
+
 	function updateTags( row, terms ) {
 		var tagContainer = row.querySelector( '.pc-link-tags' );
 		if ( ! tagContainer ) {
@@ -78,14 +97,317 @@
 		} );
 	}
 
-	function updateReadStatus( row, item ) {
-		var readStatus = row.querySelector( '.pc-read-status' );
+	function applyReadStatus( readStatus, item ) {
 		if ( ! readStatus || ! item.read_status ) {
 			return;
 		}
 
-		readStatus.className = 'pc-read-status pc-read-status-' + item.read_status;
+		[ 'unread', 'read', 'skipped', 'archived' ].forEach( function ( status ) {
+			readStatus.classList.remove( 'pc-read-status-' + status );
+		} );
+		readStatus.classList.add( 'pc-read-status-' + item.read_status );
+		readStatus.dataset.readStatus = item.read_status;
 		readStatus.textContent = item.read_label || item.read_status;
+	}
+
+	function updateReadStatus( row, item ) {
+		if ( ! item.read_status ) {
+			return;
+		}
+
+		row.querySelectorAll( '.pc-read-status' ).forEach( function ( readStatus ) {
+			applyReadStatus( readStatus, item );
+		} );
+
+		var select = row.querySelector( '.pc-quick-edit-form select[name="article_status"]' );
+		if ( select ) {
+			select.value = item.read_status;
+		}
+	}
+
+	function updateReadStatusControls( postId, item ) {
+		document.querySelectorAll( '.pc-read-status-toggle[data-post-id="' + postId + '"]' ).forEach( function ( readStatus ) {
+			applyReadStatus( readStatus, item );
+		} );
+	}
+
+	function updateArticleNotesStatus( postId, status ) {
+		var notes = document.querySelector( '.pc-article-notes[data-article-id="' + postId + '"]' );
+		if ( ! notes ) {
+			return;
+		}
+
+		notes.querySelectorAll( '.pc-note-status' ).forEach( function ( button ) {
+			button.classList.toggle( 'is-active', button.dataset.status === status );
+		} );
+	}
+
+	function updateNoteStars( ratingContainer, rating ) {
+		ratingContainer.dataset.rating = rating;
+		ratingContainer.querySelectorAll( '.pc-note-star' ).forEach( function ( star ) {
+			var active = parseInt( star.dataset.rating, 10 ) <= rating;
+			star.classList.toggle( 'is-active', active );
+			star.innerHTML = active ? '&#9733;' : '&#9734;';
+		} );
+	}
+
+	function previewNoteStars( ratingContainer, rating ) {
+		ratingContainer.querySelectorAll( '.pc-note-star' ).forEach( function ( star ) {
+			star.classList.toggle( 'is-previewed', parseInt( star.dataset.rating, 10 ) <= rating );
+		} );
+	}
+
+	function clearNoteStarPreview( ratingContainer ) {
+		ratingContainer.querySelectorAll( '.pc-note-star' ).forEach( function ( star ) {
+			star.classList.remove( 'is-previewed' );
+		} );
+	}
+
+	function setNoteSaveStatus( notes, message, state ) {
+		var status = notes.querySelector( '.pc-note-save-status' );
+		if ( ! status ) {
+			return;
+		}
+
+		status.className = 'pc-note-save-status' + ( state ? ' is-' + state : '' );
+		status.textContent = message || '';
+	}
+
+	function setReviewItemCollapsed( item, collapsed ) {
+		if ( ! item || ! item.classList.contains( 'pc-review-item' ) ) {
+			return;
+		}
+
+		item.classList.toggle( 'is-collapsed', collapsed );
+	}
+
+	function updateReviewItemCollapseForStatus( item, status ) {
+		setReviewItemCollapsed( item, 'read' === status || 'skipped' === status );
+	}
+
+	function saveArticleNote( notes, data ) {
+		var context = getArticleNotesContext( notes );
+		var postData = new FormData();
+		postData.append( 'action', 'post_collection_save_note' );
+		postData.append( '_ajax_nonce', context.nonce || '' );
+		postData.append( 'article_id', notes.dataset.articleId || '' );
+
+		Object.keys( data ).forEach( function ( key ) {
+			postData.append( key, data[ key ] );
+		} );
+
+		setNoteSaveStatus( notes, 'Saving...', 'saving' );
+
+		return fetch( context.ajaxAction, {
+			method: 'POST',
+			credentials: 'same-origin',
+			body: postData,
+		} )
+			.then( function ( response ) {
+				return response.json();
+			} )
+			.then( function ( result ) {
+				if ( ! result || ! result.success ) {
+					throw new Error( result && result.data ? result.data : 'Could not save note.' );
+				}
+
+				setNoteSaveStatus( notes, 'Saved', 'saved' );
+				window.setTimeout( function () {
+					setNoteSaveStatus( notes, '', '' );
+				}, 2000 );
+
+				return result;
+			} )
+			.catch( function ( error ) {
+				setNoteSaveStatus( notes, error.message || 'Error saving', 'error' );
+				throw error;
+		} );
+	}
+
+	function getReviewList( shell, list ) {
+		return shell ? shell.querySelector( '.pc-review-list[data-review-list="' + list + '"]' ) : null;
+	}
+
+	function getReviewStatuses( shell ) {
+		if ( ! shell || ! shell.dataset.statuses ) {
+			return {
+				unread: 'Not read yet',
+				read: 'Read',
+				skipped: 'Skipped',
+			};
+		}
+
+		return JSON.parse( shell.dataset.statuses );
+	}
+
+	function renderReviewArticle( article, context, shell ) {
+		var statuses = getReviewStatuses( shell );
+		var rating = parseInt( article.rating, 10 ) || 0;
+		var status = article.status || 'unread';
+		var isCollapsed = 'read' === status || 'skipped' === status;
+		var html = '<article class="pc-review-item' + ( isCollapsed ? ' is-collapsed' : '' ) + ' pc-article-notes" data-article-id="' + article.id + '">';
+		html += '<div class="pc-review-item-main">';
+		html += '<div class="pc-review-title-block"><h2><a href="' + escapeHtml( article.permalink ) + '">' + escapeHtml( article.title ) + '</a></h2><p>' + escapeHtml( article.author || '' );
+		if ( article.collection && article.collection !== article.author ) {
+			html += '<span>' + escapeHtml( article.collection ) + '</span>';
+		}
+		if ( article.sent_label ) {
+			html += '<span>';
+			if ( article.sent_datetime ) {
+				html += '<time datetime="' + escapeHtml( article.sent_datetime ) + '">' + escapeHtml( article.sent_label ) + '</time>';
+			} else {
+				html += escapeHtml( article.sent_label );
+			}
+			html += '</span>';
+		}
+		html += '</p></div></div>';
+		if ( article.content ) {
+			html += '<details class="pc-review-preview"><summary>Show article</summary><div>' + article.content + '</div></details>';
+			html += '<button type="button" class="pc-review-collapse">Collapse</button>';
+		}
+		html += '<div class="pc-article-notes-controls"><div class="pc-note-statuses" aria-label="Reading status">';
+		Object.keys( statuses ).forEach( function ( key ) {
+			html += '<button type="button" class="pc-note-status' + ( status === key ? ' is-active' : '' ) + '" data-status="' + escapeHtml( key ) + '">' + escapeHtml( statuses[ key ] ) + '</button>';
+		} );
+		html += '</div><div class="pc-note-rating" aria-label="Rating" data-rating="' + rating + '">';
+		for ( var i = 1; i <= 5; i++ ) {
+			html += '<button type="button" class="pc-note-star' + ( i <= rating ? ' is-active' : '' ) + '" data-rating="' + i + '" aria-label="' + i + ' stars">' + ( i <= rating ? '&#9733;' : '&#9734;' ) + '</button>';
+		}
+		html += '</div></div>';
+		html += '<label class="screen-reader-text" for="pc-review-notes-' + article.id + '">Article notes</label>';
+		html += '<textarea id="pc-review-notes-' + article.id + '" class="pc-note-text" rows="3" placeholder="Add your notes...">' + escapeHtml( article.notes || '' ) + '</textarea>';
+		html += '<div class="pc-article-notes-actions"><button type="button" class="pc-note-save">Save</button>';
+		html += '<span class="pc-note-save-status" aria-live="polite"></span></div></article>';
+		return html;
+	}
+
+	function loadMoreReviewArticles( button ) {
+		var shell = getReviewShell( button );
+		var listName = button.dataset.list || 'pending';
+		var list = getReviewList( shell, listName );
+		var context = getArticleNotesContext( shell );
+		if ( ! shell || ! list ) {
+			return;
+		}
+
+		var data = new FormData();
+		data.append( 'action', 'post_collection_load_more_pending' );
+		data.append( '_ajax_nonce', context.nonce || '' );
+		data.append( 'offset', button.dataset.offset || '0' );
+		data.append( 'type', button.dataset.type || 'all' );
+
+		var originalLabel = button.textContent;
+		button.disabled = true;
+		button.textContent = 'Loading...';
+
+		fetch( context.ajaxAction, {
+			method: 'POST',
+			credentials: 'same-origin',
+			body: data,
+		} )
+			.then( function ( response ) {
+				return response.json();
+			} )
+			.then( function ( result ) {
+				if ( ! result || ! result.success ) {
+					throw new Error( 'Could not load articles.' );
+				}
+
+				result.data.articles.forEach( function ( article ) {
+					list.insertAdjacentHTML( 'beforeend', renderReviewArticle( article, listName, shell ) );
+				} );
+
+				button.dataset.offset = result.data.offset;
+				if ( ! result.data.has_more ) {
+					button.remove();
+				}
+			} )
+			.catch( function () {
+				button.disabled = false;
+				button.textContent = originalLabel;
+			} )
+			.finally( function () {
+				if ( button.parentNode ) {
+					button.disabled = false;
+					button.textContent = originalLabel;
+				}
+			} );
+	}
+
+	function toggleReadStatus( toggle ) {
+		if ( toggle.disabled ) {
+			return;
+		}
+
+		var data = new FormData();
+		data.append( 'action', 'post_collection_toggle_read_status' );
+		data.append( 'post_id', toggle.dataset.postId || '' );
+		data.append( '_wpnonce', toggle.dataset.nonce || '' );
+
+		toggle.disabled = true;
+		toggle.setAttribute( 'aria-busy', 'true' );
+
+		fetch( toggle.dataset.ajaxAction, {
+			method: 'POST',
+			credentials: 'same-origin',
+			body: data,
+		} )
+			.then( function ( response ) {
+				return response.json();
+			} )
+			.then( function ( result ) {
+				if ( ! result || ! result.success ) {
+					throw new Error( result && result.data && result.data.message ? result.data.message : 'Could not save reading status.' );
+				}
+
+				updateReadStatusControls( result.data.id, result.data );
+				updateArticleNotesStatus( result.data.id, result.data.read_status );
+				var row = closest( toggle, '.pc-link-row' );
+				if ( row ) {
+					updateReadStatus( row, result.data );
+				}
+			} )
+			.catch( function ( error ) {
+				toggle.title = error.message;
+			} )
+			.finally( function () {
+				toggle.disabled = false;
+				toggle.removeAttribute( 'aria-busy' );
+			} );
+	}
+
+	var noteSaveTimers = {};
+
+	function queueNoteTextSave( textarea ) {
+		var notes = closest( textarea, '.pc-article-notes' );
+		if ( ! notes ) {
+			return;
+		}
+
+		var articleId = notes.dataset.articleId || '';
+		if ( noteSaveTimers[ articleId ] ) {
+			window.clearTimeout( noteSaveTimers[ articleId ] );
+		}
+
+		noteSaveTimers[ articleId ] = window.setTimeout( function () {
+			delete noteSaveTimers[ articleId ];
+			saveArticleNote( notes, { notes: textarea.value } ).catch( function () {} );
+		}, 1000 );
+	}
+
+	function saveNoteTextNow( notes ) {
+		var textarea = notes.querySelector( '.pc-note-text' );
+		if ( ! textarea ) {
+			return;
+		}
+
+		var articleId = notes.dataset.articleId || '';
+		if ( noteSaveTimers[ articleId ] ) {
+			window.clearTimeout( noteSaveTimers[ articleId ] );
+			delete noteSaveTimers[ articleId ];
+		}
+
+		saveArticleNote( notes, { notes: textarea.value } ).catch( function () {} );
 	}
 
 	function getCollectionList() {
@@ -283,6 +605,82 @@
 	}
 
 	document.addEventListener( 'click', function ( event ) {
+		var loadMoreReview = closest( event.target, '.pc-review-load-more' );
+		if ( loadMoreReview ) {
+			event.preventDefault();
+			loadMoreReviewArticles( loadMoreReview );
+			return;
+		}
+
+		var collapseReview = closest( event.target, '.pc-review-collapse' );
+		if ( collapseReview ) {
+			var collapseItem = closest( collapseReview, '.pc-review-item' );
+			if ( collapseItem ) {
+				event.preventDefault();
+				setReviewItemCollapsed( collapseItem, true );
+			}
+			return;
+		}
+
+		var readStatus = closest( event.target, '.pc-read-status-toggle' );
+		if ( readStatus ) {
+			event.preventDefault();
+			toggleReadStatus( readStatus );
+			return;
+		}
+
+		var noteStatus = closest( event.target, '.pc-note-status' );
+		if ( noteStatus ) {
+			var statusNotes = closest( noteStatus, '.pc-article-notes' );
+			if ( statusNotes ) {
+				event.preventDefault();
+				statusNotes.querySelectorAll( '.pc-note-status' ).forEach( function ( button ) {
+					button.classList.toggle( 'is-active', button === noteStatus );
+				} );
+				saveArticleNote( statusNotes, { status: noteStatus.dataset.status || '' } )
+					.then( function () {
+						var reviewItem = closest( statusNotes, '.pc-review-item' );
+						updateReadStatusControls( statusNotes.dataset.articleId, {
+							read_status: noteStatus.dataset.status || '',
+							read_label: noteStatus.textContent.trim(),
+						} );
+						updateReviewItemCollapseForStatus( reviewItem, noteStatus.dataset.status || '' );
+					} )
+					.catch( function () {} );
+			}
+			return;
+		}
+
+		var noteStar = closest( event.target, '.pc-note-star' );
+		if ( noteStar ) {
+			var ratingNotes = closest( noteStar, '.pc-article-notes' );
+			var ratingContainer = closest( noteStar, '.pc-note-rating' );
+			if ( ratingNotes && ratingContainer ) {
+				event.preventDefault();
+				var rating = parseInt( noteStar.dataset.rating, 10 ) || 0;
+				updateNoteStars( ratingContainer, rating );
+				saveArticleNote( ratingNotes, { rating: rating } ).catch( function () {} );
+			}
+			return;
+		}
+
+		var saveNote = closest( event.target, '.pc-note-save' );
+		if ( saveNote ) {
+			var saveNotes = closest( saveNote, '.pc-article-notes' );
+			if ( saveNotes ) {
+				event.preventDefault();
+				saveNoteTextNow( saveNotes );
+			}
+			return;
+		}
+
+		var collapsedReviewItem = closest( event.target, '.pc-review-item.is-collapsed' );
+		if ( collapsedReviewItem && ! closest( event.target, 'a, button, input, textarea, select, details, summary' ) ) {
+			event.preventDefault();
+			setReviewItemCollapsed( collapsedReviewItem, false );
+			return;
+		}
+
 		var editLink = closest( event.target, '.pc-quick-edit-open' );
 		if ( editLink ) {
 			var row = closest( editLink, '.pc-link-row' );
@@ -302,6 +700,54 @@
 			}
 		}
 	} );
+
+	document.addEventListener( 'input', function ( event ) {
+		if ( event.target && event.target.matches( '.pc-note-text' ) ) {
+			queueNoteTextSave( event.target );
+		}
+	} );
+
+	document.addEventListener( 'mouseover', function ( event ) {
+		var noteStar = closest( event.target, '.pc-note-star' );
+		var ratingContainer = noteStar ? closest( noteStar, '.pc-note-rating' ) : null;
+		if ( ratingContainer ) {
+			previewNoteStars( ratingContainer, parseInt( noteStar.dataset.rating, 10 ) || 0 );
+		}
+	} );
+
+	document.addEventListener( 'mouseout', function ( event ) {
+		var ratingContainer = closest( event.target, '.pc-note-rating' );
+		if ( ratingContainer && ! ratingContainer.contains( event.relatedTarget ) ) {
+			clearNoteStarPreview( ratingContainer );
+		}
+	} );
+
+	document.addEventListener( 'focusin', function ( event ) {
+		if ( event.target && event.target.matches( '.pc-note-star' ) ) {
+			var ratingContainer = closest( event.target, '.pc-note-rating' );
+			if ( ratingContainer ) {
+				previewNoteStars( ratingContainer, parseInt( event.target.dataset.rating, 10 ) || 0 );
+			}
+		}
+	} );
+
+	document.addEventListener( 'focusout', function ( event ) {
+		if ( event.target && event.target.matches( '.pc-note-star' ) ) {
+			var ratingContainer = closest( event.target, '.pc-note-rating' );
+			if ( ratingContainer && ! ratingContainer.contains( event.relatedTarget ) ) {
+				clearNoteStarPreview( ratingContainer );
+			}
+		}
+	} );
+
+	document.addEventListener( 'blur', function ( event ) {
+		if ( event.target && event.target.matches( '.pc-note-text' ) ) {
+			var notes = closest( event.target, '.pc-article-notes' );
+			if ( notes ) {
+				saveNoteTextNow( notes );
+			}
+		}
+	}, true );
 
 	document.addEventListener( 'submit', function ( event ) {
 		var form = closest( event.target, '.pc-quick-edit-form' );

--- a/assets/js/post-collection-app.js
+++ b/assets/js/post-collection-app.js
@@ -189,6 +189,17 @@
 		setReviewItemCollapsed( item, 'read' === status || 'skipped' === status );
 	}
 
+	function getCollapsedStatusLabel( status, label ) {
+		return 'read' === status || 'skipped' === status ? label : '';
+	}
+
+	function updateReviewItemCollapsedStatus( item, label ) {
+		var status = item ? item.querySelector( '.pc-review-collapsed-status' ) : null;
+		if ( status ) {
+			status.textContent = label || '';
+		}
+	}
+
 	function saveArticleNote( notes, data ) {
 		var context = getArticleNotesContext( notes );
 		var postData = new FormData();
@@ -263,6 +274,11 @@
 				html += escapeHtml( article.sent_label );
 			}
 			html += '</span>';
+		}
+		html += '<span class="pc-review-collapsed-meta pc-review-collapsed-status">' + escapeHtml( getCollapsedStatusLabel( status, statuses[ status ] || status ) ) + '</span>';
+		if ( parseInt( article.summary_word_count, 10 ) > 0 ) {
+			var summaryWordCount = parseInt( article.summary_word_count, 10 );
+			html += '<span class="pc-review-collapsed-meta">' + summaryWordCount + ' summary ' + ( 1 === summaryWordCount ? 'word' : 'words' ) + '</span>';
 		}
 		html += '</p></div></div>';
 		if ( article.content ) {
@@ -651,6 +667,7 @@
 							read_status: noteStatus.dataset.status || '',
 							read_label: noteStatus.textContent.trim(),
 						} );
+						updateReviewItemCollapsedStatus( reviewItem, getCollapsedStatusLabel( noteStatus.dataset.status || '', noteStatus.textContent.trim() ) );
 						updateReviewItemCollapseForStatus( reviewItem, noteStatus.dataset.status || '' );
 					} )
 					.catch( function () {} );

--- a/class-post-collection-app.php
+++ b/class-post-collection-app.php
@@ -91,10 +91,12 @@ class Post_Collection_App {
 		add_action( 'wp_loaded', array( $this, 'handle_collection_settings' ) );
 		add_action( 'wp_loaded', array( $this, 'handle_create_collection' ) );
 		add_action( 'wp_ajax_post_collection_quick_edit', array( $this, 'wp_ajax_quick_edit' ) );
+		add_action( 'wp_ajax_post_collection_toggle_read_status', array( $this, 'wp_ajax_toggle_read_status' ) );
 		add_filter( 'private_title_format', array( $this, 'filter_private_title_format' ), 10, 2 );
 
 		$this->app->route( '' );
 		$this->app->route( 'new', 'new.php' );
+		$this->app->route( 'review', 'review.php' );
 		$this->app->route( '{collection}/settings', 'settings.php' );
 		$this->app->route( '{collection}', 'collection.php' );
 		$this->app->route( '{collection}/{post_id}', 'post.php' );
@@ -106,6 +108,11 @@ class Post_Collection_App {
 		);
 
 		if ( current_user_can( $this->post_collection->get_required_role() ) ) {
+			$this->app->add_menu_item(
+				'review',
+				__( 'Review Articles', 'post-collection' ),
+				$this->get_review_url()
+			);
 			$this->app->add_menu_item(
 				'new-collection',
 				__( 'New Collection', 'post-collection' ),
@@ -157,6 +164,15 @@ class Post_Collection_App {
 	 */
 	public function get_new_collection_url() {
 		return home_url( '/' . self::PATH . '/new/' );
+	}
+
+	/**
+	 * Get the review queue URL.
+	 *
+	 * @return string
+	 */
+	public function get_review_url() {
+		return home_url( '/' . self::PATH . '/review/' );
 	}
 
 	/**
@@ -552,6 +568,60 @@ class Post_Collection_App {
 	}
 
 	/**
+	 * Toggle a collected post between unread and read.
+	 */
+	public function wp_ajax_toggle_read_status() {
+		if ( ! $this->can_manage_collections() ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'Sorry, you are not allowed to edit this collection.', 'post-collection' ),
+				),
+				403
+			);
+		}
+
+		$post_id = isset( $_POST['post_id'] ) ? absint( wp_unslash( $_POST['post_id'] ) ) : 0;
+		if ( ! $post_id || ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'post-collection-toggle-read-status-' . $post_id ) ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'The reading status request could not be verified.', 'post-collection' ),
+				),
+				403
+			);
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post || Post_Collection::CPT !== $post->post_type ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'That post does not exist.', 'post-collection' ),
+				),
+				404
+			);
+		}
+
+		$current_status = $this->get_article_note_status( $post );
+		$next_status    = Article_Notes::STATUS_READ === $current_status ? Article_Notes::STATUS_UNREAD : Article_Notes::STATUS_READ;
+		$note_id        = $this->post_collection->get_article_notes()->save_note( $post_id, $next_status );
+		if ( ! $note_id ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'The reading status could not be saved.', 'post-collection' ),
+				),
+				500
+			);
+		}
+
+		wp_send_json_success(
+			array(
+				'id'          => $post_id,
+				'read_status' => $next_status,
+				'read_label'  => $this->get_article_note_status_label( $next_status ),
+			)
+		);
+	}
+
+	/**
 	 * Update a post from quick edit request data.
 	 *
 	 * @param array $data Request data.
@@ -682,6 +752,32 @@ class Post_Collection_App {
 	public function get_article_note_status_label( $status ) {
 		$statuses = $this->get_article_statuses();
 		return isset( $statuses[ $status ] ) ? $statuses[ $status ] : $statuses[ Article_Notes::STATUS_UNREAD ];
+	}
+
+	/**
+	 * Render an interactive reading status label.
+	 *
+	 * @param \WP_Post $post   The post.
+	 * @param string   $status Optional reading status.
+	 */
+	public function render_article_note_status_toggle( \WP_Post $post, $status = '' ) {
+		if ( ! $this->can_manage_collections() ) {
+			return;
+		}
+
+		$status = $status ? $status : $this->get_article_note_status( $post );
+		$label  = $this->get_article_note_status_label( $status );
+		?>
+		<button
+			type="button"
+			class="pc-read-status pc-read-status-toggle pc-read-status-<?php echo esc_attr( $status ); ?>"
+			data-ajax-action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>"
+			data-post-id="<?php echo esc_attr( $post->ID ); ?>"
+			data-nonce="<?php echo esc_attr( wp_create_nonce( 'post-collection-toggle-read-status-' . $post->ID ) ); ?>"
+			data-read-status="<?php echo esc_attr( $status ); ?>"
+			aria-label="<?php echo esc_attr( sprintf( __( 'Toggle reading status for %s', 'post-collection' ), get_the_title( $post ) ) ); ?>"
+		><?php echo esc_html( $label ); ?></button>
+		<?php
 	}
 
 	/**

--- a/class-post-collection-app.php
+++ b/class-post-collection-app.php
@@ -98,6 +98,7 @@ class Post_Collection_App {
 		$this->app->route( 'new', 'new.php' );
 		$this->app->route( 'review', 'review.php' );
 		$this->app->route( '{collection}/settings', 'settings.php' );
+		$this->app->route( '{collection}/review', 'review.php' );
 		$this->app->route( '{collection}', 'collection.php' );
 		$this->app->route( '{collection}/{post_id}', 'post.php' );
 
@@ -173,6 +174,16 @@ class Post_Collection_App {
 	 */
 	public function get_review_url() {
 		return home_url( '/' . self::PATH . '/review/' );
+	}
+
+	/**
+	 * Get the review queue URL for a collection.
+	 *
+	 * @param \WP_Term $collection The collection term.
+	 * @return string
+	 */
+	public function get_collection_review_url( $collection ) {
+		return trailingslashit( $this->get_collection_url( $collection ) . 'review' );
 	}
 
 	/**

--- a/includes/class-article-notes.php
+++ b/includes/class-article-notes.php
@@ -840,6 +840,8 @@ class Article_Notes {
 		$content = $post->post_content;
 		$content = preg_replace( '/<img[^>]*>/i', '', $content );
 		$content = preg_replace( '/<figure[^>]*>.*?<\/figure>/is', '', $content );
+		$excerpt = get_the_excerpt( $post );
+		$summary_word_count = str_word_count( wp_strip_all_tags( $excerpt ) );
 
 		// Use the per-post author meta if available.
 		$author = get_post_meta( $post->ID, 'author', true );
@@ -860,7 +862,8 @@ class Article_Notes {
 			'sent_datetime' => $sent_datetime,
 			'sent_label'  => $sent_label,
 			'sent_timestamp' => $sent_timestamp,
-			'excerpt'     => get_the_excerpt( $post ),
+			'excerpt'     => $excerpt,
+			'summary_word_count' => $summary_word_count,
 			'content'     => wp_kses_post( $content ),
 			'note_id'     => $note ? $note['id'] : 0,
 			'status'      => $note ? $note['status'] : self::STATUS_UNREAD,

--- a/includes/class-article-notes.php
+++ b/includes/class-article-notes.php
@@ -610,7 +610,7 @@ class Article_Notes {
 	 * @param int $limit Maximum number of articles to return.
 	 * @return array Array of post objects with note data.
 	 */
-	public function get_reviewed_articles( $limit = 20 ) {
+	public function get_reviewed_articles( $limit = 20, $offset = 0 ) {
 		// Get note IDs with read or skipped status.
 		$note_ids = get_posts(
 			array(
@@ -648,6 +648,7 @@ class Article_Notes {
 		$args = array(
 			'post_type'      => $this->get_article_post_types(),
 			'posts_per_page' => $limit,
+			'offset'         => $offset,
 			'post_status'    => 'any',
 			'post__in'       => $article_ids,
 			'orderby'        => 'post__in',
@@ -656,6 +657,48 @@ class Article_Notes {
 		$posts = get_posts( $args );
 
 		return array_map( array( $this, 'prepare_article_data' ), $posts );
+	}
+
+	/**
+	 * Get the unified review queue, including pending, unread, read, and skipped articles.
+	 *
+	 * @param int $limit  Maximum number of articles to return.
+	 * @param int $offset Number of articles to skip.
+	 * @return array Array of article data.
+	 */
+	public function get_review_queue_articles( $limit = 20, $offset = 0 ) {
+		$query_limit = max( $limit + $offset, $limit );
+		$articles    = array_merge(
+			$this->get_pending_and_unread_articles( $query_limit ),
+			$this->get_reviewed_articles( $query_limit )
+		);
+
+		$seen   = array();
+		$result = array();
+		foreach ( $articles as $article ) {
+			if ( isset( $seen[ $article['id'] ] ) ) {
+				continue;
+			}
+
+			$seen[ $article['id'] ] = true;
+			$result[] = $article;
+		}
+
+		usort(
+			$result,
+			static function ( $a, $b ) {
+				$a_order = ! empty( $a['sent_timestamp'] ) ? (int) $a['sent_timestamp'] : (int) $a['id'];
+				$b_order = ! empty( $b['sent_timestamp'] ) ? (int) $b['sent_timestamp'] : (int) $b['id'];
+
+				if ( $a_order === $b_order ) {
+					return (int) $b['id'] - (int) $a['id'];
+				}
+
+				return $b_order - $a_order;
+			}
+		);
+
+		return array_slice( $result, $offset, $limit );
 	}
 
 	/**
@@ -721,11 +764,46 @@ class Article_Notes {
 	private function prepare_article_data( $post ) {
 		$note = $this->get_note( $post->ID );
 		$queued_meta_key = apply_filters( 'post_collection_article_queued_orderby_meta_key', '' );
+		$sent_timestamp = 0;
 		$sent_date = '';
+		$sent_datetime = '';
+		$sent_label = '';
 		if ( ! empty( $queued_meta_key ) ) {
-			$timestamp = get_post_meta( $post->ID, $queued_meta_key, true );
-			if ( $timestamp ) {
-				$sent_date = date_i18n( get_option( 'date_format' ), $timestamp );
+			$sent_timestamp = (int) get_post_meta( $post->ID, $queued_meta_key, true );
+		}
+
+		/**
+		 * Filter the timestamp for when an article entered the review queue.
+		 *
+		 * Plugins can use this to supply a more specific source timestamp than
+		 * the generic queued/orderby meta key.
+		 *
+		 * @param int      $sent_timestamp Unix timestamp.
+		 * @param \WP_Post $post           Article post.
+		 * @param string   $queued_meta_key Meta key used for queued articles.
+		 */
+		$sent_timestamp = (int) apply_filters( 'post_collection_article_sent_timestamp', $sent_timestamp, $post, $queued_meta_key );
+		if ( $sent_timestamp ) {
+			$date_format   = get_option( 'date_format' );
+			$time_format   = get_option( 'time_format' );
+			$sent_date     = date_i18n( $date_format, $sent_timestamp );
+			$sent_datetime = date_i18n( 'c', $sent_timestamp );
+			$sent_label    = sprintf(
+				/* translators: %s is a formatted date and time. */
+				__( 'Sent to e-reader %s', 'post-collection' ),
+				date_i18n( $date_format . ' ' . $time_format, $sent_timestamp )
+			);
+
+			/**
+			 * Filter the human-readable sent-to-reader label.
+			 *
+			 * @param string   $sent_label     Human-readable label.
+			 * @param int      $sent_timestamp Unix timestamp.
+			 * @param \WP_Post $post           Article post.
+			 */
+			$sent_label = apply_filters( 'post_collection_article_sent_label', $sent_label, $sent_timestamp, $post );
+			if ( ! is_string( $sent_label ) ) {
+				$sent_label = '';
 			}
 		}
 
@@ -750,6 +828,9 @@ class Article_Notes {
 			'author'      => $author,
 			'collection'  => $user->display_name,
 			'sent_date'   => $sent_date,
+			'sent_datetime' => $sent_datetime,
+			'sent_label'  => $sent_label,
+			'sent_timestamp' => $sent_timestamp,
 			'excerpt'     => get_the_excerpt( $post ),
 			'content'     => wp_kses_post( $content ),
 			'note_id'     => $note ? $note['id'] : 0,
@@ -945,8 +1026,14 @@ class Article_Notes {
 		$type = isset( $_POST['type'] ) ? sanitize_text_field( wp_unslash( $_POST['type'] ) ) : 'pending';
 		$limit = 10;
 
-		if ( 'unread' === $type ) {
+		if ( 'queue' === $type ) {
+			$articles = $this->get_review_queue_articles( $limit + 1, $offset );
+		} elseif ( 'reviewed' === $type ) {
+			$articles = $this->get_reviewed_articles( $limit + 1, $offset );
+		} elseif ( 'unread' === $type ) {
 			$articles = $this->get_unread_articles( $limit + 1, $offset );
+		} elseif ( 'all' === $type ) {
+			$articles = $this->get_pending_and_unread_articles( $limit + 1, $offset );
 		} else {
 			$articles = $this->get_pending_articles( $limit + 1, $offset );
 		}

--- a/includes/class-article-notes.php
+++ b/includes/class-article-notes.php
@@ -477,13 +477,34 @@ class Article_Notes {
 	}
 
 	/**
+	 * Apply optional filters to article queries.
+	 *
+	 * @param array $query_args Query arguments.
+	 * @param array $args       Optional filter arguments.
+	 * @return array Filtered query arguments.
+	 */
+	private function apply_article_query_args( array $query_args, array $args = array() ) {
+		if ( ! empty( $args['collection_id'] ) ) {
+			$query_args['tax_query'] = isset( $query_args['tax_query'] ) ? (array) $query_args['tax_query'] : array();
+			$query_args['tax_query'][] = array(
+				'taxonomy' => Post_Collection::COLLECTION_TAXONOMY,
+				'field'    => 'term_id',
+				'terms'    => absint( $args['collection_id'] ),
+			);
+		}
+
+		return $query_args;
+	}
+
+	/**
 	 * Get articles that have been downloaded but not yet reviewed.
 	 *
 	 * @param int $limit  Maximum number of articles to return.
 	 * @param int $offset Number of articles to skip.
+	 * @param array $args Optional filter arguments.
 	 * @return array Array of post objects with note data.
 	 */
-	public function get_pending_articles( $limit = 20, $offset = 0 ) {
+	public function get_pending_articles( $limit = 20, $offset = 0, array $args = array() ) {
 		$meta_query = apply_filters( 'post_collection_article_queued_meta_query', array() );
 		$meta_query[] = array(
 			'key'     => self::NOTE_ID_META,
@@ -494,7 +515,7 @@ class Article_Notes {
 			array_unshift( $meta_query, array( 'relation' => 'AND' ) );
 		}
 
-		$args = array(
+		$query_args = array(
 			'post_type'      => $this->get_article_post_types(),
 			'posts_per_page' => $limit,
 			'offset'         => $offset,
@@ -506,11 +527,12 @@ class Article_Notes {
 
 		$queued_meta_key = apply_filters( 'post_collection_article_queued_orderby_meta_key', '' );
 		if ( ! empty( $queued_meta_key ) ) {
-			$args['orderby'] = 'meta_value_num';
-			$args['meta_key'] = $queued_meta_key;
+			$query_args['orderby'] = 'meta_value_num';
+			$query_args['meta_key'] = $queued_meta_key;
 		}
 
-		$posts = get_posts( $args );
+		$query_args = $this->apply_article_query_args( $query_args, $args );
+		$posts = get_posts( $query_args );
 
 		return array_map( array( $this, 'prepare_article_data' ), $posts );
 	}
@@ -520,11 +542,12 @@ class Article_Notes {
 	 *
 	 * @param int $limit  Maximum number of articles to return.
 	 * @param int $offset Number of articles to skip.
+	 * @param array $args Optional filter arguments.
 	 * @return array Combined array of pending and unread articles.
 	 */
-	public function get_pending_and_unread_articles( $limit = 20, $offset = 0 ) {
-		$pending = $this->get_pending_articles( $limit, $offset );
-		$unread = $this->get_unread_articles( $limit, $offset );
+	public function get_pending_and_unread_articles( $limit = 20, $offset = 0, array $args = array() ) {
+		$pending = $this->get_pending_articles( $limit, $offset, $args );
+		$unread = $this->get_unread_articles( $limit, $offset, $args );
 
 		$combined = array_merge( $pending, $unread );
 
@@ -554,9 +577,10 @@ class Article_Notes {
 	 *
 	 * @param int $limit  Maximum number of articles to return.
 	 * @param int $offset Number of articles to skip.
+	 * @param array $args Optional filter arguments.
 	 * @return array Array of post objects with note data.
 	 */
-	public function get_unread_articles( $limit = 20, $offset = 0 ) {
+	public function get_unread_articles( $limit = 20, $offset = 0, array $args = array() ) {
 		// Get note IDs with unread status.
 		$note_ids = get_posts(
 			array(
@@ -590,7 +614,7 @@ class Article_Notes {
 			return array();
 		}
 
-		$args = array(
+		$query_args = array(
 			'post_type'      => $this->get_article_post_types(),
 			'posts_per_page' => $limit,
 			'offset'         => $offset,
@@ -599,7 +623,8 @@ class Article_Notes {
 			'orderby'        => 'post__in',
 		);
 
-		$posts = get_posts( $args );
+		$query_args = $this->apply_article_query_args( $query_args, $args );
+		$posts = get_posts( $query_args );
 
 		return array_map( array( $this, 'prepare_article_data' ), $posts );
 	}
@@ -608,9 +633,11 @@ class Article_Notes {
 	 * Get articles that have been reviewed (read or skipped).
 	 *
 	 * @param int $limit Maximum number of articles to return.
+	 * @param int $offset Number of articles to skip.
+	 * @param array $args Optional filter arguments.
 	 * @return array Array of post objects with note data.
 	 */
-	public function get_reviewed_articles( $limit = 20, $offset = 0 ) {
+	public function get_reviewed_articles( $limit = 20, $offset = 0, array $args = array() ) {
 		// Get note IDs with read or skipped status.
 		$note_ids = get_posts(
 			array(
@@ -645,7 +672,7 @@ class Article_Notes {
 			return array();
 		}
 
-		$args = array(
+		$query_args = array(
 			'post_type'      => $this->get_article_post_types(),
 			'posts_per_page' => $limit,
 			'offset'         => $offset,
@@ -654,7 +681,8 @@ class Article_Notes {
 			'orderby'        => 'post__in',
 		);
 
-		$posts = get_posts( $args );
+		$query_args = $this->apply_article_query_args( $query_args, $args );
+		$posts = get_posts( $query_args );
 
 		return array_map( array( $this, 'prepare_article_data' ), $posts );
 	}
@@ -664,13 +692,14 @@ class Article_Notes {
 	 *
 	 * @param int $limit  Maximum number of articles to return.
 	 * @param int $offset Number of articles to skip.
+	 * @param array $args Optional filter arguments.
 	 * @return array Array of article data.
 	 */
-	public function get_review_queue_articles( $limit = 20, $offset = 0 ) {
+	public function get_review_queue_articles( $limit = 20, $offset = 0, array $args = array() ) {
 		$query_limit = max( $limit + $offset, $limit );
 		$articles    = array_merge(
-			$this->get_pending_and_unread_articles( $query_limit ),
-			$this->get_reviewed_articles( $query_limit )
+			$this->get_pending_and_unread_articles( $query_limit, 0, $args ),
+			$this->get_reviewed_articles( $query_limit, 0, $args )
 		);
 
 		$seen   = array();
@@ -1025,17 +1054,21 @@ class Article_Notes {
 		$offset = isset( $_POST['offset'] ) ? (int) $_POST['offset'] : 0;
 		$type = isset( $_POST['type'] ) ? sanitize_text_field( wp_unslash( $_POST['type'] ) ) : 'pending';
 		$limit = 10;
+		$args = array();
+		if ( ! empty( $_POST['collection_id'] ) ) {
+			$args['collection_id'] = absint( wp_unslash( $_POST['collection_id'] ) );
+		}
 
 		if ( 'queue' === $type ) {
-			$articles = $this->get_review_queue_articles( $limit + 1, $offset );
+			$articles = $this->get_review_queue_articles( $limit + 1, $offset, $args );
 		} elseif ( 'reviewed' === $type ) {
-			$articles = $this->get_reviewed_articles( $limit + 1, $offset );
+			$articles = $this->get_reviewed_articles( $limit + 1, $offset, $args );
 		} elseif ( 'unread' === $type ) {
-			$articles = $this->get_unread_articles( $limit + 1, $offset );
+			$articles = $this->get_unread_articles( $limit + 1, $offset, $args );
 		} elseif ( 'all' === $type ) {
-			$articles = $this->get_pending_and_unread_articles( $limit + 1, $offset );
+			$articles = $this->get_pending_and_unread_articles( $limit + 1, $offset, $args );
 		} else {
-			$articles = $this->get_pending_articles( $limit + 1, $offset );
+			$articles = $this->get_pending_articles( $limit + 1, $offset, $args );
 		}
 
 		$has_more = count( $articles ) > $limit;

--- a/templates/app/collection.php
+++ b/templates/app/collection.php
@@ -67,13 +67,16 @@ if ( '' !== $active_tag ) {
 				<?php if ( $collection->description ) : ?>
 					<p class="pc-description"><?php echo esc_html( $collection->description ); ?></p>
 				<?php endif; ?>
+				<?php if ( $app->can_manage_collections() ) : ?>
+					<div class="pc-collection-actions">
+						<a class="pc-button" href="<?php echo esc_url( $app->get_collection_review_url( $collection ) ); ?>"><?php esc_html_e( 'Review Articles', 'post-collection' ); ?></a>
+						<a class="pc-button" href="<?php echo esc_url( $app->get_collection_settings_url( $collection ) ); ?>"><?php esc_html_e( 'Settings', 'post-collection' ); ?></a>
+					</div>
+				<?php endif; ?>
 			</div>
 			<div class="pc-collection-stats">
 				<strong><?php echo esc_html( number_format_i18n( $query->found_posts ) ); ?></strong>
 				<span><?php echo esc_html( 'bookmarks' === $mode ? __( 'visible saved links', 'post-collection' ) : __( 'visible posts', 'post-collection' ) ); ?></span>
-				<?php if ( $app->can_manage_collections() ) : ?>
-					<a href="<?php echo esc_url( $app->get_collection_settings_url( $collection ) ); ?>"><?php esc_html_e( 'Settings', 'post-collection' ); ?></a>
-				<?php endif; ?>
 			</div>
 		</div>
 

--- a/templates/app/collection.php
+++ b/templates/app/collection.php
@@ -178,9 +178,7 @@ if ( '' !== $active_tag ) {
 							<?php endif; ?>
 							<div class="pc-card-actions">
 								<a href="<?php echo esc_url( $app->get_collection_url( $collection, $post->ID ) ); ?>"><?php esc_html_e( 'Details', 'post-collection' ); ?></a>
-								<?php if ( $app->can_manage_collections() ) : ?>
-									<span class="pc-read-status pc-read-status-<?php echo esc_attr( $read_status ); ?>"><?php echo esc_html( $app->get_article_note_status_label( $read_status ) ); ?></span>
-								<?php endif; ?>
+								<?php $app->render_article_note_status_toggle( $post, $read_status ); ?>
 								<?php if ( 'private' === $post->post_status && $app->can_manage_collections() ) : ?>
 									<span><?php esc_html_e( 'Private', 'post-collection' ); ?></span>
 								<?php endif; ?>
@@ -220,9 +218,7 @@ if ( '' !== $active_tag ) {
 						<div class="pc-link-meta">
 							<time datetime="<?php echo esc_attr( get_the_date( DATE_W3C, $post ) ); ?>"><?php echo esc_html( get_the_date( '', $post ) ); ?></time>
 							<span class="pc-link-host"><?php echo esc_html( $host ); ?></span>
-							<?php if ( $app->can_manage_collections() ) : ?>
-								<span class="pc-read-status pc-read-status-<?php echo esc_attr( $read_status ); ?>"><?php echo esc_html( $app->get_article_note_status_label( $read_status ) ); ?></span>
-							<?php endif; ?>
+							<?php $app->render_article_note_status_toggle( $post, $read_status ); ?>
 							<?php if ( 'private' === $post->post_status && $app->can_manage_collections() ) : ?>
 								<span class="pc-link-private"><?php esc_html_e( 'private', 'post-collection' ); ?></span>
 							<?php endif; ?>
@@ -313,9 +309,7 @@ if ( '' !== $active_tag ) {
 							<?php endif; ?>
 							<div class="pc-row-meta">
 								<time datetime="<?php echo esc_attr( get_the_date( DATE_W3C, $post ) ); ?>"><?php echo esc_html( get_the_date( '', $post ) ); ?></time>
-								<?php if ( $app->can_manage_collections() ) : ?>
-									<span class="pc-read-status pc-read-status-<?php echo esc_attr( $read_status ); ?>"><?php echo esc_html( $app->get_article_note_status_label( $read_status ) ); ?></span>
-								<?php endif; ?>
+								<?php $app->render_article_note_status_toggle( $post, $read_status ); ?>
 								<a href="<?php echo esc_url( $app->get_source_url( $post ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Original', 'post-collection' ); ?></a>
 							</div>
 						</div>

--- a/templates/app/collection.php
+++ b/templates/app/collection.php
@@ -67,16 +67,18 @@ if ( '' !== $active_tag ) {
 				<?php if ( $collection->description ) : ?>
 					<p class="pc-description"><?php echo esc_html( $collection->description ); ?></p>
 				<?php endif; ?>
+			</div>
+			<div class="pc-collection-header-aside">
 				<?php if ( $app->can_manage_collections() ) : ?>
-					<div class="pc-collection-actions">
+					<div class="pc-app-header-actions">
 						<a class="pc-button" href="<?php echo esc_url( $app->get_collection_review_url( $collection ) ); ?>"><?php esc_html_e( 'Review Articles', 'post-collection' ); ?></a>
 						<a class="pc-button" href="<?php echo esc_url( $app->get_collection_settings_url( $collection ) ); ?>"><?php esc_html_e( 'Settings', 'post-collection' ); ?></a>
 					</div>
 				<?php endif; ?>
-			</div>
-			<div class="pc-collection-stats">
-				<strong><?php echo esc_html( number_format_i18n( $query->found_posts ) ); ?></strong>
-				<span><?php echo esc_html( 'bookmarks' === $mode ? __( 'visible saved links', 'post-collection' ) : __( 'visible posts', 'post-collection' ) ); ?></span>
+				<div class="pc-collection-stats">
+					<strong><?php echo esc_html( number_format_i18n( $query->found_posts ) ); ?></strong>
+					<span><?php echo esc_html( 'bookmarks' === $mode ? __( 'visible saved links', 'post-collection' ) : __( 'visible posts', 'post-collection' ) ); ?></span>
+				</div>
 			</div>
 		</div>
 

--- a/templates/app/index.php
+++ b/templates/app/index.php
@@ -91,7 +91,10 @@ $render_collection_card = static function ( $collection ) use ( $app ) {
 			<h1><?php esc_html_e( 'Post Collection', 'post-collection' ); ?></h1>
 		</div>
 		<?php if ( $app->can_manage_collections() ) : ?>
-			<a class="pc-button pc-button-primary" href="<?php echo esc_url( $app->get_new_collection_url() ); ?>"><?php esc_html_e( 'New Collection', 'post-collection' ); ?></a>
+			<div class="pc-app-header-actions">
+				<a class="pc-button" href="<?php echo esc_url( $app->get_review_url() ); ?>"><?php esc_html_e( 'Review Articles', 'post-collection' ); ?></a>
+				<a class="pc-button pc-button-primary" href="<?php echo esc_url( $app->get_new_collection_url() ); ?>"><?php esc_html_e( 'New Collection', 'post-collection' ); ?></a>
+			</div>
 		<?php endif; ?>
 	</header>
 

--- a/templates/app/post.php
+++ b/templates/app/post.php
@@ -29,6 +29,13 @@ $source_url = $app->get_source_url( $post );
 $host       = $app->get_source_host( $post );
 $embed_html = $app->get_post_description_embed_html( $post, 'detail' );
 $terms      = $app->get_post_terms( $post );
+$can_edit_notes = current_user_can( 'edit_posts' );
+$note           = $can_edit_notes ? $app->get_post_collection()->get_article_notes()->get_note( $post->ID ) : null;
+$statuses       = $app->get_article_statuses();
+$read_status    = $note && ! empty( $note['status'] ) ? $note['status'] : $app->get_article_note_status( $post );
+$rating         = $note ? (int) $note['rating'] : 0;
+$notes          = $note ? $note['notes'] : '';
+$notes_nonce    = $can_edit_notes ? wp_create_nonce( 'post-collection-article-notes' ) : '';
 $back_label = 'bookmarks' === $mode ? __( 'Back to Bookmarks', 'post-collection' ) : __( 'Back to Collection', 'post-collection' );
 ?>
 <!DOCTYPE html>
@@ -51,6 +58,7 @@ $back_label = 'bookmarks' === $mode ? __( 'Back to Bookmarks', 'post-collection'
 		<h1><?php echo esc_html( get_the_title( $post ) ); ?></h1>
 		<div class="pc-detail-meta">
 			<time datetime="<?php echo esc_attr( get_the_date( DATE_W3C, $post ) ); ?>"><?php echo esc_html( get_the_date( '', $post ) ); ?></time>
+			<?php $app->render_article_note_status_toggle( $post, $read_status ); ?>
 			<?php if ( 'private' === $post->post_status && $app->can_manage_collections() ) : ?>
 				<span><?php esc_html_e( 'Private', 'post-collection' ); ?></span>
 			<?php endif; ?>
@@ -80,6 +88,32 @@ $back_label = 'bookmarks' === $mode ? __( 'Back to Bookmarks', 'post-collection'
 				<?php echo apply_filters( 'the_content', $post->post_content ); ?>
 			<?php endif; ?>
 		</article>
+		<?php if ( $can_edit_notes ) : ?>
+			<section class="pc-article-notes" data-article-id="<?php echo esc_attr( $post->ID ); ?>" data-nonce="<?php echo esc_attr( $notes_nonce ); ?>" data-ajax-action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>">
+				<div class="pc-article-notes-controls">
+					<div class="pc-note-statuses" aria-label="<?php esc_attr_e( 'Reading status', 'post-collection' ); ?>">
+						<?php foreach ( $statuses as $status_key => $status_label ) : ?>
+							<button type="button" class="pc-note-status<?php echo $read_status === $status_key ? ' is-active' : ''; ?>" data-status="<?php echo esc_attr( $status_key ); ?>">
+								<?php echo esc_html( $status_label ); ?>
+							</button>
+						<?php endforeach; ?>
+					</div>
+					<div class="pc-note-rating" aria-label="<?php esc_attr_e( 'Rating', 'post-collection' ); ?>" data-rating="<?php echo esc_attr( $rating ); ?>">
+						<?php for ( $i = 1; $i <= 5; $i++ ) : ?>
+							<button type="button" class="pc-note-star<?php echo $i <= $rating ? ' is-active' : ''; ?>" data-rating="<?php echo esc_attr( $i ); ?>" aria-label="<?php echo esc_attr( sprintf( __( '%d stars', 'post-collection' ), $i ) ); ?>">
+								<?php echo $i <= $rating ? '&#9733;' : '&#9734;'; ?>
+							</button>
+						<?php endfor; ?>
+					</div>
+				</div>
+				<label class="screen-reader-text" for="pc-article-notes-<?php echo esc_attr( $post->ID ); ?>"><?php esc_html_e( 'Article notes', 'post-collection' ); ?></label>
+				<textarea id="pc-article-notes-<?php echo esc_attr( $post->ID ); ?>" class="pc-note-text" rows="5" placeholder="<?php esc_attr_e( 'Add your notes...', 'post-collection' ); ?>"><?php echo esc_textarea( $notes ); ?></textarea>
+				<div class="pc-article-notes-actions">
+					<button type="button" class="pc-note-save"><?php esc_html_e( 'Save', 'post-collection' ); ?></button>
+					<span class="pc-note-save-status" aria-live="polite"></span>
+				</div>
+			</section>
+		<?php endif; ?>
 		<nav class="pc-detail-footer-actions" aria-label="<?php esc_attr_e( 'Post navigation', 'post-collection' ); ?>">
 			<a class="pc-button" href="<?php echo esc_url( $app->get_collection_url( $collection ) ); ?>"><?php echo esc_html( $back_label ); ?></a>
 		</nav>

--- a/templates/app/review.php
+++ b/templates/app/review.php
@@ -23,8 +23,17 @@ $article_notes = $app->get_post_collection()->get_article_notes();
 $statuses      = $app->get_article_statuses();
 $nonce         = wp_create_nonce( 'post-collection-article-notes' );
 $limit         = 12;
+$collection_slug = wp_app_get_route_var( 'collection' );
+$collection      = $collection_slug ? $app->get_collection_by_username( $collection_slug ) : null;
 
-$review_articles = $article_notes->get_review_queue_articles( $limit + 1 );
+if ( $collection_slug && ( ! $collection || ! $app->can_view_collection( $collection ) ) ) {
+	status_header( 404 );
+	include __DIR__ . '/404.php';
+	return;
+}
+
+$article_args      = $collection ? array( 'collection_id' => $collection->term_id ) : array();
+$review_articles   = $article_notes->get_review_queue_articles( $limit + 1, 0, $article_args );
 $has_more_articles = count( $review_articles ) > $limit;
 if ( $has_more_articles ) {
 	$review_articles = array_slice( $review_articles, 0, $limit );
@@ -117,12 +126,18 @@ $render_article = static function ( $article ) use ( $statuses, $get_article_url
 <body <?php body_class( 'wp-app-body post-collection-app pc-review-page' ); ?>>
 	<?php wp_app_body_open(); ?>
 	<header class="pc-shell pc-detail-header">
-		<div class="pc-breadcrumb"><a href="<?php echo esc_url( $app->get_home_url() ); ?>"><?php esc_html_e( 'Collections', 'post-collection' ); ?></a></div>
+		<div class="pc-breadcrumb">
+			<a href="<?php echo esc_url( $app->get_home_url() ); ?>"><?php esc_html_e( 'Collections', 'post-collection' ); ?></a>
+			<?php if ( $collection ) : ?>
+				<span>/</span>
+				<a href="<?php echo esc_url( $app->get_collection_url( $collection ) ); ?>"><?php echo esc_html( $collection->name ); ?></a>
+			<?php endif; ?>
+		</div>
 		<p class="pc-kicker"><?php esc_html_e( 'Article notes', 'post-collection' ); ?></p>
-		<h1><?php esc_html_e( 'Review Articles', 'post-collection' ); ?></h1>
+		<h1><?php echo esc_html( $collection ? sprintf( __( 'Review %s', 'post-collection' ), $collection->name ) : __( 'Review Articles', 'post-collection' ) ); ?></h1>
 	</header>
 
-	<main class="pc-shell pc-review-shell" data-nonce="<?php echo esc_attr( $nonce ); ?>" data-ajax-action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" data-statuses="<?php echo esc_attr( wp_json_encode( $statuses ) ); ?>">
+	<main class="pc-shell pc-review-shell" data-nonce="<?php echo esc_attr( $nonce ); ?>" data-ajax-action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" data-statuses="<?php echo esc_attr( wp_json_encode( $statuses ) ); ?>" data-collection-id="<?php echo esc_attr( $collection ? $collection->term_id : 0 ); ?>">
 		<div class="pc-review-list" data-review-list="review">
 			<?php foreach ( $review_articles as $article ) : ?>
 				<?php $render_article( $article ); ?>

--- a/templates/app/review.php
+++ b/templates/app/review.php
@@ -56,6 +56,8 @@ $render_article = static function ( $article ) use ( $statuses, $get_article_url
 	$status = isset( $article['status'] ) ? $article['status'] : \PostCollection\Article_Notes::STATUS_UNREAD;
 	$url    = $get_article_url( $article );
 	$is_collapsed = in_array( $status, array( \PostCollection\Article_Notes::STATUS_READ, \PostCollection\Article_Notes::STATUS_SKIPPED ), true );
+	$summary_word_count = isset( $article['summary_word_count'] ) ? (int) $article['summary_word_count'] : 0;
+	$collapsed_status_label = $is_collapsed && isset( $statuses[ $status ] ) ? $statuses[ $status ] : '';
 	?>
 	<article class="pc-review-item<?php echo $is_collapsed ? ' is-collapsed' : ''; ?> pc-article-notes" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
 		<div class="pc-review-item-main">
@@ -73,6 +75,20 @@ $render_article = static function ( $article ) use ( $statuses, $get_article_url
 							<?php else : ?>
 								<?php echo esc_html( $article['sent_label'] ); ?>
 							<?php endif; ?>
+						</span>
+					<?php endif; ?>
+					<span class="pc-review-collapsed-meta pc-review-collapsed-status"><?php echo esc_html( $collapsed_status_label ); ?></span>
+					<?php if ( $summary_word_count > 0 ) : ?>
+						<span class="pc-review-collapsed-meta">
+							<?php
+							echo esc_html(
+								sprintf(
+									/* translators: %s is the number of words in the article summary. */
+									_n( '%s summary word', '%s summary words', $summary_word_count, 'post-collection' ),
+									number_format_i18n( $summary_word_count )
+								)
+							);
+							?>
 						</span>
 					<?php endif; ?>
 				</p>

--- a/templates/app/review.php
+++ b/templates/app/review.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Frontend app article review queue.
+ *
+ * @package Post_Collection
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$app = \PostCollection\Post_Collection_App::instance();
+if ( ! $app ) {
+	status_header( 500 );
+	return;
+}
+
+if ( ! current_user_can( 'edit_posts' ) ) {
+	status_header( 403 );
+	include __DIR__ . '/403.php';
+	return;
+}
+
+$article_notes = $app->get_post_collection()->get_article_notes();
+$statuses      = $app->get_article_statuses();
+$nonce         = wp_create_nonce( 'post-collection-article-notes' );
+$limit         = 12;
+
+$review_articles = $article_notes->get_review_queue_articles( $limit + 1 );
+$has_more_articles = count( $review_articles ) > $limit;
+if ( $has_more_articles ) {
+	$review_articles = array_slice( $review_articles, 0, $limit );
+}
+
+$get_article_url = static function ( $article ) use ( $app ) {
+	$post = get_post( $article['id'] );
+	if ( $post ) {
+		$collection = $app->get_post_collection_term( $post );
+		if ( $collection ) {
+			return $app->get_collection_url( $collection, $post->ID );
+		}
+	}
+
+	return $article['permalink'];
+};
+
+$render_article = static function ( $article ) use ( $statuses, $get_article_url ) {
+	$rating = isset( $article['rating'] ) ? (int) $article['rating'] : 0;
+	$status = isset( $article['status'] ) ? $article['status'] : \PostCollection\Article_Notes::STATUS_UNREAD;
+	$url    = $get_article_url( $article );
+	$is_collapsed = in_array( $status, array( \PostCollection\Article_Notes::STATUS_READ, \PostCollection\Article_Notes::STATUS_SKIPPED ), true );
+	?>
+	<article class="pc-review-item<?php echo $is_collapsed ? ' is-collapsed' : ''; ?> pc-article-notes" data-article-id="<?php echo esc_attr( $article['id'] ); ?>">
+		<div class="pc-review-item-main">
+			<div class="pc-review-title-block">
+				<h2><a href="<?php echo esc_url( $url ); ?>"><?php echo esc_html( $article['title'] ); ?></a></h2>
+				<p>
+					<?php echo esc_html( $article['author'] ); ?>
+					<?php if ( ! empty( $article['collection'] ) && $article['collection'] !== $article['author'] ) : ?>
+						<span><?php echo esc_html( $article['collection'] ); ?></span>
+					<?php endif; ?>
+					<?php if ( ! empty( $article['sent_label'] ) ) : ?>
+						<span>
+							<?php if ( ! empty( $article['sent_datetime'] ) ) : ?>
+								<time datetime="<?php echo esc_attr( $article['sent_datetime'] ); ?>"><?php echo esc_html( $article['sent_label'] ); ?></time>
+							<?php else : ?>
+								<?php echo esc_html( $article['sent_label'] ); ?>
+							<?php endif; ?>
+						</span>
+					<?php endif; ?>
+				</p>
+			</div>
+		</div>
+
+		<?php if ( ! empty( $article['content'] ) ) : ?>
+			<details class="pc-review-preview">
+				<summary><?php esc_html_e( 'Show article', 'post-collection' ); ?></summary>
+				<div><?php echo $article['content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
+			</details>
+			<button type="button" class="pc-review-collapse"><?php esc_html_e( 'Collapse', 'post-collection' ); ?></button>
+		<?php endif; ?>
+
+		<div class="pc-article-notes-controls">
+			<div class="pc-note-statuses" aria-label="<?php esc_attr_e( 'Reading status', 'post-collection' ); ?>">
+				<?php foreach ( $statuses as $status_key => $status_label ) : ?>
+					<button type="button" class="pc-note-status<?php echo $status === $status_key ? ' is-active' : ''; ?>" data-status="<?php echo esc_attr( $status_key ); ?>">
+						<?php echo esc_html( $status_label ); ?>
+					</button>
+				<?php endforeach; ?>
+			</div>
+			<div class="pc-note-rating" aria-label="<?php esc_attr_e( 'Rating', 'post-collection' ); ?>" data-rating="<?php echo esc_attr( $rating ); ?>">
+				<?php for ( $i = 1; $i <= 5; $i++ ) : ?>
+					<button type="button" class="pc-note-star<?php echo $i <= $rating ? ' is-active' : ''; ?>" data-rating="<?php echo esc_attr( $i ); ?>" aria-label="<?php echo esc_attr( sprintf( __( '%d stars', 'post-collection' ), $i ) ); ?>">
+						<?php echo $i <= $rating ? '&#9733;' : '&#9734;'; ?>
+					</button>
+				<?php endfor; ?>
+			</div>
+		</div>
+
+		<label class="screen-reader-text" for="pc-review-notes-<?php echo esc_attr( $article['id'] ); ?>"><?php esc_html_e( 'Article notes', 'post-collection' ); ?></label>
+		<textarea id="pc-review-notes-<?php echo esc_attr( $article['id'] ); ?>" class="pc-note-text" rows="3" placeholder="<?php esc_attr_e( 'Add your notes...', 'post-collection' ); ?>"><?php echo esc_textarea( $article['notes'] ); ?></textarea>
+
+		<div class="pc-article-notes-actions">
+			<button type="button" class="pc-note-save"><?php esc_html_e( 'Save', 'post-collection' ); ?></button>
+			<span class="pc-note-save-status" aria-live="polite"></span>
+		</div>
+	</article>
+	<?php
+};
+?>
+<!DOCTYPE html>
+<html <?php echo wp_app_language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title><?php echo wp_app_title( __( 'Review Articles', 'post-collection' ) ); ?></title>
+	<?php wp_app_head(); ?>
+</head>
+<body <?php body_class( 'wp-app-body post-collection-app pc-review-page' ); ?>>
+	<?php wp_app_body_open(); ?>
+	<header class="pc-shell pc-detail-header">
+		<div class="pc-breadcrumb"><a href="<?php echo esc_url( $app->get_home_url() ); ?>"><?php esc_html_e( 'Collections', 'post-collection' ); ?></a></div>
+		<p class="pc-kicker"><?php esc_html_e( 'Article notes', 'post-collection' ); ?></p>
+		<h1><?php esc_html_e( 'Review Articles', 'post-collection' ); ?></h1>
+	</header>
+
+	<main class="pc-shell pc-review-shell" data-nonce="<?php echo esc_attr( $nonce ); ?>" data-ajax-action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" data-statuses="<?php echo esc_attr( wp_json_encode( $statuses ) ); ?>">
+		<div class="pc-review-list" data-review-list="review">
+			<?php foreach ( $review_articles as $article ) : ?>
+				<?php $render_article( $article ); ?>
+			<?php endforeach; ?>
+		</div>
+		<?php if ( empty( $review_articles ) ) : ?>
+			<p class="pc-review-empty"><?php esc_html_e( 'No articles are waiting for review.', 'post-collection' ); ?></p>
+		<?php endif; ?>
+		<?php if ( $has_more_articles ) : ?>
+			<button type="button" class="pc-review-load-more" data-type="queue" data-list="review" data-offset="<?php echo esc_attr( count( $review_articles ) ); ?>"><?php esc_html_e( 'Load more', 'post-collection' ); ?></button>
+		<?php endif; ?>
+	</main>
+	<?php wp_app_body_close(); ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a frontend Review Articles route and home/menu entry
- expose article notes controls in the app, including status, rating, notes autosave, and clickable read status labels
- build a unified review queue from sent-to-e-reader/pending/reviewed article notes with sent timestamp labels
- show read/skipped items collapsed in-place with click-to-expand and conditional collapse controls

## Testing
- php -l class-post-collection-app.php
- php -l includes/class-article-notes.php
- php -l templates/app/collection.php
- php -l templates/app/index.php
- php -l templates/app/post.php
- php -l templates/app/review.php
- node --check assets/js/post-collection-app.js