### PR TITLE
Add Jina fallback for Cloudflare-protected pages

### DIFF
--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -2252,6 +2252,11 @@ class Post_Collection {
 				return $response;
 			}
 			if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+				$fallback_item = $this->maybe_download_cloudflare_protected_url( $url, wp_remote_retrieve_body( $response ), $response );
+				if ( ! is_wp_error( $fallback_item ) ) {
+					return $fallback_item;
+				}
+
 				return new \WP_Error(
 					'could-not-download',
 					__( 'Could not download the URL.', 'post-collection' ),
@@ -2266,12 +2271,34 @@ class Post_Collection {
 			$content = wp_remote_retrieve_body( $response );
 		}
 
+		$fallback_item = $this->maybe_download_cloudflare_protected_url( $url, $content, isset( $response ) ? $response : null );
+		if ( ! is_wp_error( $fallback_item ) ) {
+			return $fallback_item;
+		}
+
 		$item = $this->extract_content( $content, $url );
 		if ( is_wp_error( $item ) ) {
 			return $item;
 		}
 		$item->raw_html = $content;
 		return $item;
+	}
+
+	/**
+	 * Fetch URLs through Jina when a direct response is a Cloudflare challenge.
+	 *
+	 * @param string $url      The URL to download.
+	 * @param string $content  Response body.
+	 * @param array  $response Optional HTTP response.
+	 * @return ExtractedPage|\WP_Error Extracted item or a non-fallback error.
+	 */
+	private function maybe_download_cloudflare_protected_url( $url, $content, $response = null ) {
+		$cloudflare = new SiteConfig\Cloudflare_Protected();
+		if ( ! $cloudflare->is_challenge_response( (string) $content, $response ) ) {
+			return new \WP_Error( 'not-cloudflare-challenge', __( 'The response is not a Cloudflare challenge.', 'post-collection' ) );
+		}
+
+		return $cloudflare->download( $url );
 	}
 
 	/**

--- a/post-collection.php
+++ b/post-collection.php
@@ -35,6 +35,8 @@ require_once __DIR__ . '/class-post-collection-abilities.php';
 require_once __DIR__ . '/class-post-collection-app.php';
 require_once __DIR__ . '/class-extracted-page.php';
 require_once __DIR__ . '/site-configs/class-site-config.php';
+require_once __DIR__ . '/site-configs/class-jina.php';
+require_once __DIR__ . '/site-configs/class-cloudflare-protected.php';
 require_once __DIR__ . '/site-configs/class-youtube.php';
 require_once __DIR__ . '/includes/class-article-notes.php';
 

--- a/site-configs/class-cloudflare-protected.php
+++ b/site-configs/class-cloudflare-protected.php
@@ -1,0 +1,33 @@
+<?php
+namespace PostCollection\SiteConfig;
+
+defined( 'ABSPATH' ) || exit;
+
+class Cloudflare_Protected extends Jina {
+	public function is_url_supported( $url ) {
+		$scheme = wp_parse_url( $url, PHP_URL_SCHEME );
+		return in_array( strtolower( (string) $scheme ), array( 'http', 'https' ), true );
+	}
+
+	public function is_challenge_response( $html, $response = null ) {
+		if ( false !== stripos( $html, '/cdn-cgi/challenge-platform/' )
+			|| false !== stripos( $html, 'Enable JavaScript and cookies to continue' )
+			|| false !== stripos( $html, 'cf-mitigated' )
+		) {
+			return true;
+		}
+
+		if ( is_array( $response ) ) {
+			$cf_mitigated = wp_remote_retrieve_header( $response, 'cf-mitigated' );
+			if ( 'challenge' === strtolower( (string) $cf_mitigated ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	protected function get_reader_url_filter_name() {
+		return 'post_collection_cloudflare_jina_reader_url';
+	}
+}

--- a/site-configs/class-jina.php
+++ b/site-configs/class-jina.php
@@ -1,0 +1,158 @@
+<?php
+namespace PostCollection\SiteConfig;
+
+defined( 'ABSPATH' ) || exit;
+
+use PostCollection\ExtractedPage;
+
+abstract class Jina extends SiteConfig {
+	public function download( $url ) {
+		$item       = new ExtractedPage( $url );
+		$reader_url = $this->get_reader_url( $url );
+
+		if ( ! $reader_url ) {
+			return new \WP_Error(
+				'jina-reader-disabled',
+				__( 'Jina reader is disabled.', 'post-collection' ),
+				array(
+					'status' => 502,
+					'url'    => $url,
+				)
+			);
+		}
+
+		$response = wp_remote_get(
+			$reader_url,
+			array(
+				'timeout'     => 30,
+				'redirection' => 5,
+				'headers'     => array(
+					'user-agent' => 'WordPress; Post Collection Jina reader',
+					'accept'     => 'text/markdown,text/plain;q=0.9,*/*;q=0.1',
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$status = wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $status ) {
+			return new \WP_Error(
+				'jina-reader-error',
+				__( 'Could not download the article through Jina reader.', 'post-collection' ),
+				array(
+					'status'      => 502,
+					'url'         => $url,
+					'reader_url'  => $reader_url,
+					'http_status' => $status,
+					'http_body'   => wp_remote_retrieve_body( $response ),
+				)
+			);
+		}
+
+		$markdown = trim( wp_remote_retrieve_body( $response ) );
+		$title    = $this->extract_title( $markdown );
+		$content  = $this->extract_markdown_content( $markdown );
+
+		$item->title    = $title;
+		$item->content  = $this->markdown_to_html( $content );
+		$item->raw_html = $markdown;
+
+		return $item;
+	}
+
+	protected function get_reader_url( $url ) {
+		$reader_url = apply_filters(
+			$this->get_reader_url_filter_name(),
+			'https://r.jina.ai/http://%s',
+			$url
+		);
+
+		if ( ! $reader_url ) {
+			return '';
+		}
+
+		return false === strpos( $reader_url, '%s' ) ? $reader_url : sprintf( $reader_url, $url );
+	}
+
+	protected function get_reader_url_filter_name() {
+		return 'post_collection_jina_reader_url';
+	}
+
+	private function extract_title( $markdown ) {
+		if ( preg_match( '/^Title:\s*(.+)$/mi', $markdown, $matches ) ) {
+			return trim( $matches[1] );
+		}
+
+		if ( preg_match( '/^#\s+(.+)$/m', $markdown, $matches ) ) {
+			return trim( $matches[1] );
+		}
+
+		return '';
+	}
+
+	private function extract_markdown_content( $markdown ) {
+		$parts = preg_split( '/^Markdown Content:\s*$/mi', $markdown, 2 );
+		return trim( 2 === count( $parts ) ? $parts[1] : $markdown );
+	}
+
+	private function markdown_to_html( $markdown ) {
+		$blocks     = preg_split( "/\n{2,}/", trim( $markdown ) );
+		$html       = array();
+		$list_items = array();
+
+		foreach ( $blocks as $block ) {
+			$block = trim( $block );
+			if ( '' === $block ) {
+				continue;
+			}
+
+			if ( preg_match( '/^\*\s+(.+)$/m', $block ) ) {
+				foreach ( preg_split( "/\n+/", $block ) as $line ) {
+					if ( preg_match( '/^\*\s+(.+)$/', trim( $line ), $matches ) ) {
+						$list_items[] = '<li>' . $this->format_inline_markdown( $matches[1] ) . '</li>';
+					}
+				}
+				continue;
+			}
+
+			if ( $list_items ) {
+				$html[]     = '<ul>' . implode( '', $list_items ) . '</ul>';
+				$list_items = array();
+			}
+
+			if ( preg_match( '/^(#{2,6})\s+(.+)$/', $block, $matches ) ) {
+				$level  = strlen( $matches[1] );
+				$html[] = '<h' . $level . '>' . $this->format_inline_markdown( $matches[2] ) . '</h' . $level . '>';
+				continue;
+			}
+
+			if ( preg_match( '/^!\[([^\]]*)\]\(([^)]+)\)$/', $block, $matches ) ) {
+				$html[] = '<figure><img src="' . esc_url( $matches[2] ) . '" alt="' . esc_attr( $matches[1] ) . '"></figure>';
+				continue;
+			}
+
+			$html[] = '<p>' . $this->format_inline_markdown( preg_replace( "/\n+/", ' ', $block ) ) . '</p>';
+		}
+
+		if ( $list_items ) {
+			$html[] = '<ul>' . implode( '', $list_items ) . '</ul>';
+		}
+
+		return implode( "\n", $html );
+	}
+
+	private function format_inline_markdown( $text ) {
+		$text = esc_html( $text );
+
+		return preg_replace_callback(
+			'/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/',
+			function ( $matches ) {
+				return '<a href="' . esc_url( html_entity_decode( $matches[2], ENT_QUOTES, 'UTF-8' ) ) . '">' . esc_html( html_entity_decode( $matches[1], ENT_QUOTES, 'UTF-8' ) ) . '</a>';
+			},
+			$text
+		);
+	}
+}

