### PR TITLE
Add URLForwarder save support

### DIFF
--- a/assets/css/post-collection-app.css
+++ b/assets/css/post-collection-app.css
@@ -493,11 +493,68 @@ body.pc-new-collection-page .pc-detail-header {
 	font-size: 0.94rem;
 }
 
+.pc-urlforwarder-settings {
+	width: 100%;
+	border-collapse: collapse;
+	table-layout: fixed;
+}
+
+.pc-urlforwarder-settings th,
+.pc-urlforwarder-settings td {
+	padding: 10px 0;
+	border-top: 1px solid var(--pc-color-border);
+	text-align: left;
+	vertical-align: top;
+}
+
+.pc-urlforwarder-settings tr:first-child th,
+.pc-urlforwarder-settings tr:first-child td {
+	border-top: 0;
+}
+
+.pc-urlforwarder-settings th {
+	width: 150px;
+	color: var(--pc-color-text);
+	font-weight: 700;
+}
+
+.pc-urlforwarder-settings td:last-child {
+	width: 92px;
+	text-align: right;
+}
+
+.pc-urlforwarder-settings code {
+	display: block;
+	overflow-wrap: anywhere;
+	color: var(--pc-color-text);
+	font-size: 0.9rem;
+	white-space: normal;
+}
+
+.pc-urlforwarder-settings .pc-urlforwarder-output-url {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.pc-save-tab-panel .pc-urlforwarder-note {
+	margin-top: 14px;
+	margin-bottom: 0;
+}
+
 @media (max-width: 640px) {
 	.pc-save-tab-list button {
 		padding-right: 8px;
 		padding-left: 8px;
 		font-size: 0.9rem;
+	}
+
+	.pc-urlforwarder-settings th {
+		width: 118px;
+	}
+
+	.pc-urlforwarder-settings td:last-child {
+		width: 74px;
 	}
 }
 

--- a/assets/js/post-collection-app.js
+++ b/assets/js/post-collection-app.js
@@ -234,6 +234,49 @@
 		buttons[ nextIndex ].focus();
 	}
 
