### PR TITLE
Provide collection names for e-reader authors

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -2,55 +2,33 @@ name: Build dist branch
 
 on:
   push:
-    branches:
-      - '**'
+    branches-ignore:
+      - 'dist/**'
   pull_request:
     types:
       - opened
       - synchronize
       - reopened
-      - closed
   delete:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
-  group: build-dist-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref_name || github.event.ref }}
+  group: build-dist-${{ github.event_name }}-${{ github.ref_name || github.event.ref || github.event.pull_request.head.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
-    if: >-
-      (github.event_name == 'push' && !startsWith(github.ref_name, 'dist/')) ||
-      (github.event_name == 'pull_request' &&
-        github.event.action != 'closed' &&
-        github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      DIST_REF: dist/${{ github.ref_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Set dist metadata
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          REF_NAME: ${{ github.ref_name }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPOSITORY: ${{ github.repository }}
-        run: |
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            dist_ref="dist/pr-${PR_NUMBER}"
-          else
-            dist_ref="dist/${REF_NAME}"
-          fi
-
-          playground_url="https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/${REPOSITORY}/refs/heads/${dist_ref}/blueprint.json"
-
-          echo "DIST_REF=${dist_ref}" >> "$GITHUB_ENV"
-          echo "PLAYGROUND_URL=${playground_url}" >> "$GITHUB_ENV"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -58,8 +36,9 @@ jobs:
           php-version: '8.2'
           tools: composer
 
-      - name: Install dependencies
-        run: composer install --no-dev --optimize-autoloader
+      - name: Install production dependencies
+        if: hashFiles('composer.json') != ''
+        run: composer install --no-dev --optimize-autoloader --no-interaction
 
       - name: Point blueprint at dist branch
         run: |
@@ -84,26 +63,37 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add blueprint.json
-          git add -f vendor/
-          git commit -m "Build: add vendor"
+          if [ -d vendor ]; then
+            git add -f vendor/
+          fi
+          git diff --cached --quiet || git commit -m "Build: add vendor"
           git push origin HEAD:refs/heads/${DIST_REF} --force
 
+  update-pr-description:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
       - name: Add Playground link to PR description
-        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         with:
           script: |
             const markerStart = '<!-- playground-link:start -->';
             const markerEnd = '<!-- playground-link:end -->';
+            const distRef = `dist/${process.env.HEAD_REF}`;
+            const playgroundUrl = `https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/refs/heads/${distRef}/blueprint.json`;
             const playgroundSection = [
               markerStart,
               '## WordPress Playground',
               '',
               'Test this PR in WordPress Playground:',
               '',
-              process.env.PLAYGROUND_URL,
+              playgroundUrl,
               '',
-              `The linked blueprint loads the generated \`${process.env.DIST_REF}\` branch, including Composer dependencies.`,
+              `The linked blueprint loads the generated \`${distRef}\` branch, including Composer dependencies.`,
               markerEnd,
             ].join('\n');
 
@@ -122,28 +112,59 @@ jobs:
               body,
             });
 
-  delete-pr-dist:
-    if: >-
-      github.event_name == 'pull_request' &&
-      github.event.action == 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - name: Delete PR dist branch
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          git push origin ":refs/heads/dist/pr-${PR_NUMBER}" || true
-
   delete-dist:
     if: github.event_name == 'delete' && github.event.ref_type == 'branch' && !startsWith(github.event.ref, 'dist/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Delete dist branch
+      - name: Delete dist branch and remove stale PR links
+        uses: actions/github-script@v7
         env:
           BRANCH_NAME: ${{ github.event.ref }}
-        run: |
-          git push origin ":refs/heads/dist/${BRANCH_NAME}" || true
+        with:
+          script: |
+            const markerPattern = /<!-- (?:[a-z0-9-]+-)?playground-link:start -->[\s\S]*?<!-- (?:[a-z0-9-]+-)?playground-link:end -->/;
+            const { owner, repo } = context.repo;
+            const branchName = process.env.BRANCH_NAME;
+
+            try {
+              await github.rest.git.deleteRef({
+                owner,
+                repo,
+                ref: `heads/dist/${branchName}`,
+              });
+            } catch (error) {
+              if (error.status !== 404 && error.status !== 422) {
+                throw error;
+              }
+            }
+
+            const head = `${owner}:${process.env.BRANCH_NAME}`;
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'all',
+              head,
+              per_page: 100,
+            });
+
+            for (const pull of pulls) {
+              const currentBody = pull.body || '';
+              if (!markerPattern.test(currentBody)) {
+                continue;
+              }
+
+              const body = currentBody
+                .replace(markerPattern, '')
+                .replace(/\n{3,}/g, '\n\n')
+                .trim();
+
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: pull.number,
+                body,
+              });
+            }

--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -244,6 +244,7 @@ class Post_Collection {
 		add_action( 'friend_user_role_name', array( $this, 'friend_user_role_name' ), 10, 2 );
 		add_filter( 'friends_plugin_roles', array( $this, 'associate_friend_user_role' ) );
 		add_action( 'friends_override_author_name', array( $this, 'friends_override_author_name' ), 15, 3 );
+		add_filter( 'send_to_e_reader_ebook_author', array( $this, 'filter_ebook_author' ), 10, 2 );
 		add_action( 'friends_widget_friend_list_after', array( $this, 'friends_widget_friend_list_after' ), 10, 2 );
 		add_action( 'friends_author_header', array( $this, 'friends_author_header' ) );
 		add_action( 'friends_author_header', array( $this, 'enter_url_field' ) );
@@ -2466,6 +2467,42 @@ class Post_Collection {
 		$host = wp_parse_url( $post->guid, PHP_URL_HOST );
 
 		return sanitize_text_field( preg_replace( '#^www\.#', '', preg_replace( '#[^a-z0-9.-]+#i', ' ', strtolower( $host ) ) ) );
+	}
+
+	/**
+	 * Prefer assigned post collection names for generated ePub book authors.
+	 *
+	 * @param string $author Current ePub book author.
+	 * @param array  $posts  Posts included in the ePub.
+	 * @return string Filtered ePub book author.
+	 */
+	public function filter_ebook_author( $author, array $posts ) {
+		$collection_names = array();
+
+		foreach ( $posts as $post ) {
+			if ( ! $post instanceof \WP_Post ) {
+				continue;
+			}
+
+			$terms = get_the_terms( $post, self::COLLECTION_TAXONOMY );
+			if ( is_wp_error( $terms ) || empty( $terms ) ) {
+				continue;
+			}
+
+			foreach ( $terms as $term ) {
+				if ( empty( $term->name ) || in_array( $term->name, $collection_names, true ) ) {
+					continue;
+				}
+
+				$collection_names[] = $term->name;
+			}
+		}
+
+		if ( $collection_names ) {
+			return implode( ', ', $collection_names );
+		}
+
+		return $author;
 	}
 
 	/**

--- a/tests/Test_Entry_Dropdown_Menu.php
+++ b/tests/Test_Entry_Dropdown_Menu.php
@@ -75,6 +75,33 @@ class Test_Entry_Dropdown_Menu extends TestCase {
 		$this->assertStringContainsString( 'Move to Saved Posts', $output );
 	}
 
+	public function test_ebook_author_filter_prefers_collection_term_names() {
+		$post = $this->create_post(
+			103,
+			Post_Collection::CPT,
+			'Collected Item',
+			'publish'
+		);
+
+		$this->create_collection_term( 205, 'bookmarks', 'Bookmarks' );
+		$this->create_collection_term( 206, 'saved-posts', 'Saved Posts' );
+		wp_set_object_terms( $post->ID, array( 205, 206 ), Post_Collection::COLLECTION_TAXONOMY );
+
+		$this->assertSame(
+			'Bookmarks, Saved Posts',
+			apply_filters( 'send_to_e_reader_ebook_author', 'Original Author', array( $post ), null, null )
+		);
+	}
+
+	public function test_ebook_author_filter_keeps_existing_author_without_collection_terms() {
+		$post = $this->create_post( 104, Post_Collection::CPT, 'Collected Item', 'publish' );
+
+		$this->assertSame(
+			'Original Author',
+			apply_filters( 'send_to_e_reader_ebook_author', 'Original Author', array( $post ), null, null )
+		);
+	}
+
 	private function render_dropdown( \WP_Post $post, \WP_User $friend_user ) {
 		ob_start();
 		$this->plugin->entry_dropdown_menu( $post, $friend_user );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -606,6 +606,24 @@ namespace {
 		return $terms;
 	}
 
+	function get_the_terms( $post, $taxonomy ) {
+		$post = get_post( $post );
+		if ( ! $post ) {
+			return false;
+		}
+
+		$term_ids = $GLOBALS['wp_test_terms'][ $post->ID ][ $taxonomy ] ?? array();
+		$terms = array();
+		foreach ( $term_ids as $term_id ) {
+			$term = get_term( $term_id, $taxonomy );
+			if ( $term ) {
+				$terms[] = $term;
+			}
+		}
+
+		return $terms ?: false;
+	}
+
 	function has_term( $term = '', $taxonomy = '', $post = null ) {
 		$post = get_post( $post );
 		if ( ! $post ) {


### PR DESCRIPTION
## Summary
- Add a send_to_e_reader_ebook_author handler that uses assigned post collection term names
- Add regression coverage for collection-name author metadata and fallback behavior
- Include the dist build workflow update

## Tests
- vendor/bin/phpunit tests/Test_Entry_Dropdown_Menu.php
- vendor/bin/phpunit --do-not-cache-result currently hits an existing test bootstrap gap: WP_REST_Request is not stubbed for two browser-extension tests