--- a/tests/Test_Cloudflare_Protected_Site_Config.php
+++ b/tests/Test_Cloudflare_Protected_Site_Config.php
@@ -1,0 +1,64 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use PostCollection\SiteConfig\Cloudflare_Protected;
+
+require_once __DIR__ . '/../site-configs/class-site-config.php';
+require_once __DIR__ . '/../site-configs/class-jina.php';
+require_once __DIR__ . '/../site-configs/class-cloudflare-protected.php';
+
+class Test_Cloudflare_Protected_Site_Config extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		$GLOBALS['wp_test_filters']        = array();
+		$GLOBALS['wp_test_http_responses'] = array();
+	}
+
+	public function test_supports_http_urls() {
+		$config = new Cloudflare_Protected();
+
+		$this->assertTrue( $config->is_url_supported( 'https://openai.com/index/introducing-openai-presence' ) );
+		$this->assertTrue( $config->is_url_supported( 'http://example.com/article' ) );
+		$this->assertFalse( $config->is_url_supported( 'mailto:test@example.com' ) );
+	}
+
+	public function test_detects_cloudflare_challenge_body_and_headers() {
+		$config = new Cloudflare_Protected();
+
+		$this->assertTrue( $config->is_challenge_response( '<script src="/cdn-cgi/challenge-platform/h/g/orchestrate/chl_page/v1"></script>' ) );
+		$this->assertTrue(
+			$config->is_challenge_response(
+				'<html></html>',
+				array(
+					'headers' => array(
+						'cf-mitigated' => 'challenge',
+					),
+				)
+			)
+		);
+		$this->assertFalse( $config->is_challenge_response( '<article><p>Readable article.</p></article>' ) );
+	}
+
+	public function test_download_uses_jina_reader_markdown() {
+		$url        = 'https://example.com/protected-article';
+		$reader_url = 'https://r.jina.ai/http://' . $url;
+
+		$GLOBALS['wp_test_http_responses'][ $reader_url ] = array(
+			'response' => array(
+				'code' => 200,
+			),
+			'body'     => "Title: Protected Article\n\nURL Source: $url\n\nMarkdown Content:\nFirst paragraph.\n\n## Available today\n\n![Image 1: UI screenshot](https://example.com/image.png?w=3840)\n\n* One item.\n* Another item.\n\nFinal [link](https://example.com/news).",
+		);
+
+		$item = ( new Cloudflare_Protected() )->download( $url );
+
+		$this->assertFalse( is_wp_error( $item ) );
+		$this->assertSame( 'Protected Article', $item->title );
+		$this->assertStringContainsString( '<p>First paragraph.</p>', $item->content );
+		$this->assertStringContainsString( '<h2>Available today</h2>', $item->content );
+		$this->assertStringContainsString( '<img src="https://example.com/image.png?w=3840" alt="Image 1: UI screenshot">', $item->content );
+		$this->assertStringContainsString( '<ul><li>One item.</li><li>Another item.</li></ul>', $item->content );
+		$this->assertStringContainsString( '<a href="https://example.com/news">link</a>', $item->content );
+	}
+}

--- a/tests/Test_Extract_Content.php
+++ b/tests/Test_Extract_Content.php
@@ -28,4 +28,56 @@ class Test_Extract_Content extends TestCase {
 		$this->assertStringContainsString( 'Turn-based loops', wp_strip_all_tags( $item->content ) );
 		$this->assertStringNotContainsString( 'tooltip script content', wp_strip_all_tags( $item->content ) );
 	}
+
+	public function test_download_falls_back_to_jina_for_cloudflare_challenge() {
+		$plugin     = new Post_Collection_Extract_Content_Test_Plugin();
+		$url        = 'https://example.com/protected-article';
+		$reader_url = 'https://r.jina.ai/http://' . $url;
+
+		$GLOBALS['wp_test_http_responses'][ $url ] = array(
+			'headers'  => array(
+				'cf-mitigated' => 'challenge',
+			),
+			'response' => array(
+				'code' => 403,
+			),
+			'body'     => '<html><script src="/cdn-cgi/challenge-platform/h/g/orchestrate/chl_page/v1"></script></html>',
+		);
+		$GLOBALS['wp_test_http_responses'][ $reader_url ] = array(
+			'response' => array(
+				'code' => 200,
+			),
+			'body'     => "Title: Protected Article\n\nMarkdown Content:\nFull protected content.",
+		);
+
+		$item = $plugin->download( $url );
+
+		$this->assertFalse( is_wp_error( $item ) );
+		$this->assertSame( 'Protected Article', $item->title );
+		$this->assertStringContainsString( 'Full protected content.', wp_strip_all_tags( $item->content ) );
+	}
+
+	public function test_download_does_not_fallback_to_jina_for_non_cloudflare_http_errors() {
+		$plugin     = new Post_Collection_Extract_Content_Test_Plugin();
+		$url        = 'https://example.com/not-found';
+		$reader_url = 'https://r.jina.ai/http://' . $url;
+
+		$GLOBALS['wp_test_http_responses'][ $url ] = array(
+			'response' => array(
+				'code' => 404,
+			),
+			'body'     => 'Not found.',
+		);
+		$GLOBALS['wp_test_http_responses'][ $reader_url ] = array(
+			'response' => array(
+				'code' => 200,
+			),
+			'body'     => "Title: Reader Article\n\nMarkdown Content:\nReader fallback content.",
+		);
+
+		$item = $plugin->download( $url );
+
+		$this->assertTrue( is_wp_error( $item ) );
+		$this->assertSame( 'could-not-download', $item->get_error_code() );
+	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -176,6 +176,37 @@ namespace {
 		return $GLOBALS['wp_test_abilities'][ $name ] ?? null;
 	}
 
+	function wp_remote_get( $url, $args = array() ) {
+		if ( isset( $GLOBALS['wp_test_http_responses'][ $url ] ) ) {
+			return $GLOBALS['wp_test_http_responses'][ $url ];
+		}
+
+		return new WP_Error( 'http_request_failed', 'No test response registered.' );
+	}
+
+	function wp_safe_remote_get( $url, $args = array() ) {
+		return wp_remote_get( $url, $args );
+	}
+
+	function wp_remote_retrieve_response_code( $response ) {
+		return $response['response']['code'] ?? 0;
+	}
+
+	function wp_remote_retrieve_body( $response ) {
+		return $response['body'] ?? '';
+	}
+
+	function wp_remote_retrieve_header( $response, $header ) {
+		$headers = $response['headers'] ?? array();
+		foreach ( $headers as $key => $value ) {
+			if ( strtolower( (string) $key ) === strtolower( (string) $header ) ) {
+				return $value;
+			}
+		}
+
+		return '';
+	}
+
 	function is_wp_error( $thing ) {
 		return $thing instanceof WP_Error;
 	}
@@ -803,6 +834,9 @@ namespace {
 	}
 
 	require_once __DIR__ . '/../class-extracted-page.php';
+	require_once __DIR__ . '/../site-configs/class-site-config.php';
+	require_once __DIR__ . '/../site-configs/class-jina.php';
+	require_once __DIR__ . '/../site-configs/class-cloudflare-protected.php';
 	require_once __DIR__ . '/../class-user.php';
 	require_once __DIR__ . '/../class-user-query.php';
 	require_once __DIR__ . '/../includes/class-article-notes.php';


### PR DESCRIPTION
## Summary
- add a reusable Jina reader site-config base for Markdown extraction
- detect Cloudflare challenge responses in the generic downloader and fall back to Jina only for those responses
- add coverage for Cloudflare fallback, non-Cloudflare HTTP errors, and Jina Markdown conversion

## Tests
- composer test
- php -l class-post-collection.php
- php -l site-configs/class-jina.php
- php -l site-configs/class-cloudflare-protected.php