### PR TITLE
Add live post collection importer

### DIFF
--- a/assets/css/post-collection-app.css
+++ b/assets/css/post-collection-app.css
@@ -146,6 +146,7 @@ body.pc-new-collection-page .pc-detail-header {
 .post-collection-app .post-collection-bookmarklet,
 .post-collection-app .pc-collection-settings button,
 .post-collection-app .pc-create-collection-form button,
+.post-collection-app .pc-import-form button,
 .post-collection-app .pc-add-form button,
 .post-collection-app .pc-filter-bar button {
 	display: inline-flex;
@@ -166,6 +167,7 @@ body.pc-new-collection-page .pc-detail-header {
 .post-collection-app .pc-button-primary,
 .post-collection-app .pc-collection-settings button,
 .post-collection-app .pc-create-collection-form button,
+.post-collection-app .pc-import-form button,
 .post-collection-app .pc-add-form button,
 .post-collection-app .pc-filter-bar button {
 	border-color: var(--pc-color-primary);
@@ -181,6 +183,8 @@ body.pc-new-collection-page .pc-detail-header {
 .post-collection-app .pc-collection-settings button:focus,
 .post-collection-app .pc-create-collection-form button:hover,
 .post-collection-app .pc-create-collection-form button:focus,
+.post-collection-app .pc-import-form button:hover,
+.post-collection-app .pc-import-form button:focus,
 .post-collection-app .pc-add-form button:hover,
 .post-collection-app .pc-add-form button:focus,
 .post-collection-app .pc-filter-bar button:hover,
@@ -195,6 +199,8 @@ body.pc-new-collection-page .pc-detail-header {
 .post-collection-app .pc-collection-settings button:focus,
 .post-collection-app .pc-create-collection-form button:hover,
 .post-collection-app .pc-create-collection-form button:focus,
+.post-collection-app .pc-import-form button:hover,
+.post-collection-app .pc-import-form button:focus,
 .post-collection-app .pc-add-form button:hover,
 .post-collection-app .pc-add-form button:focus,
 .post-collection-app .pc-filter-bar button:hover,
@@ -518,7 +524,8 @@ body.pc-new-collection-page .pc-detail-header {
 }
 
 .pc-collection-settings label,
-.pc-create-collection-form label {
+.pc-create-collection-form label,
+.pc-import-form label {
 	display: grid;
 	gap: 4px;
 	color: var(--pc-color-muted);
@@ -545,6 +552,7 @@ body.pc-new-collection-page .pc-detail-header {
 .pc-collection-settings select,
 .pc-create-collection-form input,
 .pc-create-collection-form select,
+.pc-import-form textarea,
 .pc-add-form input,
 .pc-filter-bar input {
 	width: 100%;
@@ -560,6 +568,7 @@ body.pc-new-collection-page .pc-detail-header {
 .pc-collection-settings select:focus,
 .pc-create-collection-form input:focus,
 .pc-create-collection-form select:focus,
+.pc-import-form textarea:focus,
 .pc-add-form input:focus,
 .pc-filter-bar input:focus {
 	border-color: var(--pc-color-primary);
@@ -572,6 +581,193 @@ body.pc-new-collection-page .pc-detail-header {
 	max-width: 640px;
 	gap: 14px;
 	padding: 0;
+}
+
+.pc-import-layout {
+	display: grid;
+	grid-template-columns: minmax(0, 720px) minmax(240px, 1fr);
+	gap: 32px;
+	align-items: start;
+	padding-bottom: 64px;
+}
+
+.pc-import-main,
+.pc-import-form {
+	display: grid;
+	gap: 18px;
+}
+
+.pc-import-form textarea {
+	min-height: 300px;
+	padding: 12px;
+	resize: vertical;
+}
+
+.pc-import-file-control {
+	position: relative;
+	display: flex;
+	align-items: center;
+	min-height: 44px;
+	border: 1px solid var(--pc-color-border);
+	border-radius: 8px;
+	background: var(--pc-color-surface-alt);
+	color: var(--pc-color-text);
+	overflow: hidden;
+}
+
+.pc-import-file-button {
+	align-self: stretch;
+	display: inline-flex;
+	align-items: center;
+	padding: 0 14px;
+	border-right: 1px solid var(--pc-color-border);
+	background: var(--pc-color-surface);
+	color: var(--pc-color-text);
+	font-weight: 700;
+}
+
+.pc-import-file-name {
+	min-width: 0;
+	padding: 0 12px;
+	color: var(--pc-color-muted);
+	font-size: 0.95rem;
+	font-weight: 400;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.pc-import-file-control input[type="file"] {
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	opacity: 0;
+	cursor: pointer;
+}
+
+.pc-import-file-control:focus-within {
+	border-color: var(--pc-color-primary);
+	outline: 2px solid var(--pc-color-focus);
+	outline-offset: 1px;
+}
+
+.pc-import-aside,
+.pc-import-result,
+.pc-import-progress {
+	padding: 20px;
+	border: 1px solid var(--pc-color-border);
+	border-radius: 8px;
+	background: var(--pc-color-surface);
+}
+
+.pc-import-aside h2,
+.pc-import-result h2 {
+	margin: 0 0 10px;
+	font-size: 1.15rem;
+}
+
+.pc-import-aside ul,
+.pc-import-result ul {
+	margin: 0;
+	padding-left: 20px;
+	color: var(--pc-color-muted);
+}
+
+.pc-import-result p {
+	margin: 0 0 12px;
+	color: var(--pc-color-muted);
+}
+
+.pc-import-result details {
+	margin-top: 12px;
+}
+
+.pc-import-result code {
+	overflow-wrap: anywhere;
+}
+
+.pc-import-progress-header {
+	display: flex;
+	gap: 18px;
+	align-items: flex-start;
+	justify-content: space-between;
+}
+
+.pc-import-progress-header h2 {
+	margin: 0 0 6px;
+	font-size: 1.15rem;
+}
+
+.pc-import-progress-header p {
+	margin: 0;
+	color: var(--pc-color-muted);
+}
+
+.pc-import-progress-counts {
+	display: flex;
+	gap: 4px;
+	align-items: baseline;
+	color: var(--pc-color-muted);
+	font-weight: 700;
+}
+
+.pc-import-progress-counts strong {
+	color: var(--pc-color-primary);
+	font-size: 2rem;
+	line-height: 1;
+}
+
+.pc-import-progress-bar {
+	width: 100%;
+	height: 14px;
+	margin-top: 18px;
+}
+
+.pc-import-summary {
+	margin-top: 12px;
+	color: var(--pc-color-muted);
+	font-weight: 700;
+}
+
+.pc-import-log {
+	display: grid;
+	max-height: 360px;
+	gap: 8px;
+	margin: 18px 0 0;
+	padding: 0;
+	overflow: auto;
+	list-style: none;
+}
+
+.pc-import-log li {
+	display: grid;
+	gap: 2px;
+	padding: 10px 12px;
+	border-left: 4px solid var(--pc-color-border);
+	background: var(--pc-color-background);
+}
+
+.pc-import-log li.is-created {
+	border-left-color: #008a20;
+}
+
+.pc-import-log li.is-existing {
+	border-left-color: var(--pc-color-primary);
+}
+
+.pc-import-log li.is-failed {
+	border-left-color: #b32d2e;
+}
+
+.pc-import-log strong {
+	overflow-wrap: anywhere;
+}
+
+.pc-import-log span {
+	color: var(--pc-color-muted);
+	font-size: 0.9rem;
+	overflow-wrap: anywhere;
 }
 
 .pc-form-actions {
@@ -1470,7 +1666,8 @@ body.pc-new-collection-page .pc-detail-header {
 
 	.pc-collection-settings,
 	.pc-add-form,
-	.pc-filter-bar {
+	.pc-filter-bar,
+	.pc-import-layout {
 		grid-template-columns: 1fr;
 	}
 

--- a/assets/js/post-collection-app.js
+++ b/assets/js/post-collection-app.js
@@ -440,6 +440,169 @@
 			} );
 	}
 
+	function setImportStatus( shell, message ) {
+		var status = shell ? shell.querySelector( '[data-import-status]' ) : null;
+		if ( status ) {
+			status.textContent = message || '';
+		}
+	}
+
+	function updateImportProgress( shell, completed, total ) {
+		var completedNode = shell.querySelector( '[data-import-completed]' );
+		var totalNode = shell.querySelector( '[data-import-total]' );
+		var progress = shell.querySelector( '[data-import-progress-bar]' );
+
+		if ( completedNode ) {
+			completedNode.textContent = completed;
+		}
+		if ( totalNode ) {
+			totalNode.textContent = total;
+		}
+		if ( progress ) {
+			progress.max = total || 1;
+			progress.value = completed;
+		}
+	}
+
+	function addImportLogItem( shell, item, state, message ) {
+		var log = shell.querySelector( '[data-import-log]' );
+		if ( ! log ) {
+			return;
+		}
+
+		var row = document.createElement( 'li' );
+		row.className = 'is-' + state;
+
+		var label = document.createElement( 'strong' );
+		label.textContent = item.title || item.url || '';
+		row.appendChild( label );
+
+		var detail = document.createElement( 'span' );
+		detail.textContent = message || item.url || '';
+		row.appendChild( detail );
+
+		log.appendChild( row );
+	}
+
+	function setImportSummary( shell, created, existing, failed ) {
+		var summary = shell.querySelector( '[data-import-summary]' );
+		if ( ! summary ) {
+			return;
+		}
+
+		summary.textContent = created + ' new, ' + existing + ' already saved, ' + failed + ' failed.';
+	}
+
+	function postImportData( form, data ) {
+		return fetch( form.action, {
+			method: 'POST',
+			credentials: 'same-origin',
+			body: data,
+		} )
+			.then( function ( response ) {
+				return response.json();
+			} )
+			.then( function ( result ) {
+				if ( ! result || ! result.success ) {
+					throw new Error( result && result.data && result.data.message ? result.data.message : 'Import request failed.' );
+				}
+
+				return result.data;
+			} );
+	}
+
+	function appendItemToImportData( data, item ) {
+		data.append( 'url', item.url || '' );
+		data.append( 'title', item.title || '' );
+		( item.tags || [] ).forEach( function ( tag ) {
+			data.append( 'tags[]', tag );
+		} );
+	}
+
+	function runImport( form ) {
+		var shell = document.querySelector( '[data-import-progress]' );
+		var button = form.querySelector( 'button[type="submit"]' );
+		if ( ! shell ) {
+			return;
+		}
+
+		shell.hidden = false;
+		shell.querySelector( '[data-import-log]' ).textContent = '';
+		setImportSummary( shell, 0, 0, 0 );
+		updateImportProgress( shell, 0, 0 );
+		setImportStatus( shell, 'Reading import source...' );
+
+		if ( button ) {
+			button.disabled = true;
+			button.textContent = 'Importing...';
+		}
+
+		var parseData = new FormData( form );
+		parseData.append( 'action', form.dataset.parseAction || 'post_collection_parse_import' );
+
+		postImportData( form, parseData )
+			.then( function ( data ) {
+				var items = data.items || [];
+				var total = items.length;
+				var completed = 0;
+				var created = 0;
+				var existing = 0;
+				var failed = 0;
+
+				updateImportProgress( shell, completed, total );
+				if ( ! total ) {
+					setImportStatus( shell, 'No importable URLs found.' );
+					return Promise.resolve();
+				}
+
+				setImportStatus( shell, 'Importing 1 of ' + total + '...' );
+
+				return items.reduce( function (promise, item, index ) {
+					return promise.then( function () {
+						var itemData = new FormData();
+						itemData.append( 'action', form.dataset.importAction || 'post_collection_import_item' );
+						itemData.append( 'collection_term_id', form.querySelector( 'input[name="collection_term_id"]' ).value );
+						itemData.append( '_wpnonce', form.querySelector( 'input[name="_wpnonce"]' ).value );
+						appendItemToImportData( itemData, item );
+
+						setImportStatus( shell, 'Importing ' + ( index + 1 ) + ' of ' + total + ': ' + ( item.title || item.url ) );
+
+						return postImportData( form, itemData )
+							.then( function ( result ) {
+								completed++;
+								if ( result.created ) {
+									created++;
+									addImportLogItem( shell, item, 'created', 'Saved and extracted.' );
+								} else {
+									existing++;
+									addImportLogItem( shell, item, 'existing', 'Already saved.' );
+								}
+								updateImportProgress( shell, completed, total );
+								setImportSummary( shell, created, existing, failed );
+							} )
+							.catch( function ( error ) {
+								completed++;
+								failed++;
+								addImportLogItem( shell, item, 'failed', error.message || 'Failed.' );
+								updateImportProgress( shell, completed, total );
+								setImportSummary( shell, created, existing, failed );
+							} );
+					} );
+				}, Promise.resolve() ).then( function () {
+					setImportStatus( shell, 'Import complete.' );
+				} );
+			} )
+			.catch( function ( error ) {
+				setImportStatus( shell, error.message || 'Import failed.' );
+			} )
+			.finally( function () {
+				if ( button ) {
+					button.disabled = false;
+					button.textContent = 'Import URLs';
+				}
+			} );
+	}
+
 	var noteSaveTimers = {};
 
 	function queueNoteTextSave( textarea ) {
@@ -781,6 +944,18 @@
 		}
 	} );
 
+	document.addEventListener( 'change', function ( event ) {
+		if ( ! matches( event.target, '.pc-import-file-control input[type="file"]' ) ) {
+			return;
+		}
+
+		var field = closest( event.target, '.pc-import-file-field' );
+		var name = field ? field.querySelector( '[data-import-file-name]' ) : null;
+		if ( name ) {
+			name.textContent = event.target.files && event.target.files.length ? event.target.files[0].name : 'No file selected';
+		}
+	} );
+
 	document.addEventListener( 'mouseover', function ( event ) {
 		var noteStar = closest( event.target, '.pc-note-star' );
 		var ratingContainer = noteStar ? closest( noteStar, '.pc-note-rating' ) : null;
@@ -844,6 +1019,13 @@
 	}, true );
 
 	document.addEventListener( 'submit', function ( event ) {
+		var importForm = closest( event.target, '.pc-import-form' );
+		if ( importForm ) {
+			event.preventDefault();
+			runImport( importForm );
+			return;
+		}
+
 		var form = closest( event.target, '.pc-quick-edit-form' );
 		if ( ! form ) {
 			return;

--- a/class-post-collection-app.php
+++ b/class-post-collection-app.php
@@ -91,6 +91,8 @@ class Post_Collection_App {
 		add_action( 'wp_loaded', array( $this, 'handle_collection_settings' ) );
 		add_action( 'wp_loaded', array( $this, 'handle_create_collection' ) );
 		add_action( 'wp_ajax_post_collection_quick_edit', array( $this, 'wp_ajax_quick_edit' ) );
+		add_action( 'wp_ajax_post_collection_parse_import', array( $this, 'wp_ajax_parse_import' ) );
+		add_action( 'wp_ajax_post_collection_import_item', array( $this, 'wp_ajax_import_item' ) );
 		add_action( 'wp_ajax_post_collection_toggle_read_status', array( $this, 'wp_ajax_toggle_read_status' ) );
 		add_filter( 'private_title_format', array( $this, 'filter_private_title_format' ), 10, 2 );
 
@@ -98,6 +100,7 @@ class Post_Collection_App {
 		$this->app->route( 'new', 'new.php' );
 		$this->app->route( 'review', 'review.php' );
 		$this->app->route( '{collection}/settings', 'settings.php' );
+		$this->app->route( '{collection}/import', 'import.php' );
 		$this->app->route( '{collection}/review', 'review.php' );
 		$this->app->route( '{collection}', 'collection.php' );
 		$this->app->route( '{collection}/{post_id}', 'post.php' );
@@ -221,6 +224,16 @@ class Post_Collection_App {
 	 */
 	public function get_collection_settings_url( $collection ) {
 		return trailingslashit( $this->get_collection_url( $collection ) . 'settings' );
+	}
+
+	/**
+	 * Get the import URL for a collection.
+	 *
+	 * @param \WP_Term $collection The collection term.
+	 * @return string
+	 */
+	public function get_collection_import_url( $collection ) {
+		return trailingslashit( $this->get_collection_url( $collection ) . 'import' );
 	}
 
 	/**
@@ -428,6 +441,152 @@ class Post_Collection_App {
 
 		wp_safe_redirect( add_query_arg( 'pc-settings-updated', '1', $this->get_collection_settings_url( $collection ) ) );
 		exit;
+	}
+
+	/**
+	 * Read an uploaded import file.
+	 *
+	 * @param array $file Uploaded file data.
+	 * @return array|\WP_Error Import source or error.
+	 */
+	private function get_import_upload_source( array $file ) {
+		if ( UPLOAD_ERR_OK !== (int) $file['error'] ) {
+			return new \WP_Error( 'upload_error', __( 'The import file could not be uploaded.', 'post-collection' ), array( 'status' => 400 ) );
+		}
+
+		$filename  = isset( $file['name'] ) ? sanitize_file_name( wp_unslash( $file['name'] ) ) : '';
+		$extension = strtolower( pathinfo( $filename, PATHINFO_EXTENSION ) );
+		if ( ! in_array( $extension, array( 'csv', 'html', 'htm', 'xml', 'rss', 'atom', 'txt' ), true ) ) {
+			return new \WP_Error( 'unsupported_import_file', __( 'Please upload a CSV, bookmarks HTML, RSS, Atom, XML, or text file.', 'post-collection' ), array( 'status' => 400 ) );
+		}
+
+		$max_size = (int) apply_filters( 'post_collection_import_upload_size_limit', 5 * 1024 * 1024 );
+		$size     = isset( $file['size'] ) ? (int) $file['size'] : 0;
+		if ( $max_size > 0 && $size > $max_size ) {
+			return new \WP_Error( 'import_file_too_large', __( 'The import file is too large.', 'post-collection' ), array( 'status' => 413 ) );
+		}
+
+		$tmp_name = isset( $file['tmp_name'] ) ? $file['tmp_name'] : '';
+		if ( ! $tmp_name || ! is_uploaded_file( $tmp_name ) ) {
+			return new \WP_Error( 'invalid_import_upload', __( 'The import file upload is invalid.', 'post-collection' ), array( 'status' => 400 ) );
+		}
+
+		$content = file_get_contents( $tmp_name );
+		if ( false === $content ) {
+			return new \WP_Error( 'import_file_unreadable', __( 'The import file could not be read.', 'post-collection' ), array( 'status' => 400 ) );
+		}
+
+		return array(
+			'content'  => $content,
+			'filename' => $filename,
+		);
+	}
+
+	/**
+	 * Parse an import source for the client-side importer.
+	 */
+	public function wp_ajax_parse_import() {
+		$collection = $this->get_import_collection_from_ajax_request();
+		if ( is_wp_error( $collection ) ) {
+			wp_send_json_error(
+				array(
+					'message' => $collection->get_error_message(),
+				),
+				$collection->get_error_data( 'status' ) ? $collection->get_error_data( 'status' ) : 400
+			);
+		}
+
+		$sources    = array();
+		$raw_import = isset( $_POST['import_urls'] ) ? wp_unslash( $_POST['import_urls'] ) : '';
+		if ( trim( (string) $raw_import ) ) {
+			$sources[] = array(
+				'content'  => $raw_import,
+				'filename' => 'pasted.txt',
+			);
+		}
+
+		if ( isset( $_FILES['import_file'] ) && isset( $_FILES['import_file']['error'] ) && UPLOAD_ERR_NO_FILE !== (int) $_FILES['import_file']['error'] ) {
+			$file_source = $this->get_import_upload_source( $_FILES['import_file'] );
+			if ( is_wp_error( $file_source ) ) {
+				wp_send_json_error(
+					array(
+						'message' => $file_source->get_error_message(),
+					),
+					$file_source->get_error_data( 'status' ) ? $file_source->get_error_data( 'status' ) : 400
+				);
+			}
+			$sources[] = $file_source;
+		}
+
+		$items = $this->post_collection->parse_import_sources( $sources );
+
+		wp_send_json_success(
+			array(
+				'items' => $items,
+				'total' => count( $items ),
+			)
+		);
+	}
+
+	/**
+	 * Import one item for the client-side importer.
+	 */
+	public function wp_ajax_import_item() {
+		$collection = $this->get_import_collection_from_ajax_request();
+		if ( is_wp_error( $collection ) ) {
+			wp_send_json_error(
+				array(
+					'message' => $collection->get_error_message(),
+				),
+				$collection->get_error_data( 'status' ) ? $collection->get_error_data( 'status' ) : 400
+			);
+		}
+
+		$item = array(
+			'url'   => isset( $_POST['url'] ) ? wp_unslash( $_POST['url'] ) : '',
+			'title' => isset( $_POST['title'] ) ? wp_unslash( $_POST['title'] ) : '',
+			'tags'  => isset( $_POST['tags'] ) ? wp_unslash( $_POST['tags'] ) : array(),
+		);
+
+		if ( is_string( $item['tags'] ) ) {
+			$item['tags'] = array_filter( array_map( 'trim', explode( ',', $item['tags'] ) ) );
+		}
+
+		$result = $this->post_collection->import_item_to_collection( $collection, $item );
+		if ( is_wp_error( $result ) ) {
+			wp_send_json_error(
+				array(
+					'message' => $result->get_error_message(),
+					'url'     => isset( $item['url'] ) ? $item['url'] : '',
+				),
+				$result->get_error_data( 'status' ) ? $result->get_error_data( 'status' ) : 400
+			);
+		}
+
+		wp_send_json_success( $result );
+	}
+
+	/**
+	 * Validate and resolve the collection for import AJAX requests.
+	 *
+	 * @return \WP_Term|\WP_Error
+	 */
+	private function get_import_collection_from_ajax_request() {
+		if ( ! $this->can_manage_collections() ) {
+			return new \WP_Error( 'forbidden', __( 'Sorry, you are not allowed to import into this collection.', 'post-collection' ), array( 'status' => 403 ) );
+		}
+
+		$term_id = isset( $_POST['collection_term_id'] ) ? absint( wp_unslash( $_POST['collection_term_id'] ) ) : 0;
+		if ( ! $term_id || ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'post-collection-import-' . $term_id ) ) {
+			return new \WP_Error( 'invalid_nonce', __( 'The collection import request could not be verified.', 'post-collection' ), array( 'status' => 403 ) );
+		}
+
+		$collection = get_term( $term_id, Post_Collection::COLLECTION_TAXONOMY );
+		if ( ! $collection || is_wp_error( $collection ) ) {
+			return new \WP_Error( 'invalid_collection', __( 'Invalid post collection.', 'post-collection' ), array( 'status' => 404 ) );
+		}
+
+		return $collection;
 	}
 
 	/**

--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -1276,6 +1276,24 @@ class Post_Collection {
 	private function url_to_collection_term_postid( $url, \WP_Term $collection ) {
 		global $wpdb;
 
+		if ( ! $wpdb || empty( $wpdb->posts ) ) {
+			$posts = get_posts(
+				array(
+					'post_type'      => self::CPT,
+					'post_status'    => array( 'publish', 'private', 'trash' ),
+					'posts_per_page' => -1,
+				)
+			);
+
+			foreach ( $posts as $post ) {
+				if ( $url === $post->guid && has_term( (int) $collection->term_id, self::COLLECTION_TAXONOMY, $post ) ) {
+					return (int) $post->ID;
+				}
+			}
+
+			return null;
+		}
+
 		$post_id = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT p.ID
@@ -1358,6 +1376,7 @@ class Post_Collection {
 					'post_id'           => (int) $post_id,
 					'created'           => false,
 					'content_extracted' => false,
+					'word_count'        => $this->get_post_word_count( $post_id ),
 				);
 			}
 
@@ -1434,10 +1453,450 @@ class Post_Collection {
 				'post_id'           => (int) $post_id,
 				'created'           => true,
 				'content_extracted' => $content_extracted,
+				'word_count'        => $this->get_post_word_count( $post_id ),
 			);
 		}
 
 		return (int) $post_id;
+	}
+
+	/**
+	 * Count words in a collected post.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return int Word count.
+	 */
+	private function get_post_word_count( $post_id ) {
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return 0;
+		}
+
+		$charset = function_exists( 'get_bloginfo' ) && get_bloginfo( 'charset' ) ? get_bloginfo( 'charset' ) : 'UTF-8';
+		$content = html_entity_decode( wp_strip_all_tags( $post->post_content ), ENT_QUOTES, $charset );
+
+		return str_word_count( $content );
+	}
+
+	/**
+	 * Parse import text into unique URLs.
+	 *
+	 * @param string $raw_import Plain text, bookmark export HTML, or mixed pasted content.
+	 * @return array URL strings.
+	 */
+	public function parse_import_urls( $raw_import ) {
+		return array_map(
+			function ( $item ) {
+				return $item['url'];
+			},
+			$this->parse_import_items( $raw_import )
+		);
+	}
+
+	/**
+	 * Parse import text into unique import items.
+	 *
+	 * @param string $raw_import Plain text, bookmark HTML, CSV, RSS, or Atom.
+	 * @param string $filename Optional source filename.
+	 * @return array Import items.
+	 */
+	public function parse_import_items( $raw_import, $filename = '' ) {
+		$raw_import = (string) $raw_import;
+		$extension  = strtolower( pathinfo( (string) $filename, PATHINFO_EXTENSION ) );
+		$trimmed    = ltrim( $raw_import );
+
+		if ( 'csv' === $extension || $this->looks_like_csv_import( $raw_import ) ) {
+			return $this->deduplicate_import_items( $this->parse_csv_import_items( $raw_import ) );
+		}
+
+		if ( in_array( $extension, array( 'xml', 'rss', 'atom' ), true ) || 0 === strpos( $trimmed, '<?xml' ) || 0 === strpos( $trimmed, '<rss' ) || 0 === strpos( $trimmed, '<feed' ) ) {
+			$items = $this->parse_feed_import_items( $raw_import );
+			if ( $items ) {
+				return $this->deduplicate_import_items( $items );
+			}
+		}
+
+		return $this->deduplicate_import_items( $this->parse_text_import_items( $raw_import ) );
+	}
+
+	/**
+	 * Parse multiple import sources.
+	 *
+	 * @param array $sources Import source arrays with content and filename keys.
+	 * @return array Import items.
+	 */
+	public function parse_import_sources( array $sources ) {
+		$items = array();
+		foreach ( $sources as $source ) {
+			if ( ! is_array( $source ) ) {
+				continue;
+			}
+
+			$items = array_merge(
+				$items,
+				$this->parse_import_items(
+					isset( $source['content'] ) ? $source['content'] : '',
+					isset( $source['filename'] ) ? $source['filename'] : ''
+				)
+			);
+		}
+
+		return $this->deduplicate_import_items( $items );
+	}
+
+	/**
+	 * Detect whether text appears to be a URL export CSV.
+	 *
+	 * @param string $raw_import Import text.
+	 * @return bool
+	 */
+	private function looks_like_csv_import( $raw_import ) {
+		$line = strtok( (string) $raw_import, "\r\n" );
+		if ( false === $line || false === strpos( $line, ',' ) ) {
+			return false;
+		}
+
+		$headers = array_map( array( $this, 'normalize_import_header' ), str_getcsv( $line ) );
+		return (bool) array_intersect( $headers, array( 'url', 'href', 'link', 'resolved_url', 'given_url' ) );
+	}
+
+	/**
+	 * Parse a CSV import source.
+	 *
+	 * @param string $raw_import CSV text.
+	 * @return array Import items.
+	 */
+	private function parse_csv_import_items( $raw_import ) {
+		$handle = fopen( 'php://temp', 'r+' );
+		if ( ! $handle ) {
+			return array();
+		}
+
+		fwrite( $handle, (string) $raw_import );
+		rewind( $handle );
+
+		$headers = fgetcsv( $handle );
+		if ( ! is_array( $headers ) ) {
+			fclose( $handle );
+			return array();
+		}
+
+		$headers    = array_map( array( $this, 'normalize_import_header' ), $headers );
+		$url_index  = $this->find_import_column( $headers, array( 'url', 'href', 'link', 'resolved_url', 'given_url' ) );
+		$title_index = $this->find_import_column( $headers, array( 'title', 'item_title', 'resolved_title', 'given_title', 'name' ) );
+		$tags_index = $this->find_import_column( $headers, array( 'tags', 'tag' ) );
+		$items      = array();
+
+		if ( null === $url_index ) {
+			fclose( $handle );
+			return array();
+		}
+
+		while ( false !== ( $row = fgetcsv( $handle ) ) ) {
+			$items[] = $this->normalize_import_item(
+				array(
+					'url'   => isset( $row[ $url_index ] ) ? $row[ $url_index ] : '',
+					'title' => null !== $title_index && isset( $row[ $title_index ] ) ? $row[ $title_index ] : '',
+					'tags'  => null !== $tags_index && isset( $row[ $tags_index ] ) ? $this->split_import_tags( $row[ $tags_index ] ) : array(),
+				)
+			);
+		}
+
+		fclose( $handle );
+		return $items;
+	}
+
+	/**
+	 * Parse RSS or Atom feed text.
+	 *
+	 * @param string $raw_import XML text.
+	 * @return array Import items.
+	 */
+	private function parse_feed_import_items( $raw_import ) {
+		if ( ! function_exists( 'simplexml_load_string' ) ) {
+			return array();
+		}
+
+		$previous = libxml_use_internal_errors( true );
+		$xml      = simplexml_load_string( (string) $raw_import, 'SimpleXMLElement', LIBXML_NONET | LIBXML_NOCDATA );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous );
+
+		if ( ! $xml ) {
+			return array();
+		}
+
+		$items = array();
+		if ( isset( $xml->channel->item ) ) {
+			foreach ( $xml->channel->item as $item ) {
+				$tags = array();
+				foreach ( $item->category as $category ) {
+					$tags[] = (string) $category;
+				}
+				$items[] = $this->normalize_import_item(
+					array(
+						'url'   => (string) $item->link,
+						'title' => (string) $item->title,
+						'tags'  => $tags,
+					)
+				);
+			}
+		} elseif ( 'feed' === strtolower( $xml->getName() ) ) {
+			foreach ( $xml->entry as $entry ) {
+				$url = '';
+				foreach ( $entry->link as $link ) {
+					$attrs = $link->attributes();
+					$rel   = isset( $attrs['rel'] ) ? (string) $attrs['rel'] : 'alternate';
+					if ( isset( $attrs['href'] ) && 'alternate' === $rel ) {
+						$url = (string) $attrs['href'];
+						break;
+					}
+				}
+				$tags = array();
+				foreach ( $entry->category as $category ) {
+					$attrs = $category->attributes();
+					$tags[] = isset( $attrs['term'] ) ? (string) $attrs['term'] : (string) $category;
+				}
+				$items[] = $this->normalize_import_item(
+					array(
+						'url'   => $url,
+						'title' => (string) $entry->title,
+						'tags'  => $tags,
+					)
+				);
+			}
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Parse loose text and bookmark HTML.
+	 *
+	 * @param string $raw_import Import text.
+	 * @return array Import items.
+	 */
+	private function parse_text_import_items( $raw_import ) {
+		$charset    = function_exists( 'get_bloginfo' ) && get_bloginfo( 'charset' ) ? get_bloginfo( 'charset' ) : 'UTF-8';
+		$raw_import = html_entity_decode( (string) $raw_import, ENT_QUOTES, $charset );
+		$items      = array();
+
+		if ( preg_match_all( '/<a\b[^>]*href=[\'"]([^\'"]+)[\'"][^>]*>(.*?)<\/a>/is', $raw_import, $matches, PREG_SET_ORDER ) ) {
+			foreach ( $matches as $match ) {
+				$items[] = $this->normalize_import_item(
+					array(
+						'url'   => $match[1],
+						'title' => wp_strip_all_tags( $match[2] ),
+					)
+				);
+			}
+		}
+
+		if ( preg_match_all( '#https?://[^\s<>"\']+#i', $raw_import, $matches ) ) {
+			foreach ( $matches[0] as $url ) {
+				$items[] = $this->normalize_import_item( array( 'url' => $url ) );
+			}
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Normalize an import item.
+	 *
+	 * @param array $item Import item.
+	 * @return array
+	 */
+	private function normalize_import_item( array $item ) {
+		$url    = isset( $item['url'] ) ? trim( (string) $item['url'] ) : '';
+		$url    = preg_replace( '/[)\].,;:]+$/', '', $url );
+		$url    = esc_url_raw( $url );
+		$scheme = strtolower( (string) wp_parse_url( $url, PHP_URL_SCHEME ) );
+
+		if ( ! in_array( $scheme, array( 'http', 'https' ), true ) || ! $url || ! $this->check_url( $url ) ) {
+			$url = '';
+		}
+
+		return array(
+			'url'   => $url,
+			'title' => isset( $item['title'] ) ? wp_strip_all_tags( trim( sanitize_text_field( $item['title'] ) ) ) : '',
+			'tags'  => isset( $item['tags'] ) && is_array( $item['tags'] ) ? $this->sanitize_import_tags( $item['tags'] ) : array(),
+		);
+	}
+
+	/**
+	 * Deduplicate and remove invalid import items.
+	 *
+	 * @param array $items Import items.
+	 * @return array
+	 */
+	private function deduplicate_import_items( array $items ) {
+		$clean_items = array();
+		foreach ( $items as $item ) {
+			if ( empty( $item['url'] ) ) {
+				continue;
+			}
+
+			$key = strtolower( $item['url'] );
+			if ( isset( $clean_items[ $key ] ) ) {
+				continue;
+			}
+
+			$clean_items[ $key ] = $item;
+		}
+
+		return array_values( $clean_items );
+	}
+
+	/**
+	 * Normalize a CSV header.
+	 *
+	 * @param string $header Header text.
+	 * @return string
+	 */
+	private function normalize_import_header( $header ) {
+		return trim( preg_replace( '/[^a-z0-9]+/', '_', strtolower( (string) $header ) ), '_' );
+	}
+
+	/**
+	 * Find a matching CSV column index.
+	 *
+	 * @param array $headers Header names.
+	 * @param array $candidates Candidate names.
+	 * @return int|null
+	 */
+	private function find_import_column( array $headers, array $candidates ) {
+		foreach ( $candidates as $candidate ) {
+			$index = array_search( $candidate, $headers, true );
+			if ( false !== $index ) {
+				return (int) $index;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Split tag text from imports.
+	 *
+	 * @param string $raw_tags Raw tag text.
+	 * @return array
+	 */
+	private function split_import_tags( $raw_tags ) {
+		return $this->sanitize_import_tags( preg_split( '/[,|;]+/', (string) $raw_tags ) );
+	}
+
+	/**
+	 * Sanitize import tag names.
+	 *
+	 * @param array $tags Tag names.
+	 * @return array
+	 */
+	private function sanitize_import_tags( array $tags ) {
+		$tags = array_map(
+			function ( $tag ) {
+				return sanitize_text_field( wp_strip_all_tags( trim( (string) $tag ) ) );
+			},
+			$tags
+		);
+
+		return array_values( array_unique( array_filter( $tags ) ) );
+	}
+
+	/**
+	 * Import URLs into a taxonomy-backed collection.
+	 *
+	 * @param \WP_Term $collection Collection term.
+	 * @param string   $raw_import Plain text or exported bookmark HTML.
+	 * @return array Import summary.
+	 */
+	public function import_urls_to_collection( \WP_Term $collection, $raw_import, $filename = '' ) {
+		$all_items = array();
+		if ( is_array( $raw_import ) ) {
+			$all_items = $this->parse_import_sources( $raw_import );
+		} else {
+			$all_items = $this->parse_import_items( $raw_import, $filename );
+		}
+
+		$items    = $all_items;
+		$max      = (int) apply_filters( 'post_collection_import_url_limit', 100, $collection );
+
+		if ( $max > 0 && count( $items ) > $max ) {
+			$items = array_slice( $items, 0, $max );
+		}
+
+		$result = array(
+			'total'     => count( $items ),
+			'created'   => 0,
+			'existing'  => 0,
+			'imported'  => 0,
+			'failed'    => 0,
+			'errors'    => array(),
+			'truncated' => $max > 0 && count( $all_items ) > $max,
+			'limit'     => $max,
+		);
+
+		foreach ( $items as $item ) {
+			$save = $this->import_item_to_collection( $collection, $item );
+
+			if ( is_wp_error( $save ) ) {
+				$result['failed']++;
+				$result['errors'][] = array(
+					'url'     => $item['url'],
+					'message' => $save->get_error_message(),
+				);
+				continue;
+			}
+
+			$result['imported']++;
+			if ( ! empty( $save['created'] ) ) {
+				$result['created']++;
+			} else {
+				$result['existing']++;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Import one normalized item into a taxonomy-backed collection.
+	 *
+	 * @param \WP_Term $collection Collection term.
+	 * @param array    $item Import item.
+	 * @return array|\WP_Error Imported item result.
+	 */
+	public function import_item_to_collection( \WP_Term $collection, array $item ) {
+		$item = $this->normalize_import_item( $item );
+		if ( empty( $item['url'] ) ) {
+			return new \WP_Error( 'invalid-url', __( 'You entered an invalid URL.', 'post-collection' ), array( 'status' => 400 ) );
+		}
+
+		$save = $this->save_url_to_collection_term(
+			$item['url'],
+			$collection,
+			null,
+			array(
+				'title'          => $item['title'],
+				'tags'           => $item['tags'],
+				'return_details' => true,
+			)
+		);
+
+		if ( is_wp_error( $save ) ) {
+			return $save;
+		}
+
+		$post_id = (int) $save['post_id'];
+
+		return array(
+			'post_id'           => $post_id,
+			'url'               => $item['url'],
+			'title'             => get_the_title( $post_id ),
+			'created'           => ! empty( $save['created'] ),
+			'content_extracted' => ! empty( $save['content_extracted'] ),
+			'word_count'        => isset( $save['word_count'] ) ? (int) $save['word_count'] : 0,
+		);
 	}
 
 	/**
@@ -1686,17 +2145,25 @@ class Post_Collection {
 		$post_id      = $save_details['post_id'];
 		$edit_url = get_edit_post_link( $post_id, 'raw' );
 		$item_url = home_url( '/post-collection/' . $collection->slug . '/' . $post_id . '/' );
+		$word_count = isset( $save_details['word_count'] ) ? (int) $save_details['word_count'] : 0;
+		$word_count_label = sprintf(
+			// translators: %d is the number of words in the saved article.
+			__( '%d words', 'post-collection' ),
+			$word_count
+		);
 		if ( ! empty( $save_details['content_extracted'] ) ) {
 			$message = sprintf(
-				// translators: %s is the name of a post collection.
-				__( 'Saved extracted content to %s.', 'post-collection' ),
-				$collection->name
+				// translators: 1: post collection name, 2: article word count.
+				__( 'Saved extracted content to %1$s. %2$s.', 'post-collection' ),
+				$collection->name,
+				$word_count_label
 			);
 		} else {
 			$message = sprintf(
-				// translators: %s is the name of a post collection.
-				__( 'Saved to %s. This URL was already in the collection.', 'post-collection' ),
-				$collection->name
+				// translators: 1: post collection name, 2: article word count.
+				__( 'Saved to %1$s. This URL was already in the collection. %2$s.', 'post-collection' ),
+				$collection->name,
+				$word_count_label
 			);
 		}
 
@@ -1705,6 +2172,8 @@ class Post_Collection {
 			'message'           => $message,
 			'created'           => ! empty( $save_details['created'] ),
 			'content_extracted' => ! empty( $save_details['content_extracted'] ),
+			'word_count'        => $word_count,
+			'word_count_label'  => $word_count_label,
 			'edit_url'          => $edit_url ? $edit_url : '',
 			'url'               => $item_url ? $item_url : '',
 			'link_label'        => __( 'Open', 'post-collection' ),

--- a/templates/app/collection.php
+++ b/templates/app/collection.php
@@ -72,6 +72,7 @@ if ( '' !== $active_tag ) {
 				<?php if ( $app->can_manage_collections() ) : ?>
 					<div class="pc-app-header-actions">
 						<a class="pc-button" href="<?php echo esc_url( $app->get_collection_review_url( $collection ) ); ?>"><?php esc_html_e( 'Review Articles', 'post-collection' ); ?></a>
+						<a class="pc-button" href="<?php echo esc_url( $app->get_collection_import_url( $collection ) ); ?>"><?php esc_html_e( 'Import', 'post-collection' ); ?></a>
 						<a class="pc-button" href="<?php echo esc_url( $app->get_collection_settings_url( $collection ) ); ?>"><?php esc_html_e( 'Settings', 'post-collection' ); ?></a>
 					</div>
 				<?php endif; ?>
@@ -155,13 +156,18 @@ if ( '' !== $active_tag ) {
 					<a class="pc-button" href="<?php echo esc_url( add_query_arg( 'pc-view', $view, $base_url ) ); ?>"><?php esc_html_e( 'Clear filters', 'post-collection' ); ?></a>
 				<?php elseif ( $app->can_manage_collections() ) : ?>
 					<h2><?php esc_html_e( 'Start saving to this collection', 'post-collection' ); ?></h2>
-					<p><?php esc_html_e( 'Use the bookmarklet, paste a URL above, or save directly from your browser.', 'post-collection' ); ?></p>
+					<p><?php esc_html_e( 'Import an existing list, paste a URL above, or save directly from your browser.', 'post-collection' ); ?></p>
 					<div class="pc-save-tabs" data-pc-tabs>
 						<div class="pc-save-tab-list" role="tablist" aria-label="<?php esc_attr_e( 'Save methods', 'post-collection' ); ?>">
-							<button type="button" class="is-active" role="tab" aria-selected="true" aria-controls="pc-empty-bookmarklet-panel-<?php echo esc_attr( $collection->term_id ); ?>" id="pc-empty-bookmarklet-tab-<?php echo esc_attr( $collection->term_id ); ?>" data-pc-tab="bookmarklet"><?php esc_html_e( 'Bookmarklet', 'post-collection' ); ?></button>
+							<button type="button" class="is-active" role="tab" aria-selected="true" aria-controls="pc-empty-import-panel-<?php echo esc_attr( $collection->term_id ); ?>" id="pc-empty-import-tab-<?php echo esc_attr( $collection->term_id ); ?>" data-pc-tab="import"><?php esc_html_e( 'Import', 'post-collection' ); ?></button>
+							<button type="button" role="tab" aria-selected="false" aria-controls="pc-empty-bookmarklet-panel-<?php echo esc_attr( $collection->term_id ); ?>" id="pc-empty-bookmarklet-tab-<?php echo esc_attr( $collection->term_id ); ?>" data-pc-tab="bookmarklet" tabindex="-1"><?php esc_html_e( 'Bookmarklet', 'post-collection' ); ?></button>
 							<button type="button" role="tab" aria-selected="false" aria-controls="pc-empty-extension-panel-<?php echo esc_attr( $collection->term_id ); ?>" id="pc-empty-extension-tab-<?php echo esc_attr( $collection->term_id ); ?>" data-pc-tab="extension" tabindex="-1"><?php esc_html_e( 'Browser extension', 'post-collection' ); ?></button>
 						</div>
-						<div id="pc-empty-bookmarklet-panel-<?php echo esc_attr( $collection->term_id ); ?>" class="pc-save-tab-panel is-active" role="tabpanel" aria-labelledby="pc-empty-bookmarklet-tab-<?php echo esc_attr( $collection->term_id ); ?>" data-pc-tab-panel="bookmarklet">
+						<div id="pc-empty-import-panel-<?php echo esc_attr( $collection->term_id ); ?>" class="pc-save-tab-panel is-active" role="tabpanel" aria-labelledby="pc-empty-import-tab-<?php echo esc_attr( $collection->term_id ); ?>" data-pc-tab-panel="import">
+							<p><?php esc_html_e( 'Paste a list of URLs or a browser bookmark export and Post Collection will add each article here.', 'post-collection' ); ?></p>
+							<a class="pc-button pc-button-primary" href="<?php echo esc_url( $app->get_collection_import_url( $collection ) ); ?>"><?php esc_html_e( 'Import URLs', 'post-collection' ); ?></a>
+						</div>
+						<div id="pc-empty-bookmarklet-panel-<?php echo esc_attr( $collection->term_id ); ?>" class="pc-save-tab-panel" role="tabpanel" aria-labelledby="pc-empty-bookmarklet-tab-<?php echo esc_attr( $collection->term_id ); ?>" data-pc-tab-panel="bookmarklet" hidden>
 							<p><?php esc_html_e( "Drag this bookmarklet to your bookmarks bar, then click it when you're on an article you want to save.", 'post-collection' ); ?></p>
 							<?php
 							$app->get_post_collection()->render_bookmarklet_link(

--- a/templates/app/import.php
+++ b/templates/app/import.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Frontend app collection import.
+ *
+ * @package Post_Collection
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$app = \PostCollection\Post_Collection_App::instance();
+if ( ! $app ) {
+	status_header( 500 );
+	return;
+}
+
+if ( ! $app->can_manage_collections() ) {
+	status_header( 403 );
+	include __DIR__ . '/403.php';
+	return;
+}
+
+$collection_slug = wp_app_get_route_var( 'collection' );
+$collection      = $app->get_collection_by_username( $collection_slug );
+if ( ! $collection || ! $app->can_view_collection( $collection ) ) {
+	status_header( 404 );
+	include __DIR__ . '/404.php';
+	return;
+}
+
+?>
+<!DOCTYPE html>
+<html <?php echo wp_app_language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title><?php echo wp_app_title( __( 'Import URLs', 'post-collection' ) ); ?></title>
+	<?php wp_app_head(); ?>
+</head>
+<body <?php body_class( 'wp-app-body post-collection-app pc-import-page' ); ?>>
+	<?php wp_app_body_open(); ?>
+	<header class="pc-shell pc-detail-header">
+		<div class="pc-breadcrumb"><a href="<?php echo esc_url( $app->get_collection_url( $collection ) ); ?>"><?php echo esc_html( $collection->name ); ?></a></div>
+		<p class="pc-kicker"><?php esc_html_e( 'Bulk import', 'post-collection' ); ?></p>
+		<h1><?php esc_html_e( 'Import URLs', 'post-collection' ); ?></h1>
+	</header>
+
+	<main class="pc-shell pc-import-layout">
+		<section class="pc-import-main">
+			<form class="pc-import-form" method="post" enctype="multipart/form-data" action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" data-parse-action="post_collection_parse_import" data-import-action="post_collection_import_item">
+				<input type="hidden" name="collection_term_id" value="<?php echo esc_attr( $collection->term_id ); ?>">
+				<?php wp_nonce_field( 'post-collection-import-' . $collection->term_id ); ?>
+				<label class="pc-import-file-field" for="pc-import-file">
+					<span><?php esc_html_e( 'Import file', 'post-collection' ); ?></span>
+					<span class="pc-import-file-control">
+						<span class="pc-import-file-button"><?php esc_html_e( 'Choose file', 'post-collection' ); ?></span>
+						<span class="pc-import-file-name" data-import-file-name><?php esc_html_e( 'No file selected', 'post-collection' ); ?></span>
+						<input id="pc-import-file" type="file" name="import_file" accept=".csv,.html,.htm,.xml,.rss,.atom,.txt,text/csv,text/html,application/rss+xml,application/atom+xml,application/xml,text/xml,text/plain">
+					</span>
+				</label>
+				<label for="pc-import-urls">
+					<span><?php esc_html_e( 'Paste URLs or export contents', 'post-collection' ); ?></span>
+					<textarea id="pc-import-urls" name="import_urls" rows="14" placeholder="https://example.com/article-one&#10;https://example.com/article-two"></textarea>
+				</label>
+				<div class="pc-form-actions">
+					<a class="pc-button" href="<?php echo esc_url( $app->get_collection_url( $collection ) ); ?>"><?php esc_html_e( 'Back to Collection', 'post-collection' ); ?></a>
+					<button type="submit"><?php esc_html_e( 'Import URLs', 'post-collection' ); ?></button>
+				</div>
+			</form>
+
+			<section class="pc-import-progress" data-import-progress hidden>
+				<div class="pc-import-progress-header">
+					<div>
+						<h2><?php esc_html_e( 'Import progress', 'post-collection' ); ?></h2>
+						<p data-import-status><?php esc_html_e( 'Waiting to start.', 'post-collection' ); ?></p>
+					</div>
+					<div class="pc-import-progress-counts" aria-live="polite">
+						<strong data-import-completed>0</strong>
+						<span>/</span>
+						<span data-import-total>0</span>
+					</div>
+				</div>
+				<progress class="pc-import-progress-bar" data-import-progress-bar value="0" max="1"></progress>
+				<div class="pc-import-summary" data-import-summary></div>
+				<ul class="pc-import-log" data-import-log></ul>
+			</section>
+		</section>
+
+		<aside class="pc-import-aside">
+			<h2><?php esc_html_e( 'Accepted formats', 'post-collection' ); ?></h2>
+			<ul>
+				<li><?php esc_html_e( 'One URL per line from another reading list.', 'post-collection' ); ?></li>
+				<li><?php esc_html_e( 'Pocket CSV exports and other URL CSV files.', 'post-collection' ); ?></li>
+				<li><?php esc_html_e( 'Browser bookmarks.html exports.', 'post-collection' ); ?></li>
+				<li><?php esc_html_e( 'RSS or Atom feed files.', 'post-collection' ); ?></li>
+			</ul>
+			<p><?php esc_html_e( 'Each URL is downloaded and article content is extracted as it imports, so large files can take a while.', 'post-collection' ); ?></p>
+		</aside>
+	</main>
+	<?php wp_app_body_close(); ?>
+</body>
+</html>

--- a/tests/Test_Browser_Extension_Action.php
+++ b/tests/Test_Browser_Extension_Action.php
@@ -3,7 +3,6 @@
 use PHPUnit\Framework\TestCase;
 use PostCollection\ExtractedPage;
 use PostCollection\Post_Collection;
-use PostCollection\User;
 
 require_once __DIR__ . '/../class-post-collection.php';
 
@@ -44,7 +43,7 @@ class Test_Browser_Extension_Action extends TestCase {
 	}
 
 	public function test_save_response_reports_collected_post_word_count() {
-		$collection = $this->create_collection_user( 1, 'articles', 'Articles' );
+		$collection = $this->create_collection_term( 1, 'articles', 'Articles' );
 		$this->plugin->download_item = new ExtractedPage(
 			'https://source.example/post',
 			'Source Title',
@@ -53,7 +52,7 @@ class Test_Browser_Extension_Action extends TestCase {
 
 		$result = $this->plugin->friends_browser_extension_action_save(
 			null,
-			$this->create_request( $collection->ID ),
+			$this->create_request( $collection->term_id ),
 			new \WP_User( 99 ),
 			array()
 		);
@@ -66,11 +65,11 @@ class Test_Browser_Extension_Action extends TestCase {
 	}
 
 	public function test_existing_url_response_reports_existing_post_word_count() {
-		$collection = $this->create_collection_user( 2, 'saved', 'Saved Articles' );
+		$collection = $this->create_collection_term( 2, 'saved', 'Saved Articles' );
 		$post       = new \WP_Post(
 			(object) array(
 				'ID'           => 42,
-				'post_author'  => $collection->ID,
+				'post_author'  => 99,
 				'post_title'   => 'Existing',
 				'post_content' => '<p>Already saved words here.</p>',
 				'post_status'  => 'private',
@@ -80,11 +79,12 @@ class Test_Browser_Extension_Action extends TestCase {
 		);
 
 		$GLOBALS['wp_test_posts'][ $post->ID ] = $post;
+		$GLOBALS['wp_test_terms'][ $post->ID ][ Post_Collection::COLLECTION_TAXONOMY ] = array( $collection->term_id );
 		$this->plugin->existing_post_id       = $post->ID;
 
 		$result = $this->plugin->friends_browser_extension_action_save(
 			null,
-			$this->create_request( $collection->ID ),
+			$this->create_request( $collection->term_id ),
 			new \WP_User( 99 ),
 			array()
 		);
@@ -96,21 +96,19 @@ class Test_Browser_Extension_Action extends TestCase {
 		$this->assertStringContainsString( 'already in the collection', $result['message'] );
 	}
 
-	private function create_collection_user( $id, $login, $display_name ) {
-		$user = new User(
+	private function create_collection_term( $id, $slug, $name ) {
+		$term = new \WP_Term(
 			(object) array(
-				'ID'           => $id,
-				'user_login'   => $login,
-				'display_name' => $display_name,
-				'description'  => '',
-				'roles'        => array( 'post_collection' ),
-				'caps'         => array( 'post_collection' => true ),
+				'term_id'  => $id,
+				'name'     => $name,
+				'slug'     => $slug,
+				'taxonomy' => Post_Collection::COLLECTION_TAXONOMY,
 			)
 		);
 
-		$GLOBALS['wp_test_users'][ $id ] = $user;
+		$GLOBALS['wp_test_registered_terms'][ Post_Collection::COLLECTION_TAXONOMY ][ $id ] = $term;
 
-		return $user;
+		return $term;
 	}
 
 	private function create_request( $collection_id ) {

--- a/tests/Test_Import_Urls.php
+++ b/tests/Test_Import_Urls.php
@@ -1,0 +1,122 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use PostCollection\Post_Collection;
+
+require_once __DIR__ . '/../class-post-collection.php';
+
+class Post_Collection_Import_Test_Plugin extends Post_Collection {
+	public function __construct() {}
+}
+
+class Test_Import_Urls extends TestCase {
+	public function test_parse_import_urls_accepts_plain_lists_and_bookmark_exports() {
+		$plugin = new Post_Collection_Import_Test_Plugin();
+		$raw    = '<DT><A HREF="https://example.com/one?x=1&amp;y=2">One</A>'
+			. "\nhttps://example.com/two\n"
+			. 'Saved for later: https://example.com/three).'
+			. "\nhttps://example.com/two";
+
+		$this->assertSame(
+			array(
+				'https://example.com/one?x=1&y=2',
+				'https://example.com/two',
+				'https://example.com/three',
+			),
+			$plugin->parse_import_urls( $raw )
+		);
+	}
+
+	public function test_parse_import_urls_ignores_invalid_and_non_http_links() {
+		$plugin = new Post_Collection_Import_Test_Plugin();
+		$raw    = '<A HREF="javascript:alert(1)">Bad</A>'
+			. "\nftp://example.com/file"
+			. "\nhttps://example.com/good;";
+
+		$this->assertSame(
+			array( 'https://example.com/good' ),
+			$plugin->parse_import_urls( $raw )
+		);
+	}
+
+	public function test_parse_import_items_accepts_pocket_style_csv() {
+		$plugin = new Post_Collection_Import_Test_Plugin();
+		$csv    = "given_title,given_url,tags,status\n"
+			. "\"First Article\",https://example.com/first,\"ai, reading\",unread\n"
+			. "\"Second Article\",https://example.com/second,,archive\n";
+
+		$this->assertSame(
+			array(
+				array(
+					'url'   => 'https://example.com/first',
+					'title' => 'First Article',
+					'tags'  => array( 'ai', 'reading' ),
+				),
+				array(
+					'url'   => 'https://example.com/second',
+					'title' => 'Second Article',
+					'tags'  => array(),
+				),
+			),
+			$plugin->parse_import_items( $csv, 'pocket.csv' )
+		);
+	}
+
+	public function test_parse_import_items_accepts_rss_and_atom_files() {
+		$plugin = new Post_Collection_Import_Test_Plugin();
+		$rss    = '<?xml version="1.0"?><rss><channel><item><title>RSS Item</title><link>https://example.com/rss</link><category>news</category></item></channel></rss>';
+		$atom   = '<?xml version="1.0"?><feed><entry><title>Atom Item</title><link href="https://example.com/atom" rel="alternate"/><category term="research"/></entry></feed>';
+
+		$this->assertSame(
+			array(
+				array(
+					'url'   => 'https://example.com/rss',
+					'title' => 'RSS Item',
+					'tags'  => array( 'news' ),
+				),
+			),
+			$plugin->parse_import_items( $rss, 'feed.rss' )
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'url'   => 'https://example.com/atom',
+					'title' => 'Atom Item',
+					'tags'  => array( 'research' ),
+				),
+			),
+			$plugin->parse_import_items( $atom, 'feed.atom' )
+		);
+	}
+
+	public function test_parse_import_sources_deduplicates_across_file_and_paste_sources() {
+		$plugin = new Post_Collection_Import_Test_Plugin();
+		$sources = array(
+			array(
+				'content'  => "title,url\nOne,https://example.com/one\n",
+				'filename' => 'links.csv',
+			),
+			array(
+				'content'  => "https://example.com/one\nhttps://example.com/two",
+				'filename' => 'pasted.txt',
+			),
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'url'   => 'https://example.com/one',
+					'title' => 'One',
+					'tags'  => array(),
+				),
+				array(
+					'url'   => 'https://example.com/two',
+					'title' => '',
+					'tags'  => array(),
+				),
+			),
+			$plugin->parse_import_sources( $sources )
+		);
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -75,6 +75,10 @@ namespace {
 		return $data;
 	}
 
+	function wp_unslash( $value ) {
+		return is_array( $value ) ? array_map( 'wp_unslash', $value ) : stripslashes( (string) $value );
+	}
+
 	function force_balance_tags( $text ) {
 		return $text;
 	}
@@ -323,6 +327,20 @@ namespace {
 
 		public function get_posts() {
 			return $this->posts;
+		}
+	}
+
+	class WP_REST_Request {
+		private $params = array();
+
+		public function __construct( $method = '', $route = '' ) {}
+
+		public function set_body_params( $params ) {
+			$this->params = (array) $params;
+		}
+
+		public function get_param( $param ) {
+			return $this->params[ $param ] ?? null;
 		}
 	}
 


### PR DESCRIPTION
## Summary
- add a collection import route with upload support for CSV, browser bookmarks HTML, RSS/Atom/XML, and pasted URLs
- parse imports into normalized URL/title/tag items and import them one at a time over AJAX for live progress feedback
- surface import progress, per-item results, and onboarding links from empty collections

## Testing
- composer test
- php -l class-post-collection.php
- php -l class-post-collection-app.php
- php -l templates/app/import.php