+	function copyText( text ) {
+		if ( navigator.clipboard && navigator.clipboard.writeText ) {
+			return navigator.clipboard.writeText( text );
+		}
+
+		return new Promise( function ( resolve, reject ) {
+			var textarea = document.createElement( 'textarea' );
+			textarea.value = text;
+			textarea.setAttribute( 'readonly', '' );
+			textarea.style.position = 'fixed';
+			textarea.style.top = '-9999px';
+			document.body.appendChild( textarea );
+			textarea.select();
+
+			try {
+				if ( document.execCommand( 'copy' ) ) {
+					resolve();
+				} else {
+					reject( new Error( 'Copy failed.' ) );
+				}
+			} catch ( error ) {
+				reject( error );
+			}
+
+			document.body.removeChild( textarea );
+		} );
+	}
+
+	function copyButtonValue( button ) {
+		var value = button.dataset.copyValue || '';
+		if ( ! value ) {
+			return;
+		}
+
+		copyText( value ).then( function () {
+			button.textContent = button.dataset.copiedLabel || 'Copied';
+			window.clearTimeout( button.pcCopyTimeout );
+			button.pcCopyTimeout = window.setTimeout( function () {
+				button.textContent = button.dataset.copyLabel || 'Copy';
+			}, 2000 );
+		} );
+	}
+
 	function updateReviewItemCollapsedStatus( item, label ) {
 		var status = item ? item.querySelector( '.pc-review-collapsed-status' ) : null;
 		if ( status ) {
@@ -836,6 +879,13 @@
 		if ( loadMoreReview ) {
 			event.preventDefault();
 			loadMoreReviewArticles( loadMoreReview );
+			return;
+		}
+
+		var copyValue = closest( event.target, '.pc-copy-value' );
+		if ( copyValue ) {
+			event.preventDefault();
+			copyButtonValue( copyValue );
 			return;
 		}
 

--- a/class-post-collection-app.php
+++ b/class-post-collection-app.php
@@ -125,17 +125,20 @@ class Post_Collection_App {
 		}
 
 		if ( function_exists( 'wp_app_enqueue_style' ) ) {
+			$style_path  = POST_COLLECTION_PLUGIN_DIR . 'assets/css/post-collection-app.css';
+			$script_path = POST_COLLECTION_PLUGIN_DIR . 'assets/js/post-collection-app.js';
+
 			wp_app_enqueue_style(
 				'post-collection-app',
 				plugins_url( 'assets/css/post-collection-app.css', POST_COLLECTION_PLUGIN_FILE ),
 				array(),
-				POST_COLLECTION_VERSION
+				file_exists( $style_path ) ? filemtime( $style_path ) : POST_COLLECTION_VERSION
 			);
 			wp_app_enqueue_script(
 				'post-collection-app',
 				plugins_url( 'assets/js/post-collection-app.js', POST_COLLECTION_PLUGIN_FILE ),
 				array(),
-				POST_COLLECTION_VERSION,
+				file_exists( $script_path ) ? filemtime( $script_path ) : POST_COLLECTION_VERSION,
 				true
 			);
 		}
@@ -160,6 +163,16 @@ class Post_Collection_App {
 	 */
 	public function get_collection_bookmarklet_href( $collection ) {
 		return $this->post_collection->get_bookmarklet_href( 'collection', $collection->term_id );
+	}
+
+	/**
+	 * Build a URLForwarder URL template for a collection.
+	 *
+	 * @param \WP_Term $collection The collection term.
+	 * @return string URLForwarder template URL.
+	 */
+	public function get_collection_urlforwarder_url( $collection ) {
+		return $this->post_collection->get_urlforwarder_url( 'collection', $collection->term_id );
 	}
 
 	/**

--- a/class-post-collection.php
+++ b/class-post-collection.php
@@ -150,6 +150,38 @@ class Post_Collection {
 	}
 
 	/**
+	 * Parse a shared text payload into a URL and optional title.
+	 *
+	 * @param string $text The shared text.
+	 * @return array Parsed URL and title.
+	 */
+	public function parse_shared_url_payload( $text ) {
+		$text = trim( (string) $text );
+		if ( $this->check_url( $text ) ) {
+			return array(
+				'url'   => $text,
+				'title' => '',
+			);
+		}
+
+		if ( preg_match( '~https?://[^\s<>"\']+~i', $text, $matches, PREG_OFFSET_CAPTURE ) ) {
+			$url   = rtrim( $matches[0][0], '.,;:!?)]}' );
+			$title = trim( substr( $text, 0, $matches[0][1] ) );
+			$title = preg_replace( '/\s+/', ' ', $title );
+
+			return array(
+				'url'   => $url,
+				'title' => $title && strlen( $title ) <= 160 ? $title : '',
+			);
+		}
+
+		return array(
+			'url'   => $text,
+			'title' => '',
+		);
+	}
+
+	/**
 	 * Truncate URL using Friends method if available.
 	 *
 	 * @param string $url The URL to truncate.
@@ -1145,6 +1177,19 @@ class Post_Collection {
 	}
 
 	/**
+	 * Build a URLForwarder template for saving into a collection.
+	 *
+	 * @param string $target_arg The save endpoint query argument.
+	 * @param int    $target_id  The target collection or user ID.
+	 * @return string URLForwarder template URL.
+	 */
+	public function get_urlforwarder_url( $target_arg, $target_id ) {
+		return home_url(
+			'/?' . rawurlencode( $target_arg ) . '=' . rawurlencode( (string) $target_id ) . '&collect-post=@url&title=@subject'
+		);
+	}
+
+	/**
 	 * Render a bookmarklet link.
 	 *
 	 * @param string $href  Bookmarklet href.
@@ -1190,13 +1235,16 @@ class Post_Collection {
 	public function save_url_endpoint() {
 		$delimiter = '===BODY===';
 		$url = false;
+		$shared_title = '';
 		$collection = null;
 		if ( isset( $_REQUEST['collect-post'], $_REQUEST['collection'] ) ) {
 			$collection = get_term( absint( wp_unslash( $_REQUEST['collection'] ) ), self::COLLECTION_TAXONOMY );
 			if ( ! $collection || is_wp_error( $collection ) ) {
 				return;
 			}
-			$url = wp_unslash( $_REQUEST['collect-post'] );
+			$shared_payload = $this->parse_shared_url_payload( wp_unslash( $_REQUEST['collect-post'] ) );
+			$url            = $shared_payload['url'];
+			$shared_title   = $shared_payload['title'];
 		}
 		if ( isset( $_REQUEST['collect-post'] ) && isset( $_REQUEST['user'] ) ) {
 			if ( ! intval( $_REQUEST['user'] ) ) {
@@ -1244,10 +1292,30 @@ class Post_Collection {
 		}
 
 		if ( $collection ) {
-			$post_id = $this->save_url_to_collection_term( $url, $collection, $body );
+			$args = array();
+			if ( $shared_title ) {
+				$args['title'] = $shared_title;
+			} elseif ( isset( $_REQUEST['title'] ) ) {
+				$args['title'] = wp_unslash( $_REQUEST['title'] );
+			}
+
+			if ( isset( $_POST['post_collection_action'] ) && 'manual-save' === wp_unslash( $_POST['post_collection_action'] ) ) {
+				if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'post-collection-manual-save' ) ) {
+					wp_die( esc_html__( 'Could not verify the save request.', 'post-collection' ) );
+				}
+
+				$post_id = $this->save_url_to_collection_term_without_content( $url, $collection, $args );
+				if ( is_wp_error( $post_id ) ) {
+					wp_die( esc_html( $post_id->get_error_message() ) );
+				}
+
+				wp_safe_redirect( get_edit_post_link( $post_id, 'raw' ) );
+				exit;
+			}
+
+			$post_id = $this->save_url_to_collection_term( $url, $collection, $body, $args );
 			if ( is_wp_error( $post_id ) ) {
-				echo '<pre>';
-				print_r( $post_id );
+				$this->render_save_error_page( $post_id, $url, $collection, $args );
 				exit;
 			}
 
@@ -1264,6 +1332,107 @@ class Post_Collection {
 				exit;
 			}
 		}
+	}
+
+	/**
+	 * Save a URL to a collection without downloaded content.
+	 *
+	 * @param string   $url        Source URL.
+	 * @param \WP_Term $collection Collection term.
+	 * @param array    $args       Optional arguments: title.
+	 * @return int|\WP_Error Post ID or error.
+	 */
+	public function save_url_to_collection_term_without_content( $url, \WP_Term $collection, $args = array() ) {
+		if ( ! is_string( $url ) || ! $this->check_url( $url ) ) {
+			return new \WP_Error( 'invalid-url', __( 'You entered an invalid URL.', 'post-collection' ) );
+		}
+
+		$title = '';
+		if ( isset( $args['title'] ) ) {
+			$title = wp_strip_all_tags( trim( sanitize_text_field( $args['title'] ) ) );
+		}
+		if ( ! $title ) {
+			$path  = trim( (string) wp_parse_url( $url, PHP_URL_PATH ), '/' );
+			$parts = explode( '/', $path );
+			$title = ucwords( strtr( end( $parts ), '-', ' ' ) );
+		}
+		if ( ! $title ) {
+			$title = $url;
+		}
+
+		$post_id = $this->url_to_collection_term_postid( $url, $collection );
+		if ( $post_id ) {
+			wp_untrash_post( $post_id );
+			$updated_post = wp_update_post(
+				array(
+					'ID'         => $post_id,
+					'post_title' => $title,
+				),
+				true
+			);
+
+			return is_wp_error( $updated_post ) ? $updated_post : (int) $post_id;
+		}
+
+		$post_id = wp_insert_post(
+			array(
+				'post_status'  => 'private',
+				'post_author'  => get_current_user_id(),
+				'guid'         => $url,
+				'post_type'    => self::CPT,
+				'post_title'   => $title,
+				'post_content' => '',
+			),
+			true
+		);
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+
+		wp_set_object_terms( $post_id, array( (int) $collection->term_id ), self::COLLECTION_TAXONOMY, false );
+
+		return (int) $post_id;
+	}
+
+	/**
+	 * Render a save error page with a manual recovery action.
+	 *
+	 * @param \WP_Error $error      Save error.
+	 * @param string    $url        Source URL.
+	 * @param \WP_Term  $collection Collection term.
+	 * @param array     $args       Save arguments.
+	 */
+	private function render_save_error_page( \WP_Error $error, $url, \WP_Term $collection, $args = array() ) {
+		$title = isset( $args['title'] ) ? wp_strip_all_tags( trim( sanitize_text_field( $args['title'] ) ) ) : '';
+		?>
+		<!doctype html>
+		<html <?php language_attributes(); ?>>
+		<head>
+			<meta charset="<?php bloginfo( 'charset' ); ?>">
+			<meta name="viewport" content="width=device-width, initial-scale=1">
+			<title><?php esc_html_e( 'Could not save article', 'post-collection' ); ?></title>
+			<?php wp_head(); ?>
+		</head>
+		<body>
+			<main style="max-width: 680px; margin: 48px auto; padding: 0 20px; font-family: sans-serif;">
+				<h1><?php esc_html_e( 'Could not save article', 'post-collection' ); ?></h1>
+				<p><?php echo esc_html( $error->get_error_message() ); ?></p>
+				<p><a href="<?php echo esc_url( $url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $url ); ?></a></p>
+				<form method="post">
+					<input type="hidden" name="post_collection_action" value="manual-save">
+					<input type="hidden" name="collection" value="<?php echo esc_attr( $collection->term_id ); ?>">
+					<input type="hidden" name="collect-post" value="<?php echo esc_attr( $url ); ?>">
+					<input type="hidden" name="title" value="<?php echo esc_attr( $title ); ?>">
+					<?php wp_nonce_field( 'post-collection-manual-save' ); ?>
+					<p>
+						<button type="submit"><?php esc_html_e( 'Save anyway and edit', 'post-collection' ); ?></button>
+					</p>
+				</form>
+			</main>
+			<?php wp_footer(); ?>
+		</body>
+		</html>
+		<?php
 	}
 
 	/**

--- a/templates/app/settings.php
+++ b/templates/app/settings.php
@@ -80,6 +80,7 @@ $hide_from_home  = get_term_meta( $collection->term_id, 'post_collection_hide_fr
 				<div class="pc-save-tab-list" role="tablist" aria-label="<?php esc_attr_e( 'Save methods', 'post-collection' ); ?>">
 					<button type="button" class="is-active" role="tab" aria-selected="true" aria-controls="pc-settings-bookmarklet-panel-<?php echo esc_attr( $collection->term_id ); ?>" id="pc-settings-bookmarklet-tab-<?php echo esc_attr( $collection->term_id ); ?>" data-pc-tab="bookmarklet"><?php esc_html_e( 'Bookmarklet', 'post-collection' ); ?></button>
 					<button type="button" role="tab" aria-selected="false" aria-controls="pc-settings-extension-panel-<?php echo esc_attr( $collection->term_id ); ?>" id="pc-settings-extension-tab-<?php echo esc_attr( $collection->term_id ); ?>" data-pc-tab="extension" tabindex="-1"><?php esc_html_e( 'Browser extension', 'post-collection' ); ?></button>
+					<button type="button" role="tab" aria-selected="false" aria-controls="pc-settings-urlforwarder-panel-<?php echo esc_attr( $collection->term_id ); ?>" id="pc-settings-urlforwarder-tab-<?php echo esc_attr( $collection->term_id ); ?>" data-pc-tab="urlforwarder" tabindex="-1"><?php esc_html_e( 'URLForwarder', 'post-collection' ); ?></button>
 				</div>
 				<div id="pc-settings-bookmarklet-panel-<?php echo esc_attr( $collection->term_id ); ?>" class="pc-save-tab-panel is-active" role="tabpanel" aria-labelledby="pc-settings-bookmarklet-tab-<?php echo esc_attr( $collection->term_id ); ?>" data-pc-tab-panel="bookmarklet">
 					<p><?php esc_html_e( "Drag this bookmarklet to your bookmarks bar and click it when you're on an article you want to save from the web.", 'post-collection' ); ?></p>
@@ -96,6 +97,45 @@ $hide_from_home  = get_term_meta( $collection->term_id, 'post_collection_hide_fr
 				</div>
 				<div id="pc-settings-extension-panel-<?php echo esc_attr( $collection->term_id ); ?>" class="pc-save-tab-panel" role="tabpanel" aria-labelledby="pc-settings-extension-tab-<?php echo esc_attr( $collection->term_id ); ?>" data-pc-tab-panel="extension" hidden>
 					<p><?php esc_html_e( 'The Friends browser extension can add save actions for your collections and send the current page content for better article extraction.', 'post-collection' ); ?></p>
+				</div>
+				<div id="pc-settings-urlforwarder-panel-<?php echo esc_attr( $collection->term_id ); ?>" class="pc-save-tab-panel" role="tabpanel" aria-labelledby="pc-settings-urlforwarder-tab-<?php echo esc_attr( $collection->term_id ); ?>" data-pc-tab-panel="urlforwarder" hidden>
+					<p>
+						<?php esc_html_e( 'Use these values in', 'post-collection' ); ?>
+						<a href="<?php echo esc_url( 'https://f-droid.org/packages/net.daverix.urlforward/' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'URLForwarder for Android', 'post-collection' ); ?></a>.
+					</p>
+					<table class="pc-urlforwarder-settings">
+						<tbody>
+							<tr>
+								<th scope="row"><?php esc_html_e( 'Filter name', 'post-collection' ); ?></th>
+								<td><code><?php echo esc_html( $collection->name ); ?></code></td>
+								<td>
+									<button type="button" class="pc-button pc-copy-value" data-copy-value="<?php echo esc_attr( $collection->name ); ?>" data-copy-label="<?php esc_attr_e( 'Copy', 'post-collection' ); ?>" data-copied-label="<?php esc_attr_e( 'Copied', 'post-collection' ); ?>">
+										<?php esc_html_e( 'Copy', 'post-collection' ); ?>
+									</button>
+								</td>
+							</tr>
+							<tr>
+								<th scope="row"><?php esc_html_e( 'Output URL', 'post-collection' ); ?></th>
+								<td><code class="pc-urlforwarder-output-url"><?php echo esc_html( $app->get_collection_urlforwarder_url( $collection ) ); ?></code></td>
+								<td>
+									<button type="button" class="pc-button pc-copy-value" data-copy-value="<?php echo esc_attr( $app->get_collection_urlforwarder_url( $collection ) ); ?>" data-copy-label="<?php esc_attr_e( 'Copy', 'post-collection' ); ?>" data-copied-label="<?php esc_attr_e( 'Copied', 'post-collection' ); ?>">
+										<?php esc_html_e( 'Copy', 'post-collection' ); ?>
+									</button>
+								</td>
+							</tr>
+							<tr>
+								<th scope="row"><?php esc_html_e( 'Replaceable text', 'post-collection' ); ?></th>
+								<td><code>@url</code></td>
+								<td></td>
+							</tr>
+							<tr>
+								<th scope="row"><?php esc_html_e( 'Replaceable subject', 'post-collection' ); ?></th>
+								<td><code>@subject</code></td>
+								<td></td>
+							</tr>
+						</tbody>
+					</table>
+					<p class="pc-urlforwarder-note"><?php esc_html_e( 'The forwarded URL should be URL encoded.', 'post-collection' ); ?></p>
 				</div>
 			</div>
 		</section>

--- a/tests/Test_Save_Method_Urls.php
+++ b/tests/Test_Save_Method_Urls.php
@@ -1,0 +1,69 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use PostCollection\Post_Collection;
+
+require_once __DIR__ . '/../class-post-collection.php';
+
+class Post_Collection_Save_Method_Urls_Test_Plugin extends Post_Collection {
+	public function __construct() {}
+}
+
+class Test_Save_Method_Urls extends TestCase {
+	protected function setUp(): void {
+		parent::setUp();
+
+		$GLOBALS['wp_test_posts']            = array();
+		$GLOBALS['wp_test_terms']            = array();
+		$GLOBALS['wp_test_registered_terms'] = array();
+		$GLOBALS['wp_test_current_user_id']  = 99;
+	}
+
+	public function test_urlforwarder_template_uses_post_collection_endpoint_parameters() {
+		$plugin = new Post_Collection_Save_Method_Urls_Test_Plugin();
+
+		$this->assertSame(
+			'https://example.com/?collection=42&collect-post=@url&title=@subject',
+			$plugin->get_urlforwarder_url( 'collection', 42 )
+		);
+	}
+
+	public function test_extracts_url_from_shared_text_payload() {
+		$plugin = new Post_Collection_Save_Method_Urls_Test_Plugin();
+
+		$this->assertSame(
+			array(
+				'url'   => 'https://www.heise.de/ct/inhalt/2026/16/122/',
+				'title' => '„Eine breit streuende Schrotflinte“: Offenheit ist eine Geschäftsstrategie – auch bei KI-Modellen',
+			),
+			$plugin->parse_shared_url_payload(
+				"„Eine breit streuende Schrotflinte“: Offenheit ist eine Geschäftsstrategie – auch bei KI-Modellen\nhttps://www.heise.de/ct/inhalt/2026/16/122/"
+			)
+		);
+	}
+
+	public function test_can_save_collection_url_without_content_for_manual_editing() {
+		$plugin     = new Post_Collection_Save_Method_Urls_Test_Plugin();
+		$collection = new \WP_Term(
+			(object) array(
+				'term_id'  => 42,
+				'name'     => 'Saved',
+				'slug'     => 'saved',
+				'taxonomy' => Post_Collection::COLLECTION_TAXONOMY,
+			)
+		);
+
+		$post_id = $plugin->save_url_to_collection_term_without_content(
+			'https://www.heise.de/ct/inhalt/2026/16/122/',
+			$collection,
+			array( 'title' => 'Manual Article' )
+		);
+
+		$this->assertSame( 1, $post_id );
+		$this->assertSame( 'Manual Article', $GLOBALS['wp_test_posts'][ $post_id ]->post_title );
+		$this->assertSame( '', $GLOBALS['wp_test_posts'][ $post_id ]->post_content );
+		$this->assertSame( 'private', $GLOBALS['wp_test_posts'][ $post_id ]->post_status );
+		$this->assertSame( 'https://www.heise.de/ct/inhalt/2026/16/122/', $GLOBALS['wp_test_posts'][ $post_id ]->guid );
+		$this->assertSame( array( 42 ), $GLOBALS['wp_test_terms'][ $post_id ][ Post_Collection::COLLECTION_TAXONOMY ] );
+	}
+}


### PR DESCRIPTION
## Summary
- add URLForwarder setup values to collection settings with copy-to-clipboard controls
- parse shared text payloads to extract the first URL and use short leading prose as the title
- replace raw save errors with a recovery page that can save the URL anyway and open the editor
- version app CSS/JS by file modification time so UI changes are not hidden by stale assets

## Tests
- php -l class-post-collection.php
- php -l class-post-collection-app.php
- php -l templates/app/settings.php
- ./vendor/bin/phpunit