### PR TITLE
Fix Friends dropdown post collection actions

### DIFF
--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -238,7 +238,7 @@ class Post_Collection {
 		add_filter( 'get_edit_user_link', array( $this, 'edit_post_collection_link' ), 10, 2 );
 		add_action( 'friend_post_edit_link', array( $this, 'allow_post_editing' ), 10, 2 );
 		add_action( 'friends_show_author_edit', array( $this, 'friends_show_author_edit' ), 10, 2 );
-		add_action( 'friends_entry_dropdown_menu', array( $this, 'entry_dropdown_menu' ) );
+		add_action( 'friends_entry_dropdown_menu', array( $this, 'entry_dropdown_menu' ), 10, 2 );
 		add_action( 'friends_friend_feed_viewable', array( $this, 'friends_friend_feed_viewable' ), 10, 2 );
 		add_filter( 'friends_friend_posts_query_viewable', array( $this, 'collection_friend_posts_query_viewable' ), 10, 2 );
 		add_action( 'friend_user_role_name', array( $this, 'friend_user_role_name' ), 10, 2 );
@@ -259,6 +259,7 @@ class Post_Collection {
 		add_action( 'wp_ajax_post-collection-mark-publish', array( $this, 'wp_ajax_mark_publish' ) );
 		add_action( 'wp_ajax_post-collection-mark-private', array( $this, 'wp_ajax_mark_private' ) );
 		add_action( 'wp_ajax_post-collection-change-author', array( $this, 'wp_ajax_change_author' ) );
+		add_action( 'wp_ajax_post-collection-save-to-collection', array( $this, 'wp_ajax_save_to_collection' ) );
 		add_action( 'wp_ajax_post-collection-fetch-full-content', array( $this, 'wp_ajax_fetch_full_content' ) );
 		add_action( 'wp_ajax_post-collection-download-images', array( $this, 'wp_ajax_download_images' ) );
 		add_action( 'wp_ajax_post-collection-re-extract', array( $this, 'wp_ajax_re_extract' ) );
@@ -491,7 +492,7 @@ class Post_Collection {
 		return $show;
 	}
 
-	public function entry_dropdown_menu() {
+	public function entry_dropdown_menu( $post = null, $friend_user = null ) {
 		$divider = '<li class="divider" data-content="' . esc_attr__( 'Post Collection', 'post-collection' ) . '"></li>';
 		$list_tags = array(
 			'li' => array(
@@ -499,8 +500,15 @@ class Post_Collection {
 				'data-content' => true,
 			),
 		);
-		$user_id = get_the_author_meta( 'ID' );
-		if ( $this->is_post_collection_user( $user_id ) ) {
+		$post                    = get_post( $post );
+		$author                  = $friend_user instanceof \WP_User ? $friend_user : $this->get_feed_item_author( $post );
+		$user_id                 = $author ? $author->ID : get_the_author_meta( 'ID' );
+		$user_id                 = (int) $user_id;
+		$author_attr             = $user_id;
+		$is_post_collection_user = $this->is_post_collection_user( $user_id );
+		$is_collected_post       = $post && self::CPT === $post->post_type;
+
+		if ( $is_collected_post && $is_post_collection_user ) {
 			echo wp_kses( $divider, $list_tags );
 			$divider = '';
 			?>
@@ -517,24 +525,24 @@ class Post_Collection {
 			}
 		}
 
-		foreach ( $this->get_post_collection_users()->get_results() as $user ) {
-			if ( intval( $user_id ) === intval( $user->ID ) ) {
+		foreach ( $this->get_post_collection_terms() as $collection ) {
+			if ( $is_collected_post && has_term( (int) $collection->term_id, self::COLLECTION_TAXONOMY, $post ) ) {
 				continue;
 			}
-			if ( get_user_option( 'friends_post_collection_inactive', $user->ID ) ) {
+			if ( get_term_meta( $collection->term_id, 'friends_post_collection_inactive', true ) ) {
 				continue;
 			}
 			echo wp_kses( $divider, $list_tags );
 			$divider = '';
 			?>
-			<li class="menu-item"><a href="#" data-id="<?php echo esc_attr( get_the_ID() ); ?>" data-author="<?php echo esc_attr( $user->ID ); ?>" data-originalauthor="<?php echo esc_attr( $user->ID ); ?>" class="post-collection-change-author has-icon-right<?php echo esc_attr( get_user_option( 'friends_post_collection_copy_mode', $user->ID ) ? ' copy-mode' : '' ); ?>">
+			<li class="menu-item"><a href="#" data-id="<?php echo esc_attr( get_the_ID() ); ?>" data-collection="<?php echo esc_attr( $collection->term_id ); ?>" class="post-collection-save-to-collection has-icon-right<?php echo esc_attr( get_term_meta( $collection->term_id, 'friends_post_collection_copy_mode', true ) ? ' copy-mode' : '' ); ?>">
 				<?php
-				if ( get_user_option( 'friends_post_collection_copy_mode', $user->ID ) ) {
+				if ( get_term_meta( $collection->term_id, 'friends_post_collection_copy_mode', true ) ) {
 					echo esc_html(
 						sprintf(
 							// translators: %s is the name of a post collection.
 							_x( 'Copy to %s', 'post-collection', 'post-collection' ),
-							$user->display_name
+							$collection->name
 						)
 					);
 				} else {
@@ -542,7 +550,7 @@ class Post_Collection {
 						sprintf(
 							// translators: %s is the name of a post collection.
 							_x( 'Move to %s', 'post-collection', 'post-collection' ),
-							$user->display_name
+							$collection->name
 						)
 					);
 				}
@@ -565,13 +573,13 @@ class Post_Collection {
 		}
 
 		?>
-		<li class="menu-item"><a href="#" data-id="<?php echo esc_attr( get_the_ID() ); ?>" data-author="<?php echo esc_attr( get_the_author_meta( 'ID' ) ); ?>" class="post-collection-fetch-full-content has-icon-right">
+		<li class="menu-item"><a href="#" data-id="<?php echo esc_attr( get_the_ID() ); ?>" data-author="<?php echo esc_attr( $author_attr ); ?>" class="post-collection-fetch-full-content has-icon-right">
 			<?php
 				esc_html_e( 'Fetch full content', 'post-collection' );
 			?>
 			<i class="<?php echo esc_attr( $i_classes ); ?>"></i></a>
 		</li>
-		<li class="menu-item"><a href="#" data-id="<?php echo esc_attr( get_the_ID() ); ?>" data-author="<?php echo esc_attr( get_the_author_meta( 'ID' ) ); ?>" class="post-collection-download-images has-icon-right">
+		<li class="menu-item"><a href="#" data-id="<?php echo esc_attr( get_the_ID() ); ?>" data-author="<?php echo esc_attr( $author_attr ); ?>" class="post-collection-download-images has-icon-right">
 			<?php
 				esc_html_e( 'Download external images', 'post-collection' );
 			?>
@@ -589,6 +597,31 @@ class Post_Collection {
 		</li>
 			<?php
 		endif;
+	}
+
+	/**
+	 * Get the author for the current Friends feed item.
+	 *
+	 * Friends can store feed ownership in taxonomy relationships, so template
+	 * author globals and post_author are not always the right source.
+	 *
+	 * @param \WP_Post|null $post The feed item post.
+	 * @return \WP_User|false The resolved feed item author.
+	 */
+	private function get_feed_item_author( $post = null ) {
+		$post = get_post( $post );
+		if ( ! $post ) {
+			return false;
+		}
+
+		if ( class_exists( '\Friends\User' ) && method_exists( '\Friends\User', 'get_post_author' ) ) {
+			$author = \Friends\User::get_post_author( $post );
+			if ( $author && ! is_wp_error( $author ) ) {
+				return $author;
+			}
+		}
+
+		return User::get_post_author( $post );
 	}
 
 	public function edit_post_collection_link( $link, $user_id ) {
@@ -855,7 +888,7 @@ class Post_Collection {
 		}
 
 		if ( $this->is_on_friends_frontend() ) {
-			wp_enqueue_script( 'post-collection', plugins_url( 'post-collection.js', __FILE__ ), array( 'friends' ), 1.0 );
+			wp_enqueue_script( 'post-collection', plugins_url( 'post-collection.js', __FILE__ ), array( 'friends' ), filemtime( __DIR__ . '/post-collection.js' ) );
 		}
 	}
 
@@ -2690,6 +2723,62 @@ class Post_Collection {
 			array(
 				'new_text'   => $new_text,
 				'old_author' => $old_author->ID,
+			)
+		);
+	}
+
+	function wp_ajax_save_to_collection() {
+		if ( ! current_user_can( $this->get_required_role() ) ) {
+			wp_send_json_error( __( 'Sorry, you are not allowed to do that' ) ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+		}
+
+		$post = get_post( isset( $_POST['id'] ) ? absint( $_POST['id'] ) : 0 );
+		if ( ! $post ) {
+			wp_send_json_error( __( 'That post does not exist.' ) ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+		}
+
+		$collection = get_term( isset( $_POST['collection'] ) ? absint( $_POST['collection'] ) : 0, self::COLLECTION_TAXONOMY );
+		if ( ! $collection || is_wp_error( $collection ) ) {
+			wp_send_json_error( __( 'Invalid post collection.', 'post-collection' ) );
+		}
+
+		if ( get_term_meta( $collection->term_id, 'friends_post_collection_inactive', true ) ) {
+			wp_send_json_error( __( 'This post collection is inactive.', 'post-collection' ) );
+		}
+
+		$url = $post->guid;
+		if ( ! $this->check_url( $url ) ) {
+			$url = get_permalink( $post );
+		}
+
+		$post_id = $this->save_url_to_collection_term(
+			$url,
+			$collection,
+			$post->post_content,
+			array(
+				'title'          => $post->post_title,
+				'return_details' => true,
+			)
+		);
+
+		if ( is_wp_error( $post_id ) ) {
+			wp_send_json_error( $post_id->get_error_message() );
+		}
+
+		$save_details = $post_id;
+		$copy_mode    = (bool) get_term_meta( $collection->term_id, 'friends_post_collection_copy_mode', true );
+		if ( ! $copy_mode && self::CPT !== $post->post_type ) {
+			wp_trash_post( $post->ID );
+		}
+
+		wp_send_json_success(
+			array(
+				'post_id'  => $save_details['post_id'],
+				'new_text' => sprintf(
+					// translators: %s is the name of a post collection.
+					$copy_mode ? _x( 'Copied to %s!', 'post-collection', 'post-collection' ) : _x( 'Moved to %s!', 'post-collection', 'post-collection' ),
+					$collection->name
+				),
 			)
 		);
 	}

--- a/post-collection.js
+++ b/post-collection.js
@@ -49,6 +49,28 @@ jQuery( function ( $ ) {
 		} );
 		return false;
 	} );
+	$document.on( 'click', 'a.post-collection-save-to-collection', function () {
+		var $this = $( this );
+		if ( $this.data( 'loading' ) ) {
+			return false;
+		}
+		wp.ajax.send( 'post-collection-save-to-collection', {
+			data: {
+				id: $this.data( 'id' ),
+				collection: $this.data( 'collection' )
+			},
+			beforeSend: function () {
+				$this.data( 'loading', true );
+			},
+			success: function ( response ) {
+				$this.text( response.new_text );
+			},
+			complete: function () {
+				$this.data( 'loading', false );
+			}
+		} );
+		return false;
+	} );
 	$document.on( 'click', 'a.post-collection-fetch-full-content', function () {
 		var $this = $( this );
 		var search_indicator = $this.find( 'i' );

--- a/tests/Test_Entry_Dropdown_Menu.php
+++ b/tests/Test_Entry_Dropdown_Menu.php
@@ -1,0 +1,133 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use PostCollection\Post_Collection;
+use PostCollection\User;
+
+require_once __DIR__ . '/../class-post-collection.php';
+
+class Test_Entry_Dropdown_Menu extends TestCase {
+	private $plugin;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$GLOBALS['wp_test_actions']          = array();
+		$GLOBALS['wp_test_filters']          = array();
+		$GLOBALS['wp_test_current_user_caps'] = array(
+			'edit_private_posts' => true,
+		);
+		$GLOBALS['wp_test_posts']            = array();
+		$GLOBALS['wp_test_post_meta']        = array();
+		$GLOBALS['wp_test_terms']            = array();
+		$GLOBALS['wp_test_term_meta']        = array();
+		$GLOBALS['wp_test_registered_terms'] = array();
+		$GLOBALS['wp_test_users']            = array();
+		$GLOBALS['wp_test_user_options']     = array();
+		unset( $GLOBALS['post'] );
+
+		$this->plugin = new Post_Collection();
+	}
+
+	public function test_normal_friend_item_shows_collection_moves_without_collection_management_controls() {
+		$post = $this->create_post(
+			101,
+			'friend_post_cache',
+			'Normal Friend Item',
+			'publish'
+		);
+		$GLOBALS['post'] = $post;
+
+		$friend_user = $this->create_user( 501, 'claude', 'Claude', array( 'post_collection' ) );
+		$this->create_collection_term( 201, 'bookmarks', 'Bookmarks' );
+		$this->create_collection_term( 202, 'saved-posts', 'Saved Posts' );
+		update_term_meta( 202, 'friends_post_collection_copy_mode', true );
+
+		$output = $this->render_dropdown( $post, $friend_user );
+
+		$this->assertStringNotContainsString( 'Edit Post Collection', $output );
+		$this->assertStringNotContainsString( 'Hide post from the feed', $output );
+		$this->assertStringContainsString( 'Move to Bookmarks', $output );
+		$this->assertStringContainsString( 'Copy to Saved Posts', $output );
+	}
+
+	public function test_collected_post_shows_management_controls_and_skips_current_collection() {
+		$post = $this->create_post(
+			102,
+			Post_Collection::CPT,
+			'Collected Item',
+			'publish'
+		);
+		$GLOBALS['post'] = $post;
+
+		$collection_user = $this->create_user( 502, 'collection-author', 'Collection Author', array( 'post_collection' ) );
+		$post->post_author = $collection_user->ID;
+
+		$this->create_collection_term( 203, 'bookmarks', 'Bookmarks' );
+		$this->create_collection_term( 204, 'saved-posts', 'Saved Posts' );
+		wp_set_object_terms( $post->ID, array( 203 ), Post_Collection::COLLECTION_TAXONOMY );
+
+		$output = $this->render_dropdown( $post, $collection_user );
+
+		$this->assertStringContainsString( 'Edit Post Collection', $output );
+		$this->assertStringContainsString( 'Hide post from the feed', $output );
+		$this->assertStringNotContainsString( 'Move to Bookmarks', $output );
+		$this->assertStringContainsString( 'Move to Saved Posts', $output );
+	}
+
+	private function render_dropdown( \WP_Post $post, \WP_User $friend_user ) {
+		ob_start();
+		$this->plugin->entry_dropdown_menu( $post, $friend_user );
+		return ob_get_clean();
+	}
+
+	private function create_post( $id, $post_type, $title, $status ) {
+		$post = new \WP_Post(
+			(object) array(
+				'ID'           => $id,
+				'post_author'  => 0,
+				'post_title'   => $title,
+				'post_content' => 'Post content for ' . $title,
+				'post_status'  => $status,
+				'post_type'    => $post_type,
+				'guid'         => 'https://example.com/source/' . $id,
+			)
+		);
+
+		$GLOBALS['wp_test_posts'][ $id ] = $post;
+
+		return $post;
+	}
+
+	private function create_user( $id, $login, $display_name, array $roles ) {
+		$user = new User(
+			(object) array(
+				'ID'           => $id,
+				'user_login'   => $login,
+				'display_name' => $display_name,
+				'description'  => '',
+				'roles'        => $roles,
+				'caps'         => array_fill_keys( $roles, true ),
+			)
+		);
+
+		$GLOBALS['wp_test_users'][ $id ] = $user;
+
+		return $user;
+	}
+
+	private function create_collection_term( $id, $slug, $name ) {
+		$term = new \WP_Term(
+			(object) array(
+				'term_id'  => $id,
+				'slug'     => $slug,
+				'name'     => $name,
+				'taxonomy' => Post_Collection::COLLECTION_TAXONOMY,
+			)
+		);
+
+		$GLOBALS['wp_test_registered_terms'][ Post_Collection::COLLECTION_TAXONOMY ][ $id ] = $term;
+
+		return $term;
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,6 +21,9 @@ namespace {
 	$GLOBALS['wp_test_current_user_id']    = 0;
 	$GLOBALS['wp_test_posts']              = array();
 	$GLOBALS['wp_test_post_meta']          = array();
+	$GLOBALS['wp_test_terms']              = array();
+	$GLOBALS['wp_test_term_meta']          = array();
+	$GLOBALS['wp_test_registered_terms']   = array();
 	$GLOBALS['wp_test_users']              = array();
 	$GLOBALS['wp_test_user_options']       = array();
 
@@ -65,6 +68,10 @@ namespace {
 	}
 
 	function wp_kses_post( $data ) {
+		return $data;
+	}
+
+	function wp_kses( $data, $allowed_html, $allowed_protocols = array() ) {
 		return $data;
 	}
 
@@ -287,6 +294,21 @@ namespace {
 		}
 	}
 
+	class WP_Term {
+		public $term_id = 0;
+		public $name = '';
+		public $slug = '';
+		public $taxonomy = '';
+
+		public function __construct( $term = null ) {
+			if ( is_object( $term ) ) {
+				foreach ( get_object_vars( $term ) as $key => $value ) {
+					$this->$key = $value;
+				}
+			}
+		}
+	}
+
 	class WP_Query {
 		public $posts = array();
 		public $found_posts = 0;
@@ -447,8 +469,21 @@ namespace {
 		if ( $post instanceof WP_Post ) {
 			return $post;
 		}
+		if ( null === $post ) {
+			return $GLOBALS['post'] ?? null;
+		}
 		$post_id = is_object( $post ) ? (int) $post->ID : (int) $post;
 		return $GLOBALS['wp_test_posts'][ $post_id ] ?? null;
+	}
+
+	function get_the_ID() {
+		$post = get_post();
+		return $post ? (int) $post->ID : 0;
+	}
+
+	function get_post_status( $post = null ) {
+		$post = get_post( $post );
+		return $post ? $post->post_status : false;
 	}
 
 	function wp_get_post_parent_id( $post_id ) {
@@ -506,9 +541,83 @@ namespace {
 		return true;
 	}
 
-	function wp_set_post_terms( $post_id, $terms, $taxonomy, $append = false ) {
-		$GLOBALS['wp_test_terms'][ $post_id ][ $taxonomy ] = (array) $terms;
+	function get_terms( $args = array() ) {
+		$taxonomy = $args['taxonomy'] ?? '';
+		$terms = array_values( $GLOBALS['wp_test_registered_terms'][ $taxonomy ] ?? array() );
+
+		if ( isset( $args['orderby'] ) && 'name' === $args['orderby'] ) {
+			usort(
+				$terms,
+				function ( $a, $b ) use ( $args ) {
+					$result = strcasecmp( $a->name, $b->name );
+					return isset( $args['order'] ) && 'DESC' === strtoupper( $args['order'] ) ? -$result : $result;
+				}
+			);
+		}
+
 		return $terms;
+	}
+
+	function get_term( $term_id, $taxonomy = '' ) {
+		$term_id = (int) $term_id;
+		if ( $taxonomy ) {
+			return $GLOBALS['wp_test_registered_terms'][ $taxonomy ][ $term_id ] ?? null;
+		}
+
+		foreach ( $GLOBALS['wp_test_registered_terms'] as $terms ) {
+			if ( isset( $terms[ $term_id ] ) ) {
+				return $terms[ $term_id ];
+			}
+		}
+
+		return null;
+	}
+
+	function get_term_meta( $term_id, $key = '', $single = false ) {
+		if ( '' === $key ) {
+			return $GLOBALS['wp_test_term_meta'][ $term_id ] ?? array();
+		}
+		if ( ! array_key_exists( $term_id, $GLOBALS['wp_test_term_meta'] ) || ! array_key_exists( $key, $GLOBALS['wp_test_term_meta'][ $term_id ] ) ) {
+			return $single ? '' : array();
+		}
+		$value = $GLOBALS['wp_test_term_meta'][ $term_id ][ $key ];
+		return $single ? $value : (array) $value;
+	}
+
+	function update_term_meta( $term_id, $meta_key, $meta_value, $prev_value = '' ) {
+		$GLOBALS['wp_test_term_meta'][ $term_id ][ $meta_key ] = $meta_value;
+		return true;
+	}
+
+	function wp_set_post_terms( $post_id, $terms, $taxonomy, $append = false ) {
+		return wp_set_object_terms( $post_id, $terms, $taxonomy, $append );
+	}
+
+	function wp_set_object_terms( $object_id, $terms, $taxonomy, $append = false ) {
+		if ( $append ) {
+			$GLOBALS['wp_test_terms'][ $object_id ][ $taxonomy ] = array_values(
+				array_unique(
+					array_merge( $GLOBALS['wp_test_terms'][ $object_id ][ $taxonomy ] ?? array(), (array) $terms )
+				)
+			);
+			return $GLOBALS['wp_test_terms'][ $object_id ][ $taxonomy ];
+		}
+		$GLOBALS['wp_test_terms'][ $object_id ][ $taxonomy ] = (array) $terms;
+		return $terms;
+	}
+
+	function has_term( $term = '', $taxonomy = '', $post = null ) {
+		$post = get_post( $post );
+		if ( ! $post ) {
+			return false;
+		}
+
+		$terms = $GLOBALS['wp_test_terms'][ $post->ID ][ $taxonomy ] ?? array();
+		return in_array( (int) $term, array_map( 'intval', $terms ), true );
+	}
+
+	function wp_get_post_revisions( $post_id = 0, $args = null ) {
+		return array();
 	}
 
 	function get_the_title( $post = 0 ) {
@@ -532,6 +641,10 @@ namespace {
 
 	function get_edit_user_link( $user_id = null ) {
 		return 'https://example.com/wp-admin/user-edit.php?user_id=' . (int) $user_id;
+	}
+
+	function self_admin_url( $path = '', $scheme = 'admin' ) {
+		return 'https://example.com/wp-admin/' . ltrim( $path, '/' );
 	}
 
 	function get_user_by( $field, $value ) {


### PR DESCRIPTION
## Summary
- Render Friends feed item post collection actions from taxonomy-backed collections instead of legacy collection users
- Keep collection management controls limited to actual collected posts
- Add AJAX/JS support for moving or copying feed items into taxonomy-backed collections
- Add focused dropdown render tests for normal Friends items and collected posts

## Tests
- ./vendor/bin/phpunit tests/Test_Entry_Dropdown_Menu.php
- git diff --check

Note: composer test still has the existing WP_REST_Request bootstrap error in Test_Browser_Extension_Action.

<!-- cookbook-playground-link:start -->
## WordPress Playground

Test this PR in WordPress Playground:

https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/akirk/post-collection/refs/heads/dist/pr-33/blueprint.json

The linked blueprint loads the generated `dist/pr-33` branch, including Composer dependencies.
<!-- cookbook-playground-link:end